### PR TITLE
update: tags() to map subscribe/publish tags.

### DIFF
--- a/lib/models/asyncapi.js
+++ b/lib/models/asyncapi.js
@@ -124,15 +124,26 @@ class AsyncAPIDocument extends Base {
    * @returns {boolean}
    */
   hasTags() {
-    return !!(this._json.tags && this._json.tags.length);
+    return !!(this.tags() && this.tags().length);
   }
 
   /**
    * @returns {Tag[]}
    */
   tags() {
-    if (!this._json.tags) return [];
-    return this._json.tags.map(t => new Tag(t));
+    const tags = new Set();
+
+    this.channelNames().forEach(channelName => {
+      const channel = this.channel(channelName);
+      if (channel.hasPublish()) {
+        (channel._json.publish.tags || []).forEach(tag => tags.add(tag.name));
+      }
+      if (channel.hasSubscribe()) {
+        (channel._json.subscribe.tags || []).forEach(tag => tags.add(tag.name));
+      }
+    })
+
+    return Array.from(tags).map(t => new Tag({ name: t }));
   }
 
   /**

--- a/test/models/asyncapi_test.js
+++ b/test/models/asyncapi_test.js
@@ -155,13 +155,110 @@ describe('AsyncAPIDocument', () => {
     });
   });
 
+  describe('#hasTags()', function() {
+    it('should return true when the AsyncAPI document has tags', () => {
+      const doc = {
+        "channels": {
+          "some_channel": {
+            "publish": {
+              "message": {
+                "name": "some_map",
+                "payload": {
+                  "type": "object",
+                  "properties": {
+                    "message": "string"
+                  }
+                }
+              },
+              "tags": [{"name":"holi"}]
+            }
+          },
+          "channel_without_tags": {
+            "subscribe": {
+              "message": {
+                "name": "channel_without_tags_map",
+                "payload": {
+                  "type": "object",
+                  "properties": {
+                    "message": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      const d = new AsyncAPIDocument(doc);
+      expect(d.hasTags()).to.be.equal(true);
+    });
+    it('should return false when the AsyncAPI document has no tags', () => {
+      const doc = {
+        "channels": {
+          "channel_without_tags": {
+            "subscribe": {
+              "message": {
+                "name": "channel_without_tags_map",
+                "payload": {
+                  "type": "object",
+                  "properties": { "message": "string" }
+                }
+              }
+            }
+          }
+        }
+      }
+      const d = new AsyncAPIDocument(doc);
+      expect(d.hasTags()).to.be.equal(false);
+    });
+  });
+
   describe('#tags()', function () {
     it('should return an array of tags', () => {
-      const doc = { tags: [{ name: 'test1' }, { name: 'test2' }] };
+      const tags = [{"name":"some-app"},{"name":"another-app"}];
+      const doc = {
+        "channels": {
+          "some_channel": {
+            "publish": {
+              "message": {
+                "name": "some_map",
+                "payload": {
+                  "type": "object",
+                  "properties": { "message": "string" }
+                }
+              },
+              "tags": [tags[0]]
+            }
+          },
+          "another_channel": {
+            "subscribe": {
+              "message": {
+                "name": "another_map",
+                "payload": {
+                  "type": "object",
+                  "properties": { "message": "string" }
+                }
+              },
+              "tags": [tags[1]]
+            }
+          },
+          "channel_without_tags": {
+            "subscribe": {
+              "message": {
+                "name": "channel_without_tags_map",
+                "payload": {
+                  "type": "object",
+                  "properties": { "message": "string" }
+                }
+              }
+            }
+          }
+        }
+      }
       const d = new AsyncAPIDocument(doc);
+      expect(d.tags().length).to.be.equal(2)
       d.tags().forEach((t, i) => {
         expect(t.constructor.name).to.be.equal('Tag');
-        expect(t.json()).to.be.equal(doc.tags[i]);
+        expect(t.json()).to.be.eql(tags[i]);
       });
     });
   });


### PR DESCRIPTION
The current code to get the tags from a document only takes into account those tags in the root of the document:

```js
this._json.tags.map(t => new Tag(t))
```

Here it's supposed `tags` is at the same level of `info`, `channels`, `servers`,  etc. So, tags in channels aren't being retrieved when asking for them, nor does `hasTags` when checking if the document contains tags.

I've updated the code for `tags()` and `hasTags()` - the latter uses `tags()` to check if any tag is present in the document (which I don't know if it's okay).

By now tags are only being "extracted" from publish/subscribe entries in channels, so we can see where else could be tags and add them to `tags()` as well.