### PR TITLE
Add support for missing 'deprecated' attribute

### DIFF
--- a/lib/models/schema.js
+++ b/lib/models/schema.js
@@ -340,6 +340,13 @@ class Schema extends Base {
   /**
    * @returns {boolean}
    */
+  deprecated() {
+    return this._json.deprecated;
+  }
+
+  /**
+   * @returns {boolean}
+   */
   readOnly() {
     return !!this._json.readOnly;
   }

--- a/test/models/schema_test.js
+++ b/test/models/schema_test.js
@@ -483,6 +483,15 @@ describe('Schema', () => {
     });
   });
 
+  describe('#deprecated()', function () {
+    it('should return a boolean', () => {
+      const doc = { "type": "string", "deprecated": true };
+      const d = new Schema(doc);
+      expect(typeof d.deprecated()).to.be.equal('boolean');
+      expect(d.deprecated()).to.be.equal(doc.deprecated);
+    });
+  });
+
   describe('#readOnly()', function () {
     it('should return a boolean', () => {
       const doc = { "type": "string", "readOnly": true };


### PR DESCRIPTION
**Description**

Add support for missing 'deprecated' attribute in AsyncAPI schemas. I'm still not 100% clear what ends up in the parser, and what is left for the JSON schema itself, but there doesn't seem to be any way to 'look through' the Schema object to reach these?

**Related issue(s)**

Fixes https://github.com/asyncapi/parser-js/issues/78