### PR TITLE
Fix a bug with empty License and Contact objects

### DIFF
--- a/API.md
+++ b/API.md
@@ -158,6 +158,8 @@ Implements functions to deal with the AsyncAPI document.
     * [.defaultContentType()](#AsyncAPIDocument+defaultContentType) ⇒ <code>string</code>
     * [.hasComponents()](#AsyncAPIDocument+hasComponents) ⇒ <code>boolean</code>
     * [.components()](#AsyncAPIDocument+components) ⇒ [<code>Components</code>](#Components)
+    * [.hasTags()](#AsyncAPIDocument+hasTags) ⇒ <code>boolean</code>
+    * [.tags()](#AsyncAPIDocument+tags) ⇒ [<code>Array.&lt;Tag&gt;</code>](#Tag)
     * [.json()](#Base+json) ⇒ <code>Any</code>
 
 <a name="AsyncAPIDocument+info"></a>
@@ -217,6 +219,14 @@ Implements functions to deal with the AsyncAPI document.
 <a name="AsyncAPIDocument+components"></a>
 
 ### asyncAPIDocument.components() ⇒ [<code>Components</code>](#Components)
+**Kind**: instance method of [<code>AsyncAPIDocument</code>](#AsyncAPIDocument)  
+<a name="AsyncAPIDocument+hasTags"></a>
+
+### asyncAPIDocument.hasTags() ⇒ <code>boolean</code>
+**Kind**: instance method of [<code>AsyncAPIDocument</code>](#AsyncAPIDocument)  
+<a name="AsyncAPIDocument+tags"></a>
+
+### asyncAPIDocument.tags() ⇒ [<code>Array.&lt;Tag&gt;</code>](#Tag)
 **Kind**: instance method of [<code>AsyncAPIDocument</code>](#AsyncAPIDocument)  
 <a name="Base+json"></a>
 

--- a/lib/models/asyncapi.js
+++ b/lib/models/asyncapi.js
@@ -4,6 +4,7 @@ const Info = require('./info');
 const Server = require('./server');
 const Channel = require('./channel');
 const Components = require('./components');
+const Tag = require('./tag');
 
 /**
  * Implements functions to deal with the AsyncAPI document.
@@ -98,6 +99,21 @@ class AsyncAPIDocument extends Base {
   components() {
     if (!this._json.components) return null;
     return new Components(this._json.components);
+  }
+
+  /**
+   * @returns {boolean}
+   */
+  hasTags() {
+    return !!(this._json.tags && this._json.tags.length);
+  }
+
+  /**
+   * @returns {Tag[]}
+   */
+  tags() {
+    if (!this._json.tags) return [];
+    return this._json.tags.map(t => new Tag(t));
   }
 }
 

--- a/lib/models/info.js
+++ b/lib/models/info.js
@@ -36,6 +36,7 @@ class Info extends Base {
    * @returns {License}
    */
   license() {
+    if (!this._json.license) return null;
     return new License(this._json.license);
   }
 
@@ -43,6 +44,7 @@ class Info extends Base {
    * @returns {Contact}
    */
   contact() {
+    if (!this._json.contact) return null;
     return new Contact(this._json.contact);
   }
 }

--- a/test/models/asyncapi_test.js
+++ b/test/models/asyncapi_test.js
@@ -145,4 +145,15 @@ describe('AsyncAPIDocument', () => {
       expect(d.components().json()).to.equal(doc.components);
     });
   });
+
+  describe('#tags()', function () {
+    it('should return an array of tags', () => {
+      const doc = { tags: [{ name: 'test1' }, { name: 'test2' }] };
+      const d = new AsyncAPIDocument(doc);
+      d.tags().forEach((t, i) => {
+        expect(t.constructor.name).to.be.equal('Tag');
+        expect(t.json()).to.be.equal(doc.tags[i]);
+      });
+    });
+  });
 });

--- a/test/models/info_test.js
+++ b/test/models/info_test.js
@@ -46,6 +46,11 @@ describe('Info', () => {
       expect(d.license().constructor.name).to.be.equal('License');
       expect(d.license().json()).to.be.equal(js.license);
     });
+    
+    it('should return null if a license object is not given', () => {
+      const d = new Info({});
+      expect(d.license()).to.be.equal(null);
+    });
   });
   
   describe('#contact()', function () {
@@ -53,6 +58,12 @@ describe('Info', () => {
       const d = new Info(js);
       expect(d.contact().constructor.name).to.be.equal('Contact');
       expect(d.contact().json()).to.be.equal(js.contact);
+    });
+
+
+    it('should return null if a contact object is not given', () => {
+      const d = new Info({});
+      expect(d.contact()).to.be.equal(null);
     });
   });
 });


### PR DESCRIPTION
It was trying to create License and Contact objects without checking if their respective JSON definitions where present.