### PR TITLE
fix: throw correct errors located in files that are $ref of another $ref

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,7 +18,7 @@ const getAST = (asyncapiYAMLorJSON, initialFormat) => {
 
 const findNode = (obj, location) => {
   for (const key of location) {
-    obj = obj[utils.untilde(key)];
+    obj = obj ? obj[utils.untilde(key)] : null;
   }
   return obj;
 };

--- a/test/parse_test.js
+++ b/test/parse_test.js
@@ -410,6 +410,19 @@ describe('parse()', function() {
     }, expectedErrorObject);
   });
 
+  it('should throw proper error even if issue is inside $refed file of a $refed file', async function() {
+    const expectedErrorObject = {
+      type: 'https://github.com/asyncapi/parser-js/schema-validation-errors',
+      title: 'This is not a valid AsyncAPI Schema Object.'
+    };
+
+    await checkErrorWrapper(async () => {
+      await parser.parse(fs.readFileSync(path.resolve(__dirname, './wrong/good-ref-to-broken-file.yaml'), 'utf8'), {
+        path: __filename,
+      });
+    }, expectedErrorObject);
+  });
+
   it('should throw error if document is invalid YAML', async function() {
     const expectedErrorObject = {
       type: 'https://github.com/asyncapi/parser-js/invalid-yaml',

--- a/test/wrong/good-ref-to-broken-file.yaml
+++ b/test/wrong/good-ref-to-broken-file.yaml
@@ -1,0 +1,9 @@
+asyncapi: 2.0.0
+info:
+  title: My API
+  version: '1.0.0'
+channels:
+  mychannel:
+    publish:
+      message:
+        $ref: 'wrong/good-refed-file.yml'

--- a/test/wrong/good-refed-file.yml
+++ b/test/wrong/good-refed-file.yml
@@ -1,0 +1,2 @@
+payload:
+  $ref: refed-file-broken-schema.yml

--- a/test/wrong/refed-file-broken-schema.yml
+++ b/test/wrong/refed-file-broken-schema.yml
@@ -1,0 +1,4 @@
+type: string
+properties:
+  name:
+  type: string


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- throw correct errors located in files that are $ref of another $ref. Without this fix, the user gets the wrong type error like `Cannot read property 'properties' of undefined`

**Related issue(s)**
Fixes #177