### PR TITLE
refactor: use new version of asyncapi package

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,6 +1,6 @@
 const Ajv = require('ajv');
 const fetch = require('node-fetch');
-const asyncapi = require('asyncapi');
+const asyncapi = require('@asyncapi/specs');
 const $RefParser = require('json-schema-ref-parser');
 const mergePatch = require('tiny-merge-patch').apply;
 const ParserError = require('./errors/parser-error');

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@asyncapi/specs": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.7.1.tgz",
+      "integrity": "sha512-kt5EsszOFuYPKSCbumRbyjQ93VFSuJDt7H0WhggCtNl0STOa5d0W9AwcZmh2B1G7JG3RHxLO44om6CWnm+sQOA=="
+    },
     "@babel/code-frame": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -851,11 +856,6 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
-    },
-    "asyncapi": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/asyncapi/-/asyncapi-2.6.1.tgz",
-      "integrity": "sha512-ROszLQMYzyp/CzPyLhuT/9NpJXxI7wrjv6yW8JpA/XVMEWCqyVXr9jajJhs9d/863+ispS+ptGhg1PC17AnIzQ=="
     },
     "at-least-node": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "ajv": "^6.10.1",
-    "asyncapi": "^2.6.1",
+    "@asyncapi/specs": "^2.7.1",
     "js-yaml": "^3.13.1",
     "json-schema-ref-parser": "^7.1.0",
     "node-fetch": "^2.6.0",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Some time ago we moved all packages under `@asyncapi` scope and I forgot to bump one of the packages in parser to use dependency with a new name

I added `refactor` prefix cause I think this PR should not trigger release as this is purely cosmetical change as the dependency doesn't bring anything new.