### PR TITLE
ci: bump workflow to start on push instead of release

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,9 +1,11 @@
 name: Bump package version in dependent repos
 
 on:
-  release:
-    types:
-      - published
+  #It cannot run on release event as when release is created then version is not yet bumped in package.json
+  #This means we cannot extract easily latest version and have a risk that package is not yet on npm
+  push:
+    branches:
+      - master
 
 jobs:
   bump:
@@ -17,7 +19,8 @@ jobs:
       - name: Get name of package from package.json
         id: extractname
         run: echo "::set-output name=packname::$(npm run get-name --silent)"
-      - name: Bumping latest version of this package in other repositories
+      - if: startsWith(github.event.commits[0].message, ' chore(release):')
+        name: Bumping latest version of this package in other repositories
         uses: derberg/org-projects-dependency-manager@v1
         with:
           github_token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- we cannot react on release event, as by that time changes in package.json are not there yet, so this `npm run get-version --silent` gives you a version before the latest
- reacting right after release event there is a huge risk package is not yet there on npm. Reacting on push of bump commit makes the workflow error prone