### PR TITLE
ci: add workflow that bumps parser in other asyncapi repos

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,29 @@
+name: Bump package version in dependent repos
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Get version from package.json before release step
+        id: extractver
+        run: echo "::set-output name=version::$(npm run get-version --silent)"
+      - name: Get name of package from package.json
+        id: extractname
+        run: echo "::set-output name=packname::$(npm run get-name --silent)"
+      - name: Bumping latest version of this package in other repositories
+        uses: derberg/org-projects-dependency-manager@v1
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          committer_username: asyncapi-bot
+          committer_email: info@asyncapi.io
+          #This is commit message and PR title for repos where this package is in dependencies
+          commit_message_prod: 'fix: update ${{ steps.extractname.outputs.packname }} to ${{ steps.extractver.outputs.version }} version'
+          #This is commit message and PR title for repos where this package is in devDependencies
+          commit_message_dev: 'chore: update ${{ steps.extractname.outputs.packname }} to ${{ steps.extractver.outputs.version }} version'

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "prepublishOnly": "npm run bundle && npm run docs && npm run types",
     "release": "semantic-release",
     "get-version": "echo $npm_package_version",
+    "get-name": "echo $npm_package_name",
     "lint": "eslint --max-warnings 0 --config .eslintrc .",
     "gen-readme-toc": "markdown-toc -i README.md",
     "test-lib": "nyc --reporter=html --reporter=text mocha --exclude test/browser_test.js --recursive",


### PR DESCRIPTION
**Description**

So far just review and let me know what you think. In my opinion we should not merge it until we first make sure that dependants have workflows that test PRs and these workflows are required. Agreed?

- action that is used here https://github.com/marketplace/actions/organization-projects-dependency-manager
- it was tested against [this](https://github.com/lukasz-lab/.github) repo, with [this](https://github.com/lukasz-lab/.github/blob/master/.github/workflows/bump-on-release.yml) workflow. Result is [here](https://github.com/lukasz-lab/.github/runs/1499622298?check_suite_focus=true)
- looking at [this](https://github.com/search?q=%22%40asyncapi%2Fparser%22+org%3Aasyncapi+in%3Afile+filename%3Apackage.json&type=code) search result, this workflow will bump parser in:
  - `asyncapi/nodejs-ws-template` as `fix:`
  - `asyncapi/playground` as `fix:`
  - `asyncapi/raml-dt-schema-parser` as `chore:`
  - `asyncapi/openapi-schema-parser` as `chore:`
  - `asyncapi/avro-schema-parser` as `chore:`
  - `asyncapi/asyncapi-react` as `fix:`
  - `asyncapi/html-template` as `chore:`
  - `asyncapi/tck` as `fix:`
  - `asyncapi/generator` as `fix:`
  - `asyncapi/template-for-generator-templates` as `chore:`

**Related issue(s)**
See also https://github.com/asyncapi/.github/issues/16