### PR TITLE
feat: Revert wrong oauth2 or openIdConnect server sec info validation

### DIFF
--- a/lib/customValidators.js
+++ b/lib/customValidators.js
@@ -135,8 +135,6 @@ function validateOperationId(parsedJSON, asyncapiYAMLorJSON, initialFormat, oper
   return true;
 }
 
-/* eslint-disable sonarjs/cognitive-complexity */
-/* spliting it because it is 18 and not 15 lines would only make it more complex */
 /**
  * Validates if server security is declared properly and the name has a corresponding security schema definition in components with the same name
  * 
@@ -155,8 +153,7 @@ function validateServerSecurity(parsedJSON, asyncapiYAMLorJSON, initialFormat, s
   const srvsMap = new Map(Object.entries(srvs));
 
   const missingSecSchema = new Map(),
-    invalidSecurityValues = new Map(),
-    missingScopesList = new Map();
+    invalidSecurityValues = new Map();
 
   //we need to validate every server specified in the document
   srvsMap.forEach((server, serverName) => {
@@ -176,7 +173,6 @@ function validateServerSecurity(parsedJSON, asyncapiYAMLorJSON, initialFormat, s
         //findSecuritySchema returns type always on index 1. Type is needed further to validate if server security info can be or not an empty array
         const schemaType = schema[1];
         if (!isSrvrSecProperArray(schemaType, specialSecTypes, secObj, secName)) invalidSecurityValues.set(srvrSecurityPath, schemaType);
-        if (!hasSrvrSecScopes(schemaType, specialSecTypes, secObj, secName)) missingScopesList.set(srvrSecurityPath, schemaType);
       });
     });
   });
@@ -196,15 +192,6 @@ function validateServerSecurity(parsedJSON, asyncapiYAMLorJSON, initialFormat, s
       title: 'Server security value must be an empty array if corresponding security schema type is not oauth2 or openIdConnect.',
       parsedJSON,
       validationErrors: groupValidationErrors(root, 'security info must have an empty array because its corresponding security schema type is', invalidSecurityValues, asyncapiYAMLorJSON, initialFormat)
-    });
-  }
-
-  if (missingScopesList.size) {
-    throw new ParserError({
-      type: validationError,
-      title: 'Server security value must not be an empty array if corresponding security schema type is oauth2 or openIdConnect. Add list of required scopes.',
-      parsedJSON,
-      validationErrors: groupValidationErrors(root, 'security info must not have an empty array because its corresponding security schema type is', missingScopesList, asyncapiYAMLorJSON, initialFormat)
     });
   }
 
@@ -247,25 +234,6 @@ function isSrvrSecProperArray(schemaType, specialSecTypes, secObj, secName) {
     const securityObjValue = secObj[String(secName)];
 
     return !securityObjValue.length;
-  }
-
-  return true;
-}
-
-/**
- * Validates if given server security is not an empty array when security type requires it
- * @private
- * @param  {String} schemaType security type, like httpApiKey or userPassword
- * @param  {String[]} specialSecTypes list of special types that do not have to be an empty array
- * @param  {Object} secObj server security object
- * @param  {String} secName name os server security object
- * @returns {String[]} there are 2 elements in array, index 0 is the name of the security schema object and index 1 is it's type
- */
-function hasSrvrSecScopes(schemaType, specialSecTypes, secObj, secName) {
-  if (specialSecTypes.includes(schemaType)) {
-    const securityObjValue = secObj[String(secName)];
-
-    return !!securityObjValue.length;
   }
 
   return true;

--- a/test/customValidators_test.js
+++ b/test/customValidators_test.js
@@ -440,46 +440,6 @@ describe('validateServerSecurity()', function() {
     expect(validateServerSecurity(parsedInput, inputString, input, specialSecTypes)).to.equal(true);
   });
 
-  it('should successfully validate server security for oauth2 that requires scopes', async function() {
-    const inputString = `{
-      "asyncapi": "2.0.0",
-      "info": {
-        "version": "1.0.0"
-      },
-      "servers": {
-        "dummy": {
-          "url": "http://localhost",
-          "protocol": "kafka",
-          "security": [
-            {
-              "oauthsec": ["read:pets"]
-            }
-          ]
-        }
-      },
-      "components": {
-        "securitySchemes": {
-          "oauthsec": {
-            "type": "oauth2",
-            "flows": {
-              "implicit": {
-                "authorizationUrl": "https://example.com/api/oauth/auth",
-                "refreshUrl": "https://example.com/api/oauth/refresh",
-                "scopes": {
-                  "write:pets": "modify pets in your account",
-                  "read:pets": "read your pets"
-                }
-              }
-            }
-          }
-        }
-      }
-    }`;
-    const parsedInput = JSON.parse(inputString);
-    
-    expect(validateServerSecurity(parsedInput, inputString, input, specialSecTypes)).to.equal(true);
-  });
-
   it('should successfully validate if server security not provided', async function() {
     const inputString = `{
       "asyncapi": "2.0.0",
@@ -578,66 +538,6 @@ describe('validateServerSecurity()', function() {
             endLine: 12,
             endColumn: 29,
             endOffset: offset(252, 12)
-          }
-        }
-      ]);
-    }
-  });
-
-  it('should throw error that server security is missing scopes that are required for special security types like oauth2 and openIdConnect', async function() {
-    const inputString = `{
-      "asyncapi": "2.0.0",
-      "info": {
-        "version": "1.0.0"
-      },
-      "servers": {
-        "dummy": {
-          "url": "http://localhost",
-          "protocol": "kafka",
-          "security": [
-            {
-              "oauthsec": []
-            }
-          ]
-        }
-      },
-      "components": {
-        "securitySchemes": {
-          "oauthsec": {
-            "type": "oauth2",
-            "flows": {
-              "implicit": {
-                "authorizationUrl": "https://example.com/api/oauth/auth",
-                "refreshUrl": "https://example.com/api/oauth/refresh",
-                "scopes": {
-                  "write:pets": "modify pets in your account",
-                  "read:pets": "read your pets"
-                }
-              }
-            }
-          }
-        }
-      }
-    }`;
-    const parsedInput = JSON.parse(inputString);
-    
-    try {
-      validateServerSecurity(parsedInput, inputString, input, specialSecTypes);
-    } catch (e) {
-      expect(e.type).to.equal('https://github.com/asyncapi/parser-js/validation-errors');
-      expect(e.title).to.equal('Server security value must not be an empty array if corresponding security schema type is oauth2 or openIdConnect. Add list of required scopes.');
-      expect(e.parsedJSON).to.deep.equal(parsedInput);
-      expect(e.validationErrors).to.deep.equal([
-        {
-          title: 'dummy/security/oauthsec security info must not have an empty array because its corresponding security schema type is: oauth2',
-          location: {
-            jsonPointer: '/servers/dummy/security/oauthsec',
-            startLine: 12,
-            startColumn: 28,
-            startOffset: offset(251, 12),
-            endLine: 12,
-            endColumn: 30,
-            endOffset: offset(253, 12)
           }
         }
       ]);


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Revert wrong oauth2 or openIdConnect server sec info validation as discussed here https://github.com/asyncapi/tck/issues/22. I did not revert entire commit as there were good things like additional comments to code added, and the `offset` usage added to all tests.