### PR TITLE
test: improve feedback loop from browser tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "lint": "eslint --max-warnings 0 --config .eslintrc .",
     "gen-readme-toc": "markdown-toc -i README.md",
     "test-lib": "nyc --reporter=html --reporter=text mocha --exclude test/browser_test.js --recursive",
-    "test-browser": "npm run bundle && cp dist/bundle.js test/sample_browser/  && start-server-and-test 'http-server test/sample_browser --cors -s' 8080 'mocha --timeout 3000 test/browser_test.js' && rimraf test/sample_browser/bundle.js"
+    "test-browser": "npm run test-browser-cleanup && npm run bundle && cp dist/bundle.js test/sample_browser/  && start-server-and-test 'http-server test/sample_browser --cors -s' 8080 'mocha --timeout 3000 test/browser_test.js' && npm run test-browser-cleanup",
+    "test-browser-cleanup": "rimraf test/sample_browser/bundle.js" 
   },
   "bugs": {
     "url": "https://github.com/asyncapi/parser-js/issues"

--- a/test/browser_test.js
+++ b/test/browser_test.js
@@ -10,6 +10,10 @@ describe('Check Parser in the browser', function() {
     //use this in case you want to troubleshoot in a real chrome window => browser = await puppeteer.launch({headless: false});
     browser = await puppeteer.launch();
     page = await browser.newPage();
+    page.on('console', msg => {
+      for (let i = 0; i < msg.args().length; ++i)
+        console.error(`Browser console error ${i}: ${JSON.stringify(msg.args()[i]._remoteObject, null, 2)}`);
+    });
     await page.goto('http://localhost:8080', { waitUntil: 'networkidle0' });
   });
       

--- a/test/browser_test.js
+++ b/test/browser_test.js
@@ -12,7 +12,7 @@ describe('Check Parser in the browser', function() {
     page = await browser.newPage();
     page.on('console', msg => {
       for (let i = 0; i < msg.args().length; ++i)
-        console.error(`Browser console error ${i}: ${JSON.stringify(msg.args()[i]._remoteObject, null, 2)}`);
+        console.error(`Browser console content ${i}: ${JSON.stringify(msg.args()[i]._remoteObject, null, 2)}`);
     });
     await page.goto('http://localhost:8080', { waitUntil: 'networkidle0' });
   });

--- a/test/sample_browser/index.html
+++ b/test/sample_browser/index.html
@@ -20,7 +20,7 @@
             divElement.style.visibility = 'visible';
             divElement.innerHTML = parsedFromUrl.version();
         } catch (error) {
-            console.log(error)
+            console.error(error)
         }
     }
     execute();


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- console log everything that shows up in the browser console during browser tests
- cleanup of browser test must be done before and after test. If we do only after, the problem is that when the test fails, cleanup doesn't run

**Related issue(s)**
See also https://github.com/asyncapi/parser-js/pull/214