### PR TITLE
ci: rename pr testing job name and test node 14

### DIFF
--- a/.github/workflows/pull-request-testing.yml
+++ b/.github/workflows/pull-request-testing.yml
@@ -5,9 +5,9 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
 
 jobs:
-  release:
+  test_pr:
     if: github.event.pull_request.draft == false
-    name: 'Run tests'
+    name: 'Testing pull request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -15,14 +15,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 13
+          node-version: 14
       - name: Install dependencies
         run: npm ci
       - name: Run linter
         run: npm run lint
       - name: Run tests
         run: npm test
-      - name: Regenerate types to make sure nothing is broken
-        run: npm run types
       - name: Regenerate docs to make sure jsdoc are not broken
         run: npm run docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 13
+          node-version: 14
       - name: Install dependencies
         run: npm ci
       - name: Run tests


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- I cannot set a requirement on testing workflow on PR level because currently its job name is the same as name in release workflow, not job but step but long term it can be confusing, better have the same job name everywhere
- test on node14 as we anyway already support node14 in generator