### PR TITLE
fix: Do not stop parsing if message payload is not provided

### DIFF
--- a/lib/asyncapiSchemaFormatParser.js
+++ b/lib/asyncapiSchemaFormatParser.js
@@ -12,6 +12,9 @@ module.exports = {
  * @private
  */
 async function parse({ message, originalAsyncAPIDocument, fileFormat, parsedAsyncAPIDocument, pathToPayload }) {
+  const payload = message.payload;
+  if (!payload) return;
+
   const ajv = new Ajv({
     jsonPointers: true,
     allErrors: true,
@@ -20,7 +23,7 @@ async function parse({ message, originalAsyncAPIDocument, fileFormat, parsedAsyn
   });
   const payloadSchema = preparePayloadSchema(asyncapi[parsedAsyncAPIDocument.asyncapi]);
   const validate = ajv.compile(payloadSchema);
-  const valid = validate(message.payload);
+  const valid = validate(payload);
 
   if (!valid) throw new ParserError({
     type: 'schema-validation-errors',

--- a/test/asyncapiSchemaFormatParser_test.js
+++ b/test/asyncapiSchemaFormatParser_test.js
@@ -77,4 +77,25 @@ describe('asyncapiSchemaFormatParser', function() {
       ]);
     }
   });
+
+  it('should not throw error if payload not provided', async function() {
+    const inputString = `{
+      "asyncapi": "2.0.0",
+      "info": {
+          "title": "My API",
+          "version": "1.0.0"
+      },
+      "channels": {
+        "mychannel": {
+          "publish": {
+            "message": {
+            }
+          }
+        }
+      }
+    }`;
+    const parsedInput = JSON.parse(inputString);
+
+    expect(async () => await parser.parse(parsedInput)).to.not.throw();
+  });
 });


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- do not stop parsing if message payload is not provided. The payload is not a mandatory field for a message.

Once we merge this one I will make a PR to tck to pump parser version. This is what we will get:
- is
<img width="1261" alt="Screenshot 2020-08-04 at 12 28 11" src="https://user-images.githubusercontent.com/6995927/89283875-2da80280-d64e-11ea-8c05-bfea328c51ef.png">
- will be
<img width="1256" alt="Screenshot 2020-08-04 at 12 28 30" src="https://user-images.githubusercontent.com/6995927/89283900-38629780-d64e-11ea-9722-3eb80340a24d.png">

The drop on valid files by 2 is caused by https://github.com/asyncapi/parser-js/issues/136#issuecomment-668507568
The rest looks good

**Related issue(s)**
Fixes #136