### PR TITLE
Fix: additional items and properties are never discovered and tests failing on windows

### DIFF
--- a/lib/models/asyncapi.js
+++ b/lib/models/asyncapi.js
@@ -172,6 +172,9 @@ class AsyncAPIDocument extends Base {
   allSchemas() {
     const schemas = new Map();
     const callback = (schema) => {
+      if(!schema){
+        console.log("shit")
+      }
       if (schema.uid()) {
         schemas.set(schema.uid(), schema);
       }
@@ -268,18 +271,31 @@ function recursiveSchema(schema, callback) {
   if (schema.type() !== undefined) {
     switch (schema.type()) {
       case 'object':
-        const props = schema.properties();
-        for (const [, propertySchema] of Object.entries(props)) {
-          recursiveSchema(propertySchema, callback);
+        if(schema.additionalProperties() !== undefined && typeof schema.additionalProperties() !== "boolean"){
+          var additionalSchema = schema.additionalProperties()
+          recursiveSchema(additionalSchema, callback);
+        }
+        if(schema.properties() !== null){
+          const props = schema.properties();
+          for (const [, propertySchema] of Object.entries(props)) {
+            recursiveSchema(propertySchema, callback);
+          }
         }
         break;
       case 'array':
-        if (Array.isArray(schema.items())) {
-          schema.items().forEach(arraySchema => {
-            recursiveSchema(arraySchema, callback);
-          });
-        } else {
-          recursiveSchema(schema.items(), callback);
+        if(schema.additionalItems() !== undefined){
+          var additionalArrayItems = schema.additionalItems()
+          recursiveSchema(additionalArrayItems, callback);
+        }
+
+        if(schema.items() !== null){
+          if (Array.isArray(schema.items())) {
+            schema.items().forEach(arraySchema => {
+              recursiveSchema(arraySchema, callback);
+            });
+          } else {
+            recursiveSchema(schema.items(), callback);
+          }
         }
         break;
     }

--- a/lib/models/asyncapi.js
+++ b/lib/models/asyncapi.js
@@ -281,7 +281,7 @@ function recursiveSchema(schema, callback) {
         break;
       case 'array':
         if(schema.additionalItems() !== undefined){
-          var additionalArrayItems = schema.additionalItems()
+          const additionalArrayItems = schema.additionalItems()
           recursiveSchema(additionalArrayItems, callback);
         }
 

--- a/lib/models/asyncapi.js
+++ b/lib/models/asyncapi.js
@@ -172,9 +172,6 @@ class AsyncAPIDocument extends Base {
   allSchemas() {
     const schemas = new Map();
     const callback = (schema) => {
-      if(!schema){
-        console.log("shit")
-      }
       if (schema.uid()) {
         schemas.set(schema.uid(), schema);
       }

--- a/lib/models/asyncapi.js
+++ b/lib/models/asyncapi.js
@@ -269,7 +269,7 @@ function recursiveSchema(schema, callback) {
     switch (schema.type()) {
       case 'object':
         if(schema.additionalProperties() !== undefined && typeof schema.additionalProperties() !== "boolean"){
-          var additionalSchema = schema.additionalProperties()
+          const additionalSchema = schema.additionalProperties()
           recursiveSchema(additionalSchema, callback);
         }
         if(schema.properties() !== null){

--- a/test/models/asyncapi_test.js
+++ b/test/models/asyncapi_test.js
@@ -187,6 +187,79 @@ describe('AsyncAPIDocument', () => {
   });
 
   describe('#allSchemas()', function () {
+    
+    it('should return additional items schemas when no items specified', () => {
+      const doc = {
+        "channels": {
+          "some_channel": {
+            "subscribe": {
+              "message": {
+                "name": "some_map",
+                "payload": {
+                  "type": "array",
+                  "$id": "payloadSchema",
+                  "test": true,
+                  "additionalItems": {
+                    "type": "string",
+                    "$id": "additionalItemSchema", 
+                    "test": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+      const d = new AsyncAPIDocument(doc);
+      const schemas = d.allSchemas();
+      expect(schemas.size).to.be.equal(2);
+      //Ensure the actual keys are as expected
+      const schemaKeys = Array.from(schemas.keys());
+      expect(schemaKeys).to.deep.equal([
+        "payloadSchema",
+        "additionalItemSchema"
+      ])
+      for (const t of schemas.values()) {
+        expect(t.constructor.name).to.be.equal('Schema');
+        expect(t.json().test).to.be.equal(true);
+      }
+    });
+    it('should return additional property schemas when no properties are specified', () => {
+      const doc = {
+        "channels": {
+          "some_channel": {
+            "subscribe": {
+              "message": {
+                "name": "some_map",
+                "payload": {
+                  "type": "object",
+                  "$id": "payloadSchema",
+                  "test": true,
+                  "additionalProperties": {
+                    "type": "string",
+                    "$id": "additionalPropSchema", 
+                    "test": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+      const d = new AsyncAPIDocument(doc);
+      const schemas = d.allSchemas();
+      expect(schemas.size).to.be.equal(2);
+      //Ensure the actual keys are as expected
+      const schemaKeys = Array.from(schemas.keys());
+      expect(schemaKeys).to.deep.equal([
+        "payloadSchema",
+        "additionalPropSchema"
+      ])
+      for (const t of schemas.values()) {
+        expect(t.constructor.name).to.be.equal('Schema');
+        expect(t.json().test).to.be.equal(true);
+      }
+    });
     it('should return a map with all the schemas used in the document', () => {
       const doc = { channels: { test: { parameters: { testParam1: { schema: { $id: 'testParamSchema', test: true, k: 0 } } }, publish: { message: { headers: { test: true, k: 1 }, payload: { test: true, k: 2 } } } }, test2: { subscribe: { message: { payload: { $id: 'testPayload', test: true, k: 2 } } } } }, components: { schemas: { testSchema: { test: true, k: 3 } } } };
       const d = new AsyncAPIDocument(doc);
@@ -214,7 +287,6 @@ describe('AsyncAPIDocument', () => {
 
       //Ensure the actual keys are as expected
       const schemaKeys = Array.from(schemas.keys());
-      console.log(schemaKeys);
       expect(schemaKeys).to.deep.equal([
         "testParamSchema",
         "testParamNestedSchemaProp",

--- a/test/parse_test.js
+++ b/test/parse_test.js
@@ -206,7 +206,7 @@ describe('parse()', function () {
 
   it('should offer information about YAML line and column where $ref errors are located', async function () {
     try {
-      await parser.parse(inputYAML)
+      await parser.parse(inputYAML, { path: __filename })
     } catch (e) {
       expect(e.refs).to.deep.equal([{
         jsonPointer: '/components/schemas/testSchema/properties/test/$ref',
@@ -222,7 +222,7 @@ describe('parse()', function () {
   
   it('should offer information about JSON line and column where $ref errors are located', async function () {
     try {
-      await parser.parse(inputJSON)
+      await parser.parse(inputJSON, { path: __filename })
     } catch (e) {
       expect(e.refs).to.deep.equal([{
         jsonPointer: '/components/schemas/testSchema/properties/test/$ref',
@@ -238,7 +238,7 @@ describe('parse()', function () {
   
   it('should not offer information about JS line and column where $ref errors are located if format is JS', async function () {
     try {
-      await parser.parse(JSON.parse(inputJSON))
+      await parser.parse(JSON.parse(inputJSON), { path: __filename })
     } catch (e) {
       expect(e.refs).to.deep.equal([{
         jsonPointer: '/components/schemas/testSchema/properties/test/$ref',
@@ -316,7 +316,7 @@ describe('parse()', function () {
       expect(e.type).to.equal('https://github.com/asyncapi/parser-js/invalid-yaml');
       expect(e.title).to.equal('The provided YAML is not valid.');
       expect(e.detail).to.equal(`bad indentation of a mapping entry at line 19, column 11:\n              $ref: "#/components/schemas/sentAt"\n              ^`);
-      expect(e.location).to.deep.equal({ startOffset: 460, startLine: 19, startColumn: 11 });
+      expect(e.location).to.deep.equal({ startOffset: offset(460, 19), startLine: 19, startColumn: 11 });
     }
   });
   


### PR DESCRIPTION
- fixes #71
- Solves a problems with additional items are never checked by the recursive schema function.
- Solved tests failing on windows but not on linux.