### PR TITLE
ci: fix release workflow step that is responsible for handling twitter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,20 +43,16 @@ jobs:
         run: npm run release
       - name: Get version from package.json after release step
         id: extractver
-        #npm is slow and has delays it is better to sleep here a bit to be 100% sure the next step that relies on npm gets latest value
-        run: |
-          sleep 1m
-          echo "::set-output name=version::$(npm run get-version --silent)"
+        run: echo "::set-output name=version::$(npm run get-version --silent)"
       - name: Check if version changed  # Version check based on package.json version number
         uses: EndBug/version-check@v1.6.0
         id: check
         with:
-          #we need to do static check here because version-check action checks on local package.json from a commit from push event
-          #and version from commiton push event is older than the one we just updated and pushed to npm
-          file-url: https://unpkg.com/@asyncapi/parser@latest/package.json
-          static-checking: remoteIsNew
+          # we need to statically check that local version is now newer than the one in master
+          file-url: https://raw.githubusercontent.com/${{github.repository}}/master/package.json
+          static-checking: localIsNew
       - name: Publish information about the release to Twitter # tweet only if detected version change is not a patch
-        if: steps.check.outputs.changed == 'true' && steps.check.outputs.type != 'patch'
+        if: steps.initversion.outputs.version != steps.extractver.outputs.version && steps.check.outputs.changed == 'true' && steps.check.outputs.type != 'patch'
         uses: m1ner79/Github-Twittction@v1.0.1
         with:
           twitter_status: "Release ${{ steps.extractver.outputs.version }} for ${{github.repository}} is out in the wild 😱💪🍾🎂\n\nThank you for the contribution ${{ github.event.commits[0].author.name }} https://github.com/${{github.repository}}/releases/tag/v${{ steps.extractver.outputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,10 +43,18 @@ jobs:
         run: npm run release
       - name: Get version from package.json after release step
         id: extractver
-        run: echo "::set-output name=version::$(npm run get-version --silent)"
+        #npm is slow and has delays it is better to sleep here a bit to be 100% sure the next step that relies on npm gets latest value
+        run: |
+          sleep 1m
+          echo "::set-output name=version::$(npm run get-version --silent)"
       - name: Check if version changed  # Version check based on package.json version number
         uses: EndBug/version-check@v1.6.0
         id: check
+        with:
+          #we need to do static check here because version-check action checks on local package.json from a commit from push event
+          #and version from commiton push event is older than the one we just updated and pushed to npm
+          file-url: https://unpkg.com/@asyncapi/parser@latest/package.json
+          static-checking: remoteIsNew
       - name: Publish information about the release to Twitter # tweet only if detected version change is not a patch
         if: steps.check.outputs.changed == 'true' && steps.check.outputs.type != 'patch'
         uses: m1ner79/Github-Twittction@v1.0.1


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Since we introduced a step that validates what type of release we have (patch/minor/major) we have a problem with twitter step. It is not run when we do release, and instead, it runs next time we do the push, push commit with pump in package.json. As a result, in tweet, instead of putting the name of the user that is responsible for major/minor release, we put the name of the user that pushed bump commit, always bot user. 

This PR should fix it by checking the version from package.json on master against the version from package.json available in the workflow. Taken from https://github.com/EndBug/version-check#static-checking-with-your-latest-version-on-npm