### PR TITLE
fix: increase timeouts on tests for mac

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "npm run test:lib && npm run test:browser",
+    "test": "npm run test:browser:cleanup && npm run test:lib && npm run test:browser",
     "bundle": "browserify \"lib/browser.js\" | uglifyjs > \"dist/bundle.js\"",
     "docs": "jsdoc2md \"lib/parser.js\" -f \"lib/**/*.js\" > API.md",
     "types": "jsdoc -t \"node_modules/tsd-jsdoc/dist\" -r lib -d \"./\" && node \"./scripts/fix-ts-types.js\"",
@@ -18,7 +18,7 @@
     "get:name": "echo $npm_package_name",
     "lint": "eslint --max-warnings 0 --config \".eslintrc\" \".\"",
     "test:lib": "nyc --reporter=html --reporter=text mocha --exclude \"test/browser_test.js\" --recursive",
-    "test:browser": "npm run test:browser:cleanup && npm run bundle && cp \"dist/bundle.js\" \"test/sample_browser/\"  && start-server-and-test \"http-server test/sample_browser --cors -s\" 8080 \"mocha --timeout 6000 test/browser_test.js\" && npm run test:browser:cleanup",
+    "test:browser": "npm run test:browser:cleanup && npm run bundle && cp \"dist/bundle.js\" \"test/sample_browser/\"  && start-server-and-test \"http-server test/sample_browser --cors -s\" 8080 \"mocha --timeout 20000 test/browser_test.js\" && npm run test:browser:cleanup",
     "test:browser:cleanup": "rimraf \"test/sample_browser/bundle.js\"",
     "generate:readme:toc": "markdown-toc -i \"README.md\"",
     "generate:assets": "npm run docs && npm run generate:readme:toc && npm run types && npm run bundle",

--- a/test/browser_test.js
+++ b/test/browser_test.js
@@ -33,7 +33,7 @@ describe('Check Parser in the browser', function() {
     } catch (e) {
       throw new Error(e);
     }
-  }).timeout(3000);
+  }).timeout(5000);
 
   it('parsing spec from remote should complete successfully', async function() {
     try {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

This time it should be fine. I rerun tests on mac in this PR over 5 times and it never failed

- again have to do fix to trigger release
- increase timeouts on tests for mac