### PR TITLE
chore: Improve circular refs support with circularProps and hasCircularProps

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ For more information about the `ParserError` class, [check out the documentation
 Parser dereferences all circular references by default. In addition, to simplify interactions with the parser, the following is added:
 - `x-parser-circular` property is added to the root of the AsyncAPI document to indicate that the document contains circular references. Tooling developer that doesn't want to support circular references can use the `hasCircular()` function to check the document and provide a proper message to the user.
 - `x-parser-circular` property is added to every schema of array type that is circular. To check if schema is circular or not, you should use `isCircular()` function on a Schema model like `document.components().schema('RecursiveSelf').properties()['selfChildren'].isCircular()`.
-- `x-parser-circular-props` property is added to every schema of object type with a list of properties that are circular. To check if schema has properties with circular references, you should use `hasCircularProps()` function. To get a list of properties with circular references, you should use `circularProps()` function.
+- `x-parser-circular-props` property is added to every schema of object type with a list of properties that are circular. To check if a schema has properties with circular references, you should use `hasCircularProps()` function. To get a list of properties with circular references, you should use `circularProps()` function.
 
 ### Develop
 

--- a/README.md
+++ b/README.md
@@ -133,8 +133,9 @@ For more information about the `ParserError` class, [check out the documentation
 ### Circular references
 
 Parser dereferences all circular references by default. In addition, to simplify interactions with the parser, the following is added:
-- `x-parser-circular` property is added to the root of the AsyncAPI document to indicate that the document contains circular references. Tooling developer that doesn't want to support circular references can use the `hasCircular` method to check the document and provide a proper message to the user.
-- `x-parser-circular` property is added to every schema where circular reference starts. You should use `isCircular` method on a Schema model like `document.components().schema('RecursiveSelf').properties()['selfChildren'].isCircular()`.
+- `x-parser-circular` property is added to the root of the AsyncAPI document to indicate that the document contains circular references. Tooling developer that doesn't want to support circular references can use the `hasCircular()` function to check the document and provide a proper message to the user.
+- `x-parser-circular` property is added to every schema of array type that is circular. To check if schema is circular or not, you should use `isCircular()` function on a Schema model like `document.components().schema('RecursiveSelf').properties()['selfChildren'].isCircular()`.
+- `x-parser-circular-props` property is added to every schema of object type with a list of properties that are circular. To check if schema has properties with circular references, you should use `hasCircularProps()` function. To get a list of properties with circular references, you should use `circularProps()` function.
 
 ### Develop
 

--- a/lib/models/asyncapi.js
+++ b/lib/models/asyncapi.js
@@ -9,6 +9,7 @@ const Tag = require('./tag');
 const xParserMessageName = 'x-parser-message-name';
 const xParserSchemaId = 'x-parser-schema-id';
 const xParserCircle = 'x-parser-circular';
+const xParserCircleProps = 'x-parser-circular-props';
 
 /**
  * Implements functions to deal with the AsyncAPI document.
@@ -298,8 +299,12 @@ function isCircular(schema, seenObjects) {
  * @private
  * @param {Schema} schema schema that should be marked as circular
  */
-function markCircular(schema) {
-  schema.json()[String(xParserCircle)] = true;
+function markCircular(schema, prop) {
+  if (schema.type() === 'array') return schema.json()[String(xParserCircle)] = true;
+
+  const circPropsList = schema.json()[String(xParserCircleProps)] || [];
+  circPropsList.push(prop);
+  schema.json()[String(xParserCircleProps)] = circPropsList;
 }
 
 /**
@@ -333,8 +338,8 @@ function recursiveSchema(schemaContent, callback) {
  *         schema {Schema}: the found schema.
  */
 function crawl(schema, seenObj, callback) {
-  if (schema.isCircular() || isCircular(schema, seenObj)) return true;
-  
+  if (isCircular(schema, seenObj)) return true;
+
   seenObj.push(schema.json());
   callback(schema);
   if (schema.type() !== undefined) {
@@ -428,8 +433,8 @@ function recursiveSchemaObject(schema, seenObj, callback) {
   }
   if (schema.properties() !== null) {
     const props = schema.properties();
-    for (const [, propertySchema] of Object.entries(props)) {
-      if (crawl(propertySchema, seenObj, callback)) markCircular(schema);
+    for (const [prop, propertySchema] of Object.entries(props)) {
+      if (crawl(propertySchema, seenObj, callback)) markCircular(schema, prop);
     }
   }
 }

--- a/lib/models/schema.js
+++ b/lib/models/schema.js
@@ -369,6 +369,20 @@ class Schema extends Base {
   isCircular() {
     return !!this.ext('x-parser-circular');
   }
+
+  /**
+   * @returns {boolean}
+   */
+  hasCircularProps() {
+    return !!this.ext('x-parser-circular-props');
+  }
+
+  /**
+   * @returns {[string]}
+   */
+  circularProps() {
+    return this.ext('x-parser-circular-props');
+  }
 }
 
 module.exports = addExtensions(Schema);

--- a/test/good/circular-refs.yaml
+++ b/test/good/circular-refs.yaml
@@ -47,6 +47,13 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/RecursiveSelf'
+        selfObjectChildren:
+          type: object
+          properties:
+            test:
+              $ref: '#/components/schemas/RecursiveSelf'
+            nonRecursive:
+              type: string
         selfSomething:
           type: object
           properties:

--- a/test/parse_test.js
+++ b/test/parse_test.js
@@ -494,6 +494,10 @@ describe('parse()', function() {
     expect(result.components().schema('RecursiveSelf').isCircular()).to.equal(false);
     expect(result.components().schema('NonRecursive').isCircular()).to.equal(false);
     expect(result.components().schema('RecursiveSelf').properties()['selfChildren'].isCircular()).to.equal(true);
+    expect(result.components().schema('RecursiveSelf').properties()['selfObjectChildren'].isCircular()).to.equal(false);
+    expect(result.components().schema('RecursiveSelf').properties()['selfObjectChildren'].hasCircularProps()).to.equal(true);
+    expect(result.components().schema('RecursiveSelf').properties()['selfObjectChildren'].circularProps()[0]).to.equal('test');
+    expect(result.components().schema('RecursiveSelf').properties()['selfObjectChildren'].circularProps().length).to.equal(1);
     expect(result.components().schema('NonRecursive').properties()['child'].isCircular()).to.equal(false);
     //NormalSchemaB is referred twice, from NormalSchemaA and NormalSchemaC. 
     //If seenObjects array is not handled properly, once NormalSchemaB is seen for a second time while traversing NormalSchemaC, then NormalSchemaC is marked as object holding circular refs


### PR DESCRIPTION
**Description**

Unfortunately, the functionality that I added was useless in action. I tried it in 2 templates and I realized that marking the object as circular only if one of its props is circular doesn't make sense.

[BREAKING CHANGE] now object doesn't have the `x-parser-circular` is some props are circular, instead, it gets `x-parser-circular-props` with proper functions on schema model (`circularProps` and `hasCircularProps`). Thanks to it later in the template I can easily eliminate traversing circular props, and still go through those that are not circular, not listed in `x-parser-circular-props`.