### PR TITLE
feat: Validate oauth2 or openIdConnect have scopes in server sec

### DIFF
--- a/lib/customValidators.js
+++ b/lib/customValidators.js
@@ -135,6 +135,8 @@ function validateOperationId(parsedJSON, asyncapiYAMLorJSON, initialFormat, oper
   return true;
 }
 
+/* eslint-disable sonarjs/cognitive-complexity */
+/* spliting it because it is 18 and not 15 lines would only make it more complex */
 /**
  * Validates if server security is declared properly and the name has a corresponding security schema definition in components with the same name
  * 
@@ -152,23 +154,29 @@ function validateServerSecurity(parsedJSON, asyncapiYAMLorJSON, initialFormat, s
   const root = 'servers';
   const srvsMap = new Map(Object.entries(srvs));
 
-  const missingSecSchema = new Map();
-  const invalidSecurityValues = new Map();
+  const missingSecSchema = new Map(),
+    invalidSecurityValues = new Map(),
+    missingScopesList = new Map();
 
+  //we need to validate every server specified in the document
   srvsMap.forEach((server, serverName) => {
     const serverSecInfo = server.security;
 
     if (!serverSecInfo) return true;
 
+    //server security info is an array of many possible values
     serverSecInfo.forEach(secObj => {
       Object.keys(secObj).forEach(secName => {
+        //security schema is located in components object, we need to find if there is security schema with the same name as the server security info object
         const schema = findSecuritySchema(secName, parsedJSON.components);
         const srvrSecurityPath = `${serverName}/security/${secName}`;
 
         if (!schema.length) return missingSecSchema.set(srvrSecurityPath);
 
+        //findSecuritySchema returns type always on index 1. Type is needed further to validate if server security info can be or not an empty array
         const schemaType = schema[1];
         if (!isSrvrSecProperArray(schemaType, specialSecTypes, secObj, secName)) invalidSecurityValues.set(srvrSecurityPath, schemaType);
+        if (!hasSrvrSecScopes(schemaType, specialSecTypes, secObj, secName)) missingScopesList.set(srvrSecurityPath, schemaType);
       });
     });
   });
@@ -188,6 +196,15 @@ function validateServerSecurity(parsedJSON, asyncapiYAMLorJSON, initialFormat, s
       title: 'Server security value must be an empty array if corresponding security schema type is not oauth2 or openIdConnect.',
       parsedJSON,
       validationErrors: groupValidationErrors(root, 'security info must have an empty array because its corresponding security schema type is', invalidSecurityValues, asyncapiYAMLorJSON, initialFormat)
+    });
+  }
+
+  if (missingScopesList.size) {
+    throw new ParserError({
+      type: validationError,
+      title: 'Server security value must not be an empty array if corresponding security schema type is oauth2 or openIdConnect. Add list of required scopes.',
+      parsedJSON,
+      validationErrors: groupValidationErrors(root, 'security info must not have an empty array because its corresponding security schema type is', missingScopesList, asyncapiYAMLorJSON, initialFormat)
     });
   }
 
@@ -230,6 +247,25 @@ function isSrvrSecProperArray(schemaType, specialSecTypes, secObj, secName) {
     const securityObjValue = secObj[String(secName)];
 
     return !securityObjValue.length;
+  }
+
+  return true;
+}
+
+/**
+ * Validates if given server security is not an empty array when security type requires it
+ * @private
+ * @param  {String} schemaType security type, like httpApiKey or userPassword
+ * @param  {String[]} specialSecTypes list of special types that do not have to be an empty array
+ * @param  {Object} secObj server security object
+ * @param  {String} secName name os server security object
+ * @returns {String[]} there are 2 elements in array, index 0 is the name of the security schema object and index 1 is it's type
+ */
+function hasSrvrSecScopes(schemaType, specialSecTypes, secObj, secName) {
+  if (specialSecTypes.includes(schemaType)) {
+    const securityObjValue = secObj[String(secName)];
+
+    return !!securityObjValue.length;
   }
 
   return true;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,6 +3,8 @@ const { yamlAST, loc } = require('@fmvilas/pseudo-yaml-ast');
 const jsonAST = require('json-to-ast');
 const jsonParseBetterErrors = require('../lib/json-parse');
 const ParserError = require('./errors/parser-error');
+const { EOL } = require('os');
+const eolLength = EOL.length;
 
 const jsonPointerToArray = jsonPointer => (jsonPointer || '/').split('/').splice(1);
 
@@ -296,3 +298,15 @@ utils.groupValidationErrors = (root, errorMessage, errorElements, asyncapiYAMLor
 
   return errors;
 };
+
+/**
+ * Tests helper for testing start and end offset position of error in file to make sure tests work on Windows too
+ * 
+ * @function offset
+ * @private
+ * @param  {Number} oset end or start offset number
+ * @param  {Number} line end or start line number
+ * @returns {Number} calculated offset number
+
+ */
+utils.offset = (oset, line) => (oset + ((eolLength - 1) * (line - 1)));

--- a/test/asyncapiSchemaFormatParser_test.js
+++ b/test/asyncapiSchemaFormatParser_test.js
@@ -2,6 +2,8 @@ const parser = require('../lib');
 const chai = require('chai');
 const fs = require('fs');
 const path = require('path');
+const { offset } = require('../lib/utils'); 
+
 const expect = chai.expect;
 
 describe('asyncapiSchemaFormatParser', function() {
@@ -20,10 +22,10 @@ describe('asyncapiSchemaFormatParser', function() {
             jsonPointer: '/channels/mychannel/publish/message/payload/additionalProperties',
             startLine: 13,
             startColumn: 38,
-            startOffset: 252,
+            startOffset: offset(252, 13),
             endLine: 15,
             endColumn: 15,
-            endOffset: 297
+            endOffset: offset(297, 15)
           }
         },
         {
@@ -32,10 +34,10 @@ describe('asyncapiSchemaFormatParser', function() {
             jsonPointer: '/channels/mychannel/publish/message/payload/additionalProperties',
             startLine: 13,
             startColumn: 38,
-            startOffset: 252,
+            startOffset: offset(252, 13),
             endLine: 15,
             endColumn: 15,
-            endOffset: 297
+            endOffset: offset(297, 15)
           }
         },
         {
@@ -44,10 +46,10 @@ describe('asyncapiSchemaFormatParser', function() {
             jsonPointer: '/channels/mychannel/publish/message/payload/additionalProperties',
             startLine: 13,
             startColumn: 38,
-            startOffset: 252,
+            startOffset: offset(252, 13),
             endLine: 15,
             endColumn: 15,
-            endOffset: 297
+            endOffset: offset(297, 15)
           }
         },
         {
@@ -56,10 +58,10 @@ describe('asyncapiSchemaFormatParser', function() {
             jsonPointer: '/channels/mychannel/publish/message/payload/additionalProperties',
             startLine: 13,
             startColumn: 38,
-            startOffset: 252,
+            startOffset: offset(252, 13),
             endLine: 15,
             endColumn: 15,
-            endOffset: 297
+            endOffset: offset(297, 15)
           }
         },
         {
@@ -68,16 +70,15 @@ describe('asyncapiSchemaFormatParser', function() {
             jsonPointer: '/channels/mychannel/publish/message/payload/additionalProperties',
             startLine: 13,
             startColumn: 38,
-            startOffset: 252,
+            startOffset: offset(252, 13),
             endLine: 15,
             endColumn: 15,
-            endOffset: 297
+            endOffset: offset(297, 15)
           }
         }
       ]);
     }
   });
-
   it('should not throw error if payload not provided', async function() {
     const inputString = `{
       "asyncapi": "2.0.0",

--- a/test/customValidators_test.js
+++ b/test/customValidators_test.js
@@ -1,5 +1,6 @@
 const { validateChannelParams, validateServerVariables, validateOperationId, validateServerSecurity } = require('../lib/customValidators.js');
 const chai = require('chai');
+const { offset } = require('../lib/utils'); 
 
 const expect = chai.expect;
 const input = 'json';
@@ -59,10 +60,10 @@ describe('validateServerVariables()', function() {
             jsonPointer: '/servers/dummy',
             startLine: 3,
             startColumn: 19,
-            startOffset: 39,
+            startOffset: offset(39, 3),
             endLine: 10,
             endColumn: 11,
-            endOffset: 196
+            endOffset: offset(196, 10),
           }
         }
       ]);
@@ -92,10 +93,10 @@ describe('validateServerVariables()', function() {
             jsonPointer: '/servers/dummy',
             startLine: 3,
             startColumn: 19,
-            startOffset: 39,
+            startOffset: offset(39, 3),
             endLine: 5,
             endColumn: 11,
-            endOffset: 89
+            endOffset: offset(89, 5),
           }
         }
       ]);
@@ -130,10 +131,10 @@ describe('validateServerVariables()', function() {
             jsonPointer: '/servers/dummy',
             startLine: 3,
             startColumn: 19,
-            startOffset: 39,
+            startOffset: offset(39, 3),
             endLine: 10,
             endColumn: 11,
-            endOffset: 200
+            endOffset: offset(200, 10),
           }
         }
       ]);
@@ -209,10 +210,10 @@ describe('validateChannelParams()', function() {
             jsonPointer: '/channels/test~1{test}~1{testid}',
             startLine: 3,
             startColumn: 34,
-            startOffset: 54,
+            startOffset: offset(54, 3),
             endLine: 11,
             endColumn: 11,
-            endOffset: 214
+            endOffset: offset(214, 11)
           }
         }
       ]);
@@ -248,10 +249,10 @@ describe('validateChannelParams()', function() {
             jsonPointer: '/channels/test~1{test}',
             startLine: 3,
             startColumn: 25,
-            startOffset: 45,
+            startOffset: offset(45, 3),
             endLine: 11,
             endColumn: 11,
-            endOffset: 206
+            endOffset: offset(206, 11)
           }
         }
       ]);
@@ -280,10 +281,10 @@ describe('validateChannelParams()', function() {
             jsonPointer: '/channels/test~1{test}~1{testid}',
             startLine: 3,
             startColumn: 34,
-            startOffset: 54,
+            startOffset: offset(54, 3),
             endLine: 4,
             endColumn: 11,
-            endOffset: 65
+            endOffset: offset(65, 4)
           }
         }
       ]);
@@ -381,10 +382,10 @@ describe('validateOperationId()', function() {
             jsonPointer: '/channels/test~12/subscribe/operationId',
             startLine: 14,
             startColumn: 29,
-            startOffset: 273,
+            startOffset: offset(273, 14),
             endLine: 14,
             endColumn: 35,
-            endOffset: 279
+            endOffset: offset(279, 14)
           }
         },
         {
@@ -393,10 +394,10 @@ describe('validateOperationId()', function() {
             jsonPointer: '/channels/test~13/subscribe/operationId',
             startLine: 19,
             startColumn: 29,
-            startOffset: 375,
+            startOffset: offset(375, 19),
             endLine: 19,
             endColumn: 35,
-            endOffset: 381
+            endOffset: offset(381, 19)
           }
         }
       ]);
@@ -573,10 +574,10 @@ describe('validateServerSecurity()', function() {
             jsonPointer: '/servers/dummy/security/complex',
             startLine: 12,
             startColumn: 27,
-            startOffset: 250,
+            startOffset: offset(250, 12),
             endLine: 12,
             endColumn: 29,
-            endOffset: 252
+            endOffset: offset(252, 12)
           }
         }
       ]);
@@ -633,10 +634,10 @@ describe('validateServerSecurity()', function() {
             jsonPointer: '/servers/dummy/security/oauthsec',
             startLine: 12,
             startColumn: 28,
-            startOffset: 251,
+            startOffset: offset(251, 12),
             endLine: 12,
             endColumn: 30,
-            endOffset: 253
+            endOffset: offset(253, 12)
           }
         }
       ]);
@@ -678,10 +679,10 @@ describe('validateServerSecurity()', function() {
             jsonPointer: '/servers/dummy/security/complex',
             startLine: 12,
             startColumn: 27,
-            startOffset: 250,
+            startOffset: offset(250, 12),
             endLine: 12,
             endColumn: 29,
-            endOffset: 252
+            endOffset: offset(252, 12)
           }
         }
       ]);
@@ -734,10 +735,10 @@ describe('validateServerSecurity()', function() {
             jsonPointer: '/servers/dummy/security/basic',
             startLine: 12,
             startColumn: 25,
-            startOffset: 248,
+            startOffset: offset(248, 12),
             endLine: 12,
             endColumn: 45,
-            endOffset: 268
+            endOffset: offset(268, 12)
           }
         },
         {
@@ -746,10 +747,10 @@ describe('validateServerSecurity()', function() {
             jsonPointer: '/servers/dummy/security/apikey',
             startLine: 15,
             startColumn: 26,
-            startOffset: 322,
+            startOffset: offset(322, 15),
             endLine: 15,
             endColumn: 36,
-            endOffset: 332
+            endOffset: offset(332, 15)
           }
         }
       ]);

--- a/test/customValidators_test.js
+++ b/test/customValidators_test.js
@@ -439,6 +439,46 @@ describe('validateServerSecurity()', function() {
     expect(validateServerSecurity(parsedInput, inputString, input, specialSecTypes)).to.equal(true);
   });
 
+  it('should successfully validate server security for oauth2 that requires scopes', async function() {
+    const inputString = `{
+      "asyncapi": "2.0.0",
+      "info": {
+        "version": "1.0.0"
+      },
+      "servers": {
+        "dummy": {
+          "url": "http://localhost",
+          "protocol": "kafka",
+          "security": [
+            {
+              "oauthsec": ["read:pets"]
+            }
+          ]
+        }
+      },
+      "components": {
+        "securitySchemes": {
+          "oauthsec": {
+            "type": "oauth2",
+            "flows": {
+              "implicit": {
+                "authorizationUrl": "https://example.com/api/oauth/auth",
+                "refreshUrl": "https://example.com/api/oauth/refresh",
+                "scopes": {
+                  "write:pets": "modify pets in your account",
+                  "read:pets": "read your pets"
+                }
+              }
+            }
+          }
+        }
+      }
+    }`;
+    const parsedInput = JSON.parse(inputString);
+    
+    expect(validateServerSecurity(parsedInput, inputString, input, specialSecTypes)).to.equal(true);
+  });
+
   it('should successfully validate if server security not provided', async function() {
     const inputString = `{
       "asyncapi": "2.0.0",
@@ -537,6 +577,66 @@ describe('validateServerSecurity()', function() {
             endLine: 12,
             endColumn: 29,
             endOffset: 252
+          }
+        }
+      ]);
+    }
+  });
+
+  it('should throw error that server security is missing scopes that are required for special security types like oauth2 and openIdConnect', async function() {
+    const inputString = `{
+      "asyncapi": "2.0.0",
+      "info": {
+        "version": "1.0.0"
+      },
+      "servers": {
+        "dummy": {
+          "url": "http://localhost",
+          "protocol": "kafka",
+          "security": [
+            {
+              "oauthsec": []
+            }
+          ]
+        }
+      },
+      "components": {
+        "securitySchemes": {
+          "oauthsec": {
+            "type": "oauth2",
+            "flows": {
+              "implicit": {
+                "authorizationUrl": "https://example.com/api/oauth/auth",
+                "refreshUrl": "https://example.com/api/oauth/refresh",
+                "scopes": {
+                  "write:pets": "modify pets in your account",
+                  "read:pets": "read your pets"
+                }
+              }
+            }
+          }
+        }
+      }
+    }`;
+    const parsedInput = JSON.parse(inputString);
+    
+    try {
+      validateServerSecurity(parsedInput, inputString, input, specialSecTypes);
+    } catch (e) {
+      expect(e.type).to.equal('https://github.com/asyncapi/parser-js/validation-errors');
+      expect(e.title).to.equal('Server security value must not be an empty array if corresponding security schema type is oauth2 or openIdConnect. Add list of required scopes.');
+      expect(e.parsedJSON).to.deep.equal(parsedInput);
+      expect(e.validationErrors).to.deep.equal([
+        {
+          title: 'dummy/security/oauthsec security info must not have an empty array because its corresponding security schema type is: oauth2',
+          location: {
+            jsonPointer: '/servers/dummy/security/oauthsec',
+            startLine: 12,
+            startColumn: 28,
+            startOffset: 251,
+            endLine: 12,
+            endColumn: 30,
+            endOffset: 253
           }
         }
       ]);

--- a/test/parse_test.js
+++ b/test/parse_test.js
@@ -1,10 +1,10 @@
-const { EOL } = require('os');
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 const fs = require('fs');
 const path = require('path');
 const parser = require('../lib');
 const ParserError = require('../lib/errors/parser-error');
+const { offset } = require('../lib/utils'); 
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -20,8 +20,6 @@ const invalidYamlOutput = '{"asyncapi":"2.0.0","info":{"version":"1.0.0"},"chann
 const invalidJsonOutput = '{"asyncapi":"2.0.0","info":{"version":"1.0.0"},"channels":{"mychannel":{"publish":{"message":{"payload":{"type":"object","properties":{"name":{"type":"string"}}}}}}},"components":{"messages":{"testMessage":{"payload":{"type":"object","properties":{"name":{"type":"string"},"test":{"type":"object","properties":{"testing":{"type":"string"}}}}}}},"schemas":{"testSchema":{"type":"object","properties":{"name":{"type":"string"},"test":{"type":"object","properties":{"testing":{"type":"string"}}}}}}}}';
 const outputJsonWithRefs = '{"asyncapi":"2.0.0","info":{"title":"My API","version":"1.0.0"},"channels":{"mychannel":{"publish":{"traits":[{"externalDocs":{"url":"https://company.com/docs"}}],"externalDocs":{"x-extension":true,"url":"https://irrelevant.com"},"message":{"traits":[{"x-some-extension":"some extension"}],"payload":{"type":"object","properties":{"name":{"type":"string"},"test":null}}}}},"oneOfMessageChannel":{"publish":{"message":{"oneOf":[{"traits":[{"x-some-extension":"some extension"}],"payload":{"type":"object","properties":{"name":{"type":"string"},"test":null}}}]}}}},"components":{"messages":{"testMessage":{"traits":[{"x-some-extension":"some extension"}],"payload":{"type":"object","properties":{"name":{"type":"string"},"test":null}}}},"schemas":{"testSchema":{"type":"object","properties":{"name":{"type":"string"},"test":null}}},"messageTraits":{"extension":{"x-some-extension":"some extension"}},"operationTraits":{"docs":{"externalDocs":{"url":"https://company.com/docs"}}}}}';
 const invalidAsyncAPI = '{"asyncapi":"2.0.0","info":{}}';
-
-const eolLength = EOL.length;
 
 /* eslint-disable sonarjs/cognitive-complexity */
 /**
@@ -53,8 +51,6 @@ const checkErrorWrapper = async (fn, validationObject) => {
   }
 };
 
-const offset = (oset, line) => (oset + ((eolLength - 1) * (line - 1)));
-
 describe('parse()', function() {
   it('should parse YAML', async function() {
     const result = await parser.parse(inputYAML, { path: __filename });
@@ -71,22 +67,24 @@ describe('parse()', function() {
         location: { 
           endColumn: 31,
           endLine: 1,
-          endOffset: 29,
+          endOffset: offset(29, 1),
           jsonPointer: '/info',
           startColumn: 29,
           startLine: 1,
-          startOffset: 27
+          startOffset: offset(27, 1)
         }
       },
       {
         title: '/info should have required property \'version\'',
-        location: { endColumn: 31,
+        location: { 
+          endColumn: 31,
           endLine: 1,
-          endOffset: 29,
+          endOffset: offset(29, 1),
           jsonPointer: '/info',
           startColumn: 29,
           startLine: 1,
-          startOffset: 27 }
+          startOffset: offset(27, 1) 
+        }
       },
       {
         title: '/ should have required property \'channels\'',
@@ -213,7 +211,7 @@ describe('parse()', function() {
           jsonPointer: '/asyncapi',
           startLine: 1,
           startColumn: 1,
-          startOffset: 0,
+          startOffset: offset(0, 1),
           endLine: 1,
           endColumn: 16,
           endOffset: offset(15, 1),
@@ -231,7 +229,7 @@ describe('parse()', function() {
       type: 'https://github.com/asyncapi/parser-js/invalid-yaml',
       title: 'The provided YAML is not valid.',
       detail: 'duplicated mapping key at line 2, column -4:\n    bad:\n    ^',
-      location: { startOffset: 5, startLine: 2, startColumn: -4 }
+      location: { startOffset: offset(5, 2), startLine: 2, startColumn: -4 }
     };
 
     await checkErrorWrapper(async () => {
@@ -249,10 +247,10 @@ describe('parse()', function() {
           jsonPointer: '/components/schemas/testSchema/properties/test/$ref',
           startLine: 35,
           startColumn: 11,
-          startOffset: 736,
+          startOffset: offset(736, 35),
           endLine: 35,
           endColumn: 34,
-          endOffset: 759
+          endOffset: offset(759, 35)
         }
       ]
     };
@@ -270,10 +268,10 @@ describe('parse()', function() {
           jsonPointer: '/components/schemas/testSchema/properties/test/$ref',
           startLine: 35,
           startColumn: 11,
-          startOffset: 736,
+          startOffset: offset(736, 35),
           endLine: 35,
           endColumn: 34,
-          endOffset: 759
+          endOffset: offset(759, 35)
         }
       ]
     };
@@ -407,7 +405,7 @@ describe('parse()', function() {
       type: 'https://github.com/asyncapi/parser-js/invalid-yaml',
       title: 'The provided YAML is not valid.',
       detail: 'bad indentation of a mapping entry at line 19, column 11:\n              $ref: "#/components/schemas/sentAt"\n              ^',
-      location: { startOffset: 460, startLine: 19, startColumn: 11 }
+      location: { startOffset: offset(460, 19), startLine: 19, startColumn: 11 }
     };
 
     await checkErrorWrapper(async () => {
@@ -420,7 +418,7 @@ describe('parse()', function() {
       type: 'https://github.com/asyncapi/parser-js/invalid-json',
       title: 'The provided JSON is not valid.',
       detail: 'Unexpected token j in JSON at position 12 while parsing near \' {"invalid "json" }\'',
-      location: { startOffset: 12, startLine: 1, startColumn: 12 }
+      location: { startOffset: offset(12, 1), startLine: 1, startColumn: 12 }
     };
 
     await checkErrorWrapper(async () => {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Validate oauth2 or openIdConnect have scopes in server sec
- This PR will make these test cases to pass https://github.com/asyncapi/tck/blob/master/tests/asyncapi-2.0/Security%20Requirement%20Object/invalid-oauth2-without-scopes.yaml and https://github.com/asyncapi/tck/blob/master/tests/asyncapi-2.0/Security%20Requirement%20Object/invalid-openIdConnect-without-scopes.yaml

I think such validation would be also handlable with if/else statement in AsyncAPI JSON Schema (didn't check but I believe it is doable) but because we already had logic for validation of server security, it was easy to plug in there