### PR TITLE
feat: remove dist/bundle.js from gitignore to get it pushed to npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 .vscode
-dist


### PR DESCRIPTION
**Description**

- remove `.keep` as `bundle.js` will alwasy be in `dist` dir
- remove dist from gitignore as now it is not published to npm. Now with each release bundle.js will be pushed to repo with PR that bumps package.json
