### PR TITLE
fix: message function returns message and not null if index not provided

### DIFF
--- a/lib/models/operation.js
+++ b/lib/models/operation.js
@@ -31,8 +31,9 @@ class Operation extends OperationTraitable {
    * @returns {Message}
    */
   message(index) {
-    if (typeof index !== 'number' || !this._json.message) return null;
+    if (!this._json.message) return null;
     if (!this._json.message.oneOf) return new Message(this._json.message);
+    if (typeof index !== 'number') return null;
     if (index > this._json.message.oneOf.length - 1) return null;
     return new Message(this._json.message.oneOf[+index]);
   }

--- a/test/models/operation_test.js
+++ b/test/models/operation_test.js
@@ -87,6 +87,12 @@ describe('Operation', function() {
   });
   
   describe('#message()', function() {
+    it('should return null if channel doesn\'t have a message', function() {
+      const doc = { };
+      const d = new Operation(doc);
+      expect(d.message()).to.be.equal(null);
+    });
+    
     it('should return a specific Message object', function() {
       const doc = { message: { oneOf: [{ test: true }, { test: false }] } };
       const d = new Operation(doc);
@@ -98,6 +104,18 @@ describe('Operation', function() {
       const doc = { message: { oneOf: [{ test: true }, { test: false }] } };
       const d = new Operation(doc);
       expect(d.message(100)).to.be.equal(null);
+    });
+
+    it('should return null if index is not a number', function() {
+      const doc = { message: { oneOf: [{ test: true }, { test: false }] } };
+      const d = new Operation(doc);
+      expect(d.message('0')).to.be.equal(null);
+    });
+
+    it('should return message object if no index is provided and message is not oneOf', function() {
+      const doc = { message: { test: true } };
+      const d = new Operation(doc);
+      expect(d.message().json()).to.be.deep.equal(doc.message);
     });
   });
 });


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- message function returns message and not null if index not provided

**Related issue(s)**
See also https://github.com/asyncapi/java-spring-template/issues/75 where the issue was noticed