### PR TITLE
test: extract checkErrorWrapper and use it in other tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "get:name": "echo $npm_package_name",
     "lint": "eslint --max-warnings 0 --config \".eslintrc\" \".\"",
     "test:lib": "nyc --reporter=html --reporter=text mocha --exclude \"test/browser_test.js\" --recursive",
-    "test:browser": "npm run test:browser:cleanup && npm run bundle && cp \"dist/bundle.js\" \"test/sample_browser/\"  && start-server-and-test \"http-server test/sample_browser --cors -s\" 8080 \"mocha --timeout 20000 test/browser_test.js\" && npm run test:browser:cleanup",
+    "test:browser": "npm run test:browser:cleanup && npm run bundle && shx cp \"dist/bundle.js\" \"test/sample_browser/\"  && start-server-and-test \"http-server test/sample_browser --cors -s\" 8080 \"mocha --timeout 20000 test/browser_test.js\" && npm run test:browser:cleanup",
     "test:browser:cleanup": "rimraf \"test/sample_browser/bundle.js\"",
     "generate:readme:toc": "markdown-toc -i \"README.md\"",
     "generate:assets": "npm run docs && npm run generate:readme:toc && npm run types && npm run bundle",
@@ -59,6 +59,7 @@
     "puppeteer": "^7.0.1",
     "rimraf": "^3.0.2",
     "semantic-release": "^17.0.4",
+    "shx": "^0.3.3",
     "start-server-and-test": "^1.11.3",
     "tsd-jsdoc": "^2.5.0",
     "uglify-es": "^3.3.9"

--- a/test/asyncapiSchemaFormatParser_test.js
+++ b/test/asyncapiSchemaFormatParser_test.js
@@ -12,7 +12,7 @@ describe('asyncapiSchemaFormatParser', function() {
     const expectedErrorObject = {
       type: 'https://github.com/asyncapi/parser-js/schema-validation-errors',
       title: 'This is not a valid AsyncAPI Schema Object.',
-      parsedJSON: invalidAsyncapi,
+      parsedJSON: JSON.parse(invalidAsyncapi),
       validationErrors: [{
         title: '/channels/mychannel/publish/message/payload/additionalProperties should be object,boolean',
         location: {

--- a/test/asyncapiSchemaFormatParser_test.js
+++ b/test/asyncapiSchemaFormatParser_test.js
@@ -2,82 +2,81 @@ const parser = require('../lib');
 const chai = require('chai');
 const fs = require('fs');
 const path = require('path');
-const { offset } = require('./testsUtils'); 
+const { offset, checkErrorWrapper } = require('./testsUtils');
 
 const expect = chai.expect;
 
 describe('asyncapiSchemaFormatParser', function() {
   it('should throw an error because of invalid schema', async function() {
     const invalidAsyncapi = fs.readFileSync(path.resolve(__dirname, './wrong/invalid-payload-asyncapi-format.json'), 'utf8');
-    try {
-      await parser.parse(invalidAsyncapi);
-    } catch (e) {
-      expect(e.type).to.equal('https://github.com/asyncapi/parser-js/schema-validation-errors');
-      expect(e.title).to.equal('This is not a valid AsyncAPI Schema Object.');
-      expect(e.parsedJSON).to.deep.equal(JSON.parse(invalidAsyncapi));
-      expect(e.validationErrors).to.deep.equal([
-        {
-          title: '/channels/mychannel/publish/message/payload/additionalProperties should be object,boolean',
-          location: {
-            jsonPointer: '/channels/mychannel/publish/message/payload/additionalProperties',
-            startLine: 13,
-            startColumn: 38,
-            startOffset: offset(252, 13),
-            endLine: 15,
-            endColumn: 15,
-            endOffset: offset(297, 15)
-          }
-        },
-        {
-          title: '/channels/mychannel/publish/message/payload/additionalProperties should be object,boolean',
-          location: {
-            jsonPointer: '/channels/mychannel/publish/message/payload/additionalProperties',
-            startLine: 13,
-            startColumn: 38,
-            startOffset: offset(252, 13),
-            endLine: 15,
-            endColumn: 15,
-            endOffset: offset(297, 15)
-          }
-        },
-        {
-          title: '/channels/mychannel/publish/message/payload/additionalProperties should be object',
-          location: {
-            jsonPointer: '/channels/mychannel/publish/message/payload/additionalProperties',
-            startLine: 13,
-            startColumn: 38,
-            startOffset: offset(252, 13),
-            endLine: 15,
-            endColumn: 15,
-            endOffset: offset(297, 15)
-          }
-        },
-        {
-          title: '/channels/mychannel/publish/message/payload/additionalProperties should be boolean',
-          location: {
-            jsonPointer: '/channels/mychannel/publish/message/payload/additionalProperties',
-            startLine: 13,
-            startColumn: 38,
-            startOffset: offset(252, 13),
-            endLine: 15,
-            endColumn: 15,
-            endOffset: offset(297, 15)
-          }
-        },
-        {
-          title: '/channels/mychannel/publish/message/payload/additionalProperties should match some schema in anyOf',
-          location: {
-            jsonPointer: '/channels/mychannel/publish/message/payload/additionalProperties',
-            startLine: 13,
-            startColumn: 38,
-            startOffset: offset(252, 13),
-            endLine: 15,
-            endColumn: 15,
-            endOffset: offset(297, 15)
-          }
+    const expectedErrorObject = {
+      type: 'https://github.com/asyncapi/parser-js/schema-validation-errors',
+      title: 'This is not a valid AsyncAPI Schema Object.',
+      parsedJSON: invalidAsyncapi,
+      validationErrors: [{
+        title: '/channels/mychannel/publish/message/payload/additionalProperties should be object,boolean',
+        location: {
+          jsonPointer: '/channels/mychannel/publish/message/payload/additionalProperties',
+          startLine: 13,
+          startColumn: 38,
+          startOffset: offset(252, 13),
+          endLine: 15,
+          endColumn: 15,
+          endOffset: offset(297, 15)
         }
-      ]);
-    }
+      },
+      {
+        title: '/channels/mychannel/publish/message/payload/additionalProperties should be object,boolean',
+        location: {
+          jsonPointer: '/channels/mychannel/publish/message/payload/additionalProperties',
+          startLine: 13,
+          startColumn: 38,
+          startOffset: offset(252, 13),
+          endLine: 15,
+          endColumn: 15,
+          endOffset: offset(297, 15)
+        }
+      },
+      {
+        title: '/channels/mychannel/publish/message/payload/additionalProperties should be object',
+        location: {
+          jsonPointer: '/channels/mychannel/publish/message/payload/additionalProperties',
+          startLine: 13,
+          startColumn: 38,
+          startOffset: offset(252, 13),
+          endLine: 15,
+          endColumn: 15,
+          endOffset: offset(297, 15)
+        }
+      },
+      {
+        title: '/channels/mychannel/publish/message/payload/additionalProperties should be boolean',
+        location: {
+          jsonPointer: '/channels/mychannel/publish/message/payload/additionalProperties',
+          startLine: 13,
+          startColumn: 38,
+          startOffset: offset(252, 13),
+          endLine: 15,
+          endColumn: 15,
+          endOffset: offset(297, 15)
+        }
+      },
+      {
+        title: '/channels/mychannel/publish/message/payload/additionalProperties should match some schema in anyOf',
+        location: {
+          jsonPointer: '/channels/mychannel/publish/message/payload/additionalProperties',
+          startLine: 13,
+          startColumn: 38,
+          startOffset: offset(252, 13),
+          endLine: 15,
+          endColumn: 15,
+          endOffset: offset(297, 15)
+        }
+      }]
+    };
+    await checkErrorWrapper(async () => {
+      await parser.parse(invalidAsyncapi);
+    }, expectedErrorObject);
   });
   it('should not throw error if payload not provided', async function() {
     const inputString = `{

--- a/test/customValidators_test.js
+++ b/test/customValidators_test.js
@@ -50,7 +50,7 @@ describe('validateServerVariables()', function () {
     const expectedErrorObject = {
       type: 'https://github.com/asyncapi/parser-js/validation-errors',
       title: 'Not all server variables are described with variable object',
-      parsedJSON: JSON.stringify(parsedInput),
+      parsedJSON: parsedInput,
       validationErrors: [{
         title: 'dummy server does not have a corresponding variable object for: host',
         location: {
@@ -83,7 +83,7 @@ describe('validateServerVariables()', function () {
     const expectedErrorObject = {
       type: 'https://github.com/asyncapi/parser-js/validation-errors',
       title: 'Not all server variables are described with variable object',
-      parsedJSON: JSON.stringify(parsedInput),
+      parsedJSON: parsedInput,
       validationErrors: [{
         title: 'dummy server does not have a corresponding variable object for: host,port',
         location: {
@@ -121,7 +121,7 @@ describe('validateServerVariables()', function () {
     const expectedErrorObject = {
       type: 'https://github.com/asyncapi/parser-js/validation-errors',
       title: 'Not all server variables are described with variable object',
-      parsedJSON: JSON.stringify(parsedInput),
+      parsedJSON: parsedInput,
       validationErrors: [{
         title: 'dummy server does not have a corresponding variable object for: port',
         location: {
@@ -228,7 +228,7 @@ describe('validateChannel()', function () {
     const expectedErrorObject = {
       type: 'https://github.com/asyncapi/parser-js/validation-errors',
       title: 'Channel validation failed',
-      parsedJSON: JSON.stringify(parsedInput),
+      parsedJSON: parsedInput,
       validationErrors: [{
         title: 'test/{test}/{testid} channel does not have a corresponding parameter object for: testid',
         location: {
@@ -267,7 +267,7 @@ describe('validateChannel()', function () {
     const expectedErrorObject = {
       type: 'https://github.com/asyncapi/parser-js/validation-errors',
       title: 'Channel validation failed',
-      parsedJSON: JSON.stringify(parsedInput),
+      parsedJSON: parsedInput,
       validationErrors: [{
         title: 'test/{test} channel does not have a corresponding parameter object for: test',
         location: {
@@ -299,7 +299,7 @@ describe('validateChannel()', function () {
     const expectedErrorObject = {
       type: 'https://github.com/asyncapi/parser-js/validation-errors',
       title: 'Channel validation failed',
-      parsedJSON: JSON.stringify(parsedInput),
+      parsedJSON: parsedInput,
       validationErrors: [{
         title: 'test/{test}/{testid} channel does not have a corresponding parameter object for: test,testid',
         location: {
@@ -367,7 +367,7 @@ describe('validateChannel()', function () {
     const expectedErrorObject = {
       type: 'https://github.com/asyncapi/parser-js/validation-errors',
       title: 'Channel validation failed',
-      parsedJSON: JSON.stringify(parsedInput),
+      parsedJSON: parsedInput,
       validationErrors: [{
         title: '/user/signedup?foo=1 channel contains invalid name with url query parameters: ?foo=1',
         location: {
@@ -399,7 +399,7 @@ describe('validateChannel()', function () {
     const expectedErrorObject = {
       type: 'https://github.com/asyncapi/parser-js/validation-errors',
       title: 'Channel validation failed',
-      parsedJSON: JSON.stringify(parsedInput),
+      parsedJSON: parsedInput,
       validationErrors: [{
         title: '/?foo=1 channel contains invalid name with url query parameters: ?foo=1',
         location: {
@@ -431,7 +431,7 @@ describe('validateChannel()', function () {
     const expectedErrorObject = {
       type: 'https://github.com/asyncapi/parser-js/validation-errors',
       title: 'Channel validation failed',
-      parsedJSON: JSON.stringify(parsedInput),
+      parsedJSON: parsedInput,
       validationErrors: [{
         title: '/user/signedup?foo=1&bar=0 channel contains invalid name with url query parameters: ?foo=1&bar=0',
         location: {
@@ -465,7 +465,7 @@ describe('validateChannel()', function () {
     const expectedErrorObject = {
       type: 'https://github.com/asyncapi/parser-js/validation-errors',
       title: 'Channel validation failed',
-      parsedJSON: JSON.stringify(parsedInput),
+      parsedJSON: parsedInput,
       validationErrors: [{
         title: '/user/signedup?foo=1 channel contains invalid name with url query parameters: ?foo=1',
         location: {
@@ -499,7 +499,7 @@ describe('validateChannel()', function () {
     const expectedErrorObject = {
       type: 'https://github.com/asyncapi/parser-js/validation-errors',
       title: 'Channel validation failed',
-      parsedJSON: JSON.stringify(parsedInput),
+      parsedJSON: parsedInput,
       validationErrors: [{
         title: '/user/signedup?foo=1 channel contains invalid name with url query parameters: ?foo=1',
         location: {
@@ -543,7 +543,7 @@ describe('validateChannel()', function () {
     const expectedErrorObject = {
       type: 'https://github.com/asyncapi/parser-js/validation-errors',
       title: 'Channel validation failed',
-      parsedJSON: JSON.stringify(parsedInput),
+      parsedJSON: parsedInput,
       validationErrors: [{
         title: 'user/{userId}/signedup?foo=1 channel does not have a corresponding parameter object for: userId',
         location: {
@@ -589,7 +589,7 @@ describe('validateChannel()', function () {
     const expectedErrorObject = {
       type: 'https://github.com/asyncapi/parser-js/validation-errors',
       title: 'Channel validation failed',
-      parsedJSON: JSON.stringify(parsedInput),
+      parsedJSON: parsedInput,
       validationErrors: [{
         title: 'test/{test} channel does not have a corresponding parameter object for: test',
         location: {
@@ -689,7 +689,7 @@ describe('validateOperationId()', function () {
     const expectedErrorObject = {
       type: 'https://github.com/asyncapi/parser-js/validation-errors',
       title: 'operationId must be unique across all the operations.',
-      parsedJSON: JSON.stringify(parsedInput),
+      parsedJSON: parsedInput,
       validationErrors: [{
         title: 'test/2/subscribe/operationId is a duplicate of: test/1/publish/operationId',
         location: {
@@ -841,7 +841,7 @@ describe('validateServerSecurity()', function () {
     const expectedErrorObject = {
       type: 'https://github.com/asyncapi/parser-js/validation-errors',
       title: 'Server security name must correspond to a security scheme which is declared in the security schemes under the components object.',
-      parsedJSON: JSON.stringify(parsedInput),
+      parsedJSON: parsedInput,
       validationErrors: [{
         title: 'dummy/security/complex doesn\'t have a corresponding security schema under the components object',
         location: {
@@ -886,7 +886,7 @@ describe('validateServerSecurity()', function () {
     const expectedErrorObject = {
       type: 'https://github.com/asyncapi/parser-js/validation-errors',
       title: 'Server security name must correspond to a security scheme which is declared in the security schemes under the components object.',
-      parsedJSON: JSON.stringify(parsedInput),
+      parsedJSON: parsedInput,
       validationErrors: [{
         title: 'dummy/security/complex doesn\'t have a corresponding security schema under the components object',
         location: {
@@ -942,7 +942,7 @@ describe('validateServerSecurity()', function () {
     const expectedErrorObject = {
       type: 'https://github.com/asyncapi/parser-js/validation-errors',
       title: 'Server security value must be an empty array if corresponding security schema type is not oauth2 or openIdConnect.',
-      parsedJSON: JSON.stringify(parsedInput),
+      parsedJSON: parsedInput,
       validationErrors: [{
         title: 'dummy/security/basic security info must have an empty array because its corresponding security schema type is: userPassword',
         location: {

--- a/test/customValidators_test.js
+++ b/test/customValidators_test.js
@@ -1,5 +1,6 @@
 const { validateServerVariables, validateOperationId, validateServerSecurity, validateChannels } = require('../lib/customValidators.js');
 const chai = require('chai');
+const { checkErrorWrapper } = require('./testsUtils');
 
 const expect = chai.expect;
 const input = 'json';
@@ -46,27 +47,27 @@ describe('validateServerVariables()', function () {
     }`;
     const parsedInput = JSON.parse(inputString);
 
-    try {
-      validateServerVariables(parsedInput, inputString, input);
-    } catch (e) {
-      expect(e.type).to.equal('https://github.com/asyncapi/parser-js/validation-errors');
-      expect(e.title).to.equal('Not all server variables are described with variable object');
-      expect(e.parsedJSON).to.deep.equal(parsedInput);
-      expect(e.validationErrors).to.deep.equal([
-        {
-          title: 'dummy server does not have a corresponding variable object for: host',
-          location: {
-            jsonPointer: '/servers/dummy',
-            startLine: 3,
-            startColumn: 19,
-            startOffset: 39,
-            endLine: 10,
-            endColumn: 11,
-            endOffset: 196,
-          }
+    const expectedErrorObject = {
+      type: 'https://github.com/asyncapi/parser-js/validation-errors',
+      title: 'Not all server variables are described with variable object',
+      parsedJSON: JSON.stringify(parsedInput),
+      validationErrors: [{
+        title: 'dummy server does not have a corresponding variable object for: host',
+        location: {
+          jsonPointer: '/servers/dummy',
+          startLine: 3,
+          startColumn: 19,
+          startOffset: 39,
+          endLine: 10,
+          endColumn: 11,
+          endOffset: 196,
         }
-      ]);
-    }
+      }]
+    };
+
+    await checkErrorWrapper(async () => {
+      await validateServerVariables(parsedInput, inputString, input);
+    }, expectedErrorObject);
   });
 
   it('should throw error that variables are not provided if there is no variables object', async function () {
@@ -79,27 +80,27 @@ describe('validateServerVariables()', function () {
     }`;
     const parsedInput = JSON.parse(inputString);
 
-    try {
-      validateServerVariables(parsedInput, inputString, input);
-    } catch (e) {
-      expect(e.type).to.equal('https://github.com/asyncapi/parser-js/validation-errors');
-      expect(e.title).to.equal('Not all server variables are described with variable object');
-      expect(e.parsedJSON).to.deep.equal(parsedInput);
-      expect(e.validationErrors).to.deep.equal([
-        {
-          title: 'dummy server does not have a corresponding variable object for: host,port',
-          location: {
-            jsonPointer: '/servers/dummy',
-            startLine: 3,
-            startColumn: 19,
-            startOffset: 39,
-            endLine: 5,
-            endColumn: 11,
-            endOffset: 89,
-          }
+    const expectedErrorObject = {
+      type: 'https://github.com/asyncapi/parser-js/validation-errors',
+      title: 'Not all server variables are described with variable object',
+      parsedJSON: JSON.stringify(parsedInput),
+      validationErrors: [{
+        title: 'dummy server does not have a corresponding variable object for: host,port',
+        location: {
+          jsonPointer: '/servers/dummy',
+          startLine: 3,
+          startColumn: 19,
+          startOffset: 39,
+          endLine: 5,
+          endColumn: 11,
+          endOffset: 89,
         }
-      ]);
-    }
+      }]
+    };
+
+    await checkErrorWrapper(async () => {
+      await validateServerVariables(parsedInput, inputString, input);
+    }, expectedErrorObject);
   });
 
   it('should throw error that variables are not provided even if they are but not matching the name', async function () {
@@ -117,27 +118,27 @@ describe('validateServerVariables()', function () {
     }`;
     const parsedInput = JSON.parse(inputString);
 
-    try {
-      validateServerVariables(parsedInput, inputString, input);
-    } catch (e) {
-      expect(e.type).to.equal('https://github.com/asyncapi/parser-js/validation-errors');
-      expect(e.title).to.equal('Not all server variables are described with variable object');
-      expect(e.parsedJSON).to.deep.equal(parsedInput);
-      expect(e.validationErrors).to.deep.equal([
-        {
-          title: 'dummy server does not have a corresponding variable object for: port',
-          location: {
-            jsonPointer: '/servers/dummy',
-            startLine: 3,
-            startColumn: 19,
-            startOffset: 39,
-            endLine: 10,
-            endColumn: 11,
-            endOffset: 200,
-          }
+    const expectedErrorObject = {
+      type: 'https://github.com/asyncapi/parser-js/validation-errors',
+      title: 'Not all server variables are described with variable object',
+      parsedJSON: JSON.stringify(parsedInput),
+      validationErrors: [{
+        title: 'dummy server does not have a corresponding variable object for: port',
+        location: {
+          jsonPointer: '/servers/dummy',
+          startLine: 3,
+          startColumn: 19,
+          startOffset: 39,
+          endLine: 10,
+          endColumn: 11,
+          endOffset: 200,
         }
-      ]);
-    }
+      }]
+    };
+
+    await checkErrorWrapper(async () => {
+      await validateServerVariables(parsedInput, inputString, input);
+    }, expectedErrorObject);
   });
 
   it('should throw error', async function () {
@@ -224,27 +225,27 @@ describe('validateChannel()', function () {
     }`;
     const parsedInput = JSON.parse(inputString);
 
-    try {
-      validateChannels(parsedInput, inputString, input);
-    } catch (e) {
-      expect(e.type).to.equal('https://github.com/asyncapi/parser-js/validation-errors');
-      expect(e.title).to.equal('Channel validation failed');
-      expect(e.parsedJSON).to.deep.equal(parsedInput);
-      expect(e.validationErrors).to.deep.equal([
-        {
-          title: 'test/{test}/{testid} channel does not have a corresponding parameter object for: testid',
-          location: {
-            jsonPointer: '/channels/test~1{test}~1{testid}',
-            startLine: 3,
-            startColumn: 34,
-            startOffset: 54,
-            endLine: 11,
-            endColumn: 11,
-            endOffset: 214
-          }
+    const expectedErrorObject = {
+      type: 'https://github.com/asyncapi/parser-js/validation-errors',
+      title: 'Channel validation failed',
+      parsedJSON: JSON.stringify(parsedInput),
+      validationErrors: [{
+        title: 'test/{test}/{testid} channel does not have a corresponding parameter object for: testid',
+        location: {
+          jsonPointer: '/channels/test~1{test}~1{testid}',
+          startLine: 3,
+          startColumn: 34,
+          startOffset: 54,
+          endLine: 11,
+          endColumn: 11,
+          endOffset: 214
         }
-      ]);
-    }
+      }]
+    };
+
+    await checkErrorWrapper(async () => {
+      await validateChannels(parsedInput, inputString, input);
+    }, expectedErrorObject);
   });
 
   it('should throw error that one of provided channel params is not declared even if other not provided params have a corresponding parameter object', async function () {
@@ -263,27 +264,27 @@ describe('validateChannel()', function () {
     }`;
     const parsedInput = JSON.parse(inputString);
 
-    try {
-      validateChannels(parsedInput, inputString, input);
-    } catch (e) {
-      expect(e.type).to.equal('https://github.com/asyncapi/parser-js/validation-errors');
-      expect(e.title).to.equal('Channel validation failed');
-      expect(e.parsedJSON).to.deep.equal(parsedInput);
-      expect(e.validationErrors).to.deep.equal([
-        {
-          title: 'test/{test} channel does not have a corresponding parameter object for: test',
-          location: {
-            jsonPointer: '/channels/test~1{test}',
-            startLine: 3,
-            startColumn: 25,
-            startOffset: 45,
-            endLine: 11,
-            endColumn: 11,
-            endOffset: 206
-          }
+    const expectedErrorObject = {
+      type: 'https://github.com/asyncapi/parser-js/validation-errors',
+      title: 'Channel validation failed',
+      parsedJSON: JSON.stringify(parsedInput),
+      validationErrors: [{
+        title: 'test/{test} channel does not have a corresponding parameter object for: test',
+        location: {
+          jsonPointer: '/channels/test~1{test}',
+          startLine: 3,
+          startColumn: 25,
+          startOffset: 45,
+          endLine: 11,
+          endColumn: 11,
+          endOffset: 206
         }
-      ]);
-    }
+      }]
+    };
+
+    await checkErrorWrapper(async () => {
+      await validateChannels(parsedInput, inputString, input);
+    }, expectedErrorObject);
   });
 
   it('should throw error when there are no parameter objects', async function () {
@@ -295,27 +296,27 @@ describe('validateChannel()', function () {
     }`;
     const parsedInput = JSON.parse(inputString);
 
-    try {
-      validateChannels(parsedInput, inputString, input);
-    } catch (e) {
-      expect(e.type).to.equal('https://github.com/asyncapi/parser-js/validation-errors');
-      expect(e.title).to.equal('Channel validation failed');
-      expect(e.parsedJSON).to.deep.equal(parsedInput);
-      expect(e.validationErrors).to.deep.equal([
-        {
-          title: 'test/{test}/{testid} channel does not have a corresponding parameter object for: test,testid',
-          location: {
-            jsonPointer: '/channels/test~1{test}~1{testid}',
-            startLine: 3,
-            startColumn: 34,
-            startOffset: 54,
-            endLine: 4,
-            endColumn: 11,
-            endOffset: 65
-          }
+    const expectedErrorObject = {
+      type: 'https://github.com/asyncapi/parser-js/validation-errors',
+      title: 'Channel validation failed',
+      parsedJSON: JSON.stringify(parsedInput),
+      validationErrors: [{
+        title: 'test/{test}/{testid} channel does not have a corresponding parameter object for: test,testid',
+        location: {
+          jsonPointer: '/channels/test~1{test}~1{testid}',
+          startLine: 3,
+          startColumn: 34,
+          startOffset: 54,
+          endLine: 4,
+          endColumn: 11,
+          endOffset: 65
         }
-      ]);
-    }
+      }]
+    };
+
+    await checkErrorWrapper(async () => {
+      await validateChannels(parsedInput, inputString, input);
+    }, expectedErrorObject);
   });
 
   it('should throw error', async function () {
@@ -363,27 +364,27 @@ describe('validateChannel()', function () {
     }`;
     const parsedInput = JSON.parse(inputString);
 
-    try {
-      validateChannels(parsedInput, inputString, input);
-    } catch (e) {
-      expect(e.type).to.equal('https://github.com/asyncapi/parser-js/validation-errors');
-      expect(e.title).to.equal('Channel validation failed');
-      expect(e.parsedJSON).to.deep.equal(parsedInput);
-      expect(e.validationErrors).to.deep.equal([
-        {
-          title: '/user/signedup?foo=1 channel contains invalid name with url query parameters: ?foo=1',
-          location: {
-            endColumn: 11,
-            endLine: 4,
-            endOffset: 65,
-            jsonPointer: '/channels/~1user~1signedup?foo=1',
-            startColumn: 34,
-            startLine: 3,
-            startOffset: 54
-          }
+    const expectedErrorObject = {
+      type: 'https://github.com/asyncapi/parser-js/validation-errors',
+      title: 'Channel validation failed',
+      parsedJSON: JSON.stringify(parsedInput),
+      validationErrors: [{
+        title: '/user/signedup?foo=1 channel contains invalid name with url query parameters: ?foo=1',
+        location: {
+          endColumn: 11,
+          endLine: 4,
+          endOffset: 65,
+          jsonPointer: '/channels/~1user~1signedup?foo=1',
+          startColumn: 34,
+          startLine: 3,
+          startOffset: 54
         }
-      ]);
-    }
+      }]
+    };
+
+    await checkErrorWrapper(async () => {
+      await validateChannels(parsedInput, inputString, input);
+    }, expectedErrorObject);
   });
 
   it('should throw error that the provided channel name is invalid when channel name is just a single slash (/)', async function () {
@@ -395,27 +396,27 @@ describe('validateChannel()', function () {
     }`;
     const parsedInput = JSON.parse(inputString);
 
-    try {
-      validateChannels(parsedInput, inputString, input);
-    } catch (e) {
-      expect(e.type).to.equal('https://github.com/asyncapi/parser-js/validation-errors');
-      expect(e.title).to.equal('Channel validation failed');
-      expect(e.parsedJSON).to.deep.equal(parsedInput);
-      expect(e.validationErrors).to.deep.equal([
-        {
-          title: '/?foo=1 channel contains invalid name with url query parameters: ?foo=1',
-          location: {
-            endColumn: 11,
-            endLine: 4,
-            endOffset: 52,
-            jsonPointer: '/channels/~1?foo=1',
-            startColumn: 21,
-            startLine: 3,
-            startOffset: 41
-          }
+    const expectedErrorObject = {
+      type: 'https://github.com/asyncapi/parser-js/validation-errors',
+      title: 'Channel validation failed',
+      parsedJSON: JSON.stringify(parsedInput),
+      validationErrors: [{
+        title: '/?foo=1 channel contains invalid name with url query parameters: ?foo=1',
+        location: {
+          endColumn: 11,
+          endLine: 4,
+          endOffset: 52,
+          jsonPointer: '/channels/~1?foo=1',
+          startColumn: 21,
+          startLine: 3,
+          startOffset: 41
         }
-      ]);
-    }
+      }]
+    };
+
+    await checkErrorWrapper(async () => {
+      await validateChannels(parsedInput, inputString, input);
+    }, expectedErrorObject);
   });
 
   it('should throw error that channel has invalid name with two query params', async function () {
@@ -427,27 +428,27 @@ describe('validateChannel()', function () {
   }`;
     const parsedInput = JSON.parse(inputString);
 
-    try {
-      validateChannels(parsedInput, inputString, input);
-    } catch (e) {
-      expect(e.type).to.equal('https://github.com/asyncapi/parser-js/validation-errors');
-      expect(e.title).to.equal('Channel validation failed');
-      expect(e.parsedJSON).to.deep.equal(parsedInput);
-      expect(e.validationErrors).to.deep.equal([
-        {
-          title: '/user/signedup?foo=1&bar=0 channel contains invalid name with url query parameters: ?foo=1&bar=0',
-          location: {
-            endColumn: 9,
-            endLine: 4,
-            endOffset: 65,
-            jsonPointer: '/channels/~1user~1signedup?foo=1&bar=0',
-            startColumn: 38,
-            startLine: 3,
-            startOffset: 56
-          }
+    const expectedErrorObject = {
+      type: 'https://github.com/asyncapi/parser-js/validation-errors',
+      title: 'Channel validation failed',
+      parsedJSON: JSON.stringify(parsedInput),
+      validationErrors: [{
+        title: '/user/signedup?foo=1&bar=0 channel contains invalid name with url query parameters: ?foo=1&bar=0',
+        location: {
+          endColumn: 9,
+          endLine: 4,
+          endOffset: 65,
+          jsonPointer: '/channels/~1user~1signedup?foo=1&bar=0',
+          startColumn: 38,
+          startLine: 3,
+          startOffset: 56
         }
-      ]);
-    }
+      }]
+    };
+
+    await checkErrorWrapper(async () => {
+      await validateChannels(parsedInput, inputString, input);
+    }, expectedErrorObject);
   });
 
   it('should throw error that one of the provided channel name is invalid', async function () {
@@ -461,27 +462,27 @@ describe('validateChannel()', function () {
   }`;
     const parsedInput = JSON.parse(inputString);
 
-    try {
-      validateChannels(parsedInput, inputString, input);
-    } catch (e) {
-      expect(e.type).to.equal('https://github.com/asyncapi/parser-js/validation-errors');
-      expect(e.title).to.equal('Channel validation failed');
-      expect(e.parsedJSON).to.deep.equal(parsedInput);
-      expect(e.validationErrors).to.deep.equal([
-        {
-          title: '/user/signedup?foo=1 channel contains invalid name with url query parameters: ?foo=1',
-          location: {
-            endColumn: 9,
-            endLine: 4,
-            endOffset: 59,
-            jsonPointer: '/channels/~1user~1signedup?foo=1',
-            startColumn: 32,
-            startLine: 3,
-            startOffset: 50
-          }
+    const expectedErrorObject = {
+      type: 'https://github.com/asyncapi/parser-js/validation-errors',
+      title: 'Channel validation failed',
+      parsedJSON: JSON.stringify(parsedInput),
+      validationErrors: [{
+        title: '/user/signedup?foo=1 channel contains invalid name with url query parameters: ?foo=1',
+        location: {
+          endColumn: 9,
+          endLine: 4,
+          endOffset: 59,
+          jsonPointer: '/channels/~1user~1signedup?foo=1',
+          startColumn: 32,
+          startLine: 3,
+          startOffset: 50
         }
-      ]);
-    }
+      }]
+    };
+
+    await checkErrorWrapper(async () => {
+      await validateChannels(parsedInput, inputString, input);
+    }, expectedErrorObject);
   });
 
   it('should throw error that both provided channel name is invalid', async function () {
@@ -495,39 +496,39 @@ describe('validateChannel()', function () {
   }`;
     const parsedInput = JSON.parse(inputString);
 
-    try {
-      validateChannels(parsedInput, inputString, input);
-    } catch (e) {
-      expect(e.type).to.equal('https://github.com/asyncapi/parser-js/validation-errors');
-      expect(e.title).to.equal('Channel validation failed');
-      expect(e.parsedJSON).to.deep.equal(parsedInput);
-      expect(e.validationErrors).to.deep.equal([
-        {
-          title: '/user/signedup?foo=1 channel contains invalid name with url query parameters: ?foo=1',
-          location: {
-            endColumn: 9,
-            endLine: 4,
-            endOffset: 59,
-            jsonPointer: '/channels/~1user~1signedup?foo=1',
-            startColumn: 32,
-            startLine: 3,
-            startOffset: 50
-          }
-        },
-        {
-          title: '/user/login?bar=2 channel contains invalid name with url query parameters: ?bar=2',
-          location: {
-            endColumn: 9,
-            endLine: 6,
-            endOffset: 96,
-            jsonPointer: '/channels/~1user~1login?bar=2',
-            startColumn: 28,
-            startLine: 5,
-            startOffset: 87
-          }
+    const expectedErrorObject = {
+      type: 'https://github.com/asyncapi/parser-js/validation-errors',
+      title: 'Channel validation failed',
+      parsedJSON: JSON.stringify(parsedInput),
+      validationErrors: [{
+        title: '/user/signedup?foo=1 channel contains invalid name with url query parameters: ?foo=1',
+        location: {
+          endColumn: 9,
+          endLine: 4,
+          endOffset: 59,
+          jsonPointer: '/channels/~1user~1signedup?foo=1',
+          startColumn: 32,
+          startLine: 3,
+          startOffset: 50
         }
-      ]);
-    }
+      },
+      {
+        title: '/user/login?bar=2 channel contains invalid name with url query parameters: ?bar=2',
+        location: {
+          endColumn: 9,
+          endLine: 6,
+          endOffset: 96,
+          jsonPointer: '/channels/~1user~1login?bar=2',
+          startColumn: 28,
+          startLine: 5,
+          startOffset: 87
+        }
+      }]
+    };
+
+    await checkErrorWrapper(async () => {
+      await validateChannels(parsedInput, inputString, input);
+    }, expectedErrorObject);
   });
 
   it('should throw error that single channel definition failed both validations', async function () {
@@ -539,39 +540,39 @@ describe('validateChannel()', function () {
   }`;
     const parsedInput = JSON.parse(inputString);
 
-    try {
-      validateChannels(parsedInput, inputString, input);
-    } catch (e) {
-      expect(e.type).to.equal('https://github.com/asyncapi/parser-js/validation-errors');
-      expect(e.title).to.equal('Channel validation failed');
-      expect(e.parsedJSON).to.deep.equal(parsedInput);
-      expect(e.validationErrors).to.deep.equal([
-        {
-          title: 'user/{userId}/signedup?foo=1 channel does not have a corresponding parameter object for: userId',
-          location: {
-            endColumn: 9,
-            endLine: 4,
-            endOffset: 67,
-            jsonPointer: '/channels/user~1{userId}~1signedup?foo=1',
-            startColumn: 40,
-            startLine: 3,
-            startOffset: 58
-          }
-        },
-        {
-          title: 'user/{userId}/signedup?foo=1 channel contains invalid name with url query parameters: ?foo=1',
-          location: {
-            endColumn: 9,
-            endLine: 4,
-            endOffset: 67,
-            jsonPointer: '/channels/user~1{userId}~1signedup?foo=1',
-            startColumn: 40,
-            startLine: 3,
-            startOffset: 58
-          }
+    const expectedErrorObject = {
+      type: 'https://github.com/asyncapi/parser-js/validation-errors',
+      title: 'Channel validation failed',
+      parsedJSON: JSON.stringify(parsedInput),
+      validationErrors: [{
+        title: 'user/{userId}/signedup?foo=1 channel does not have a corresponding parameter object for: userId',
+        location: {
+          endColumn: 9,
+          endLine: 4,
+          endOffset: 67,
+          jsonPointer: '/channels/user~1{userId}~1signedup?foo=1',
+          startColumn: 40,
+          startLine: 3,
+          startOffset: 58
         }
-      ]);
-    }
+      },
+      {
+        title: 'user/{userId}/signedup?foo=1 channel contains invalid name with url query parameters: ?foo=1',
+        location: {
+          endColumn: 9,
+          endLine: 4,
+          endOffset: 67,
+          jsonPointer: '/channels/user~1{userId}~1signedup?foo=1',
+          startColumn: 40,
+          startLine: 3,
+          startOffset: 58
+        }
+      }]
+    };
+
+    await checkErrorWrapper(async () => {
+      await validateChannels(parsedInput, inputString, input);
+    }, expectedErrorObject);
   });
 
   it('should throw error that both provided channels contain errors', async function () {
@@ -585,39 +586,39 @@ describe('validateChannel()', function () {
   }`;
     const parsedInput = JSON.parse(inputString);
 
-    try {
-      validateChannels(parsedInput, inputString, input);
-    } catch (e) {
-      expect(e.type).to.equal('https://github.com/asyncapi/parser-js/validation-errors');
-      expect(e.title).to.equal('Channel validation failed');
-      expect(e.parsedJSON).to.deep.equal(parsedInput);
-      expect(e.validationErrors).to.deep.equal([
-        {
-          title: 'test/{test} channel does not have a corresponding parameter object for: test',
-          location: {
-            endColumn: 9,
-            endLine: 6,
-            endOffset: 90,
-            jsonPointer: '/channels/test~1{test}',
-            startColumn: 22,
-            startLine: 5,
-            startOffset: 81
-          }
-        },
-        {
-          title: '/user/signedup?foo=1 channel contains invalid name with url query parameters: ?foo=1',
-          location: {
-            endColumn: 9,
-            endLine: 4,
-            endOffset: 59,
-            jsonPointer: '/channels/~1user~1signedup?foo=1',
-            startColumn: 32,
-            startLine: 3,
-            startOffset: 50
-          }
+    const expectedErrorObject = {
+      type: 'https://github.com/asyncapi/parser-js/validation-errors',
+      title: 'Channel validation failed',
+      parsedJSON: JSON.stringify(parsedInput),
+      validationErrors: [{
+        title: 'test/{test} channel does not have a corresponding parameter object for: test',
+        location: {
+          endColumn: 9,
+          endLine: 6,
+          endOffset: 90,
+          jsonPointer: '/channels/test~1{test}',
+          startColumn: 22,
+          startLine: 5,
+          startOffset: 81
         }
-      ]);
-    }
+      },
+      {
+        title: '/user/signedup?foo=1 channel contains invalid name with url query parameters: ?foo=1',
+        location: {
+          endColumn: 9,
+          endLine: 4,
+          endOffset: 59,
+          jsonPointer: '/channels/~1user~1signedup?foo=1',
+          startColumn: 32,
+          startLine: 3,
+          startOffset: 50
+        }
+      }]
+    };
+
+    await checkErrorWrapper(async () => {
+      await validateChannels(parsedInput, inputString, input);
+    }, expectedErrorObject);
   });
 });
 describe('validateOperationId()', function () {
@@ -654,7 +655,7 @@ describe('validateOperationId()', function () {
     expect(validateOperationId(parsedInput, inputString, input, operations)).to.equal(true);
   });
 
-  it('should throw error that operationIds are duplicated and that they duplicate', function () {
+  it('should throw error that operationIds are duplicated and that they duplicate', async function () {
     const inputString = `{
       "asyncapi": "2.0.0",
       "info": {
@@ -685,39 +686,39 @@ describe('validateOperationId()', function () {
     }`;
     const parsedInput = JSON.parse(inputString);
 
-    try {
-      validateOperationId(parsedInput, inputString, input, operations);
-    } catch (e) {
-      expect(e.type).to.equal('https://github.com/asyncapi/parser-js/validation-errors');
-      expect(e.title).to.equal('operationId must be unique across all the operations.');
-      expect(e.parsedJSON).to.deep.equal(parsedInput);
-      expect(e.validationErrors).to.deep.equal([
-        {
-          title: 'test/2/subscribe/operationId is a duplicate of: test/1/publish/operationId',
-          location: {
-            jsonPointer: '/channels/test~12/subscribe/operationId',
-            startLine: 14,
-            startColumn: 29,
-            startOffset: 273,
-            endLine: 14,
-            endColumn: 35,
-            endOffset: 279
-          }
-        },
-        {
-          title: 'test/3/subscribe/operationId is a duplicate of: test/1/publish/operationId',
-          location: {
-            jsonPointer: '/channels/test~13/subscribe/operationId',
-            startLine: 19,
-            startColumn: 29,
-            startOffset: 375,
-            endLine: 19,
-            endColumn: 35,
-            endOffset: 381
-          }
+    const expectedErrorObject = {
+      type: 'https://github.com/asyncapi/parser-js/validation-errors',
+      title: 'operationId must be unique across all the operations.',
+      parsedJSON: JSON.stringify(parsedInput),
+      validationErrors: [{
+        title: 'test/2/subscribe/operationId is a duplicate of: test/1/publish/operationId',
+        location: {
+          jsonPointer: '/channels/test~12/subscribe/operationId',
+          startLine: 14,
+          startColumn: 29,
+          startOffset: 273,
+          endLine: 14,
+          endColumn: 35,
+          endOffset: 279
         }
-      ]);
-    }
+      },
+      {
+        title: 'test/3/subscribe/operationId is a duplicate of: test/1/publish/operationId',
+        location: {
+          jsonPointer: '/channels/test~13/subscribe/operationId',
+          startLine: 19,
+          startColumn: 29,
+          startOffset: 375,
+          endLine: 19,
+          endColumn: 35,
+          endOffset: 381
+        }
+      }]
+    };
+
+    await checkErrorWrapper(async () => {
+      await validateOperationId(parsedInput, inputString, input, operations);
+    }, expectedErrorObject);
   });
 });
 
@@ -837,27 +838,27 @@ describe('validateServerSecurity()', function () {
     }`;
     const parsedInput = JSON.parse(inputString);
 
-    try {
-      validateServerSecurity(parsedInput, inputString, input, specialSecTypes);
-    } catch (e) {
-      expect(e.type).to.equal('https://github.com/asyncapi/parser-js/validation-errors');
-      expect(e.title).to.equal('Server security name must correspond to a security scheme which is declared in the security schemes under the components object.');
-      expect(e.parsedJSON).to.deep.equal(parsedInput);
-      expect(e.validationErrors).to.deep.equal([
-        {
-          title: 'dummy/security/complex doesn\'t have a corresponding security schema under the components object',
-          location: {
-            jsonPointer: '/servers/dummy/security/complex',
-            startLine: 12,
-            startColumn: 27,
-            startOffset: 250,
-            endLine: 12,
-            endColumn: 29,
-            endOffset: 252
-          }
+    const expectedErrorObject = {
+      type: 'https://github.com/asyncapi/parser-js/validation-errors',
+      title: 'Server security name must correspond to a security scheme which is declared in the security schemes under the components object.',
+      parsedJSON: JSON.stringify(parsedInput),
+      validationErrors: [{
+        title: 'dummy/security/complex doesn\'t have a corresponding security schema under the components object',
+        location: {
+          jsonPointer: '/servers/dummy/security/complex',
+          startLine: 12,
+          startColumn: 27,
+          startOffset: 250,
+          endLine: 12,
+          endColumn: 29,
+          endOffset: 252
         }
-      ]);
-    }
+      }]
+    };
+
+    await checkErrorWrapper(async () => {
+      await validateServerSecurity(parsedInput, inputString, input, specialSecTypes);
+    }, expectedErrorObject);
   });
 
   it('should throw error that server has no security schema provided when components schema object is not in the document', async function () {
@@ -882,27 +883,27 @@ describe('validateServerSecurity()', function () {
     }`;
     const parsedInput = JSON.parse(inputString);
 
-    try {
-      validateServerSecurity(parsedInput, inputString, input, specialSecTypes);
-    } catch (e) {
-      expect(e.type).to.equal('https://github.com/asyncapi/parser-js/validation-errors');
-      expect(e.title).to.equal('Server security name must correspond to a security scheme which is declared in the security schemes under the components object.');
-      expect(e.parsedJSON).to.deep.equal(parsedInput);
-      expect(e.validationErrors).to.deep.equal([
-        {
-          title: 'dummy/security/complex doesn\'t have a corresponding security schema under the components object',
-          location: {
-            jsonPointer: '/servers/dummy/security/complex',
-            startLine: 12,
-            startColumn: 27,
-            startOffset: 250,
-            endLine: 12,
-            endColumn: 29,
-            endOffset: 252
-          }
+    const expectedErrorObject = {
+      type: 'https://github.com/asyncapi/parser-js/validation-errors',
+      title: 'Server security name must correspond to a security scheme which is declared in the security schemes under the components object.',
+      parsedJSON: JSON.stringify(parsedInput),
+      validationErrors: [{
+        title: 'dummy/security/complex doesn\'t have a corresponding security schema under the components object',
+        location: {
+          jsonPointer: '/servers/dummy/security/complex',
+          startLine: 12,
+          startColumn: 27,
+          startOffset: 250,
+          endLine: 12,
+          endColumn: 29,
+          endOffset: 252
         }
-      ]);
-    }
+      }]
+    };
+
+    await checkErrorWrapper(async () => {
+      await validateServerSecurity(parsedInput, inputString, input, specialSecTypes);
+    }, expectedErrorObject);
   });
 
   it('should throw error that server security is not declared as empty array', async function () {
@@ -938,39 +939,38 @@ describe('validateServerSecurity()', function () {
     }`;
     const parsedInput = JSON.parse(inputString);
 
-    try {
-      validateServerSecurity(parsedInput, inputString, input, specialSecTypes);
-    } catch (e) {
-      expect(e.type).to.equal('https://github.com/asyncapi/parser-js/validation-errors');
-      expect(e.title).to.equal('Server security value must be an empty array if corresponding security schema type is not oauth2 or openIdConnect.');
-      expect(e.parsedJSON).to.deep.equal(parsedInput);
-      expect(e.validationErrors).to.deep.equal([
-        {
-          title: 'dummy/security/basic security info must have an empty array because its corresponding security schema type is: userPassword',
-          location: {
-            jsonPointer: '/servers/dummy/security/basic',
-            startLine: 12,
-            startColumn: 25,
-            startOffset: 248,
-            endLine: 12,
-            endColumn: 45,
-            endOffset: 268
-          }
-        },
-        {
-          title: 'dummy/security/apikey security info must have an empty array because its corresponding security schema type is: httpApiKey',
-          location: {
-            jsonPointer: '/servers/dummy/security/apikey',
-            startLine: 15,
-            startColumn: 26,
-            startOffset: 322,
-            endLine: 15,
-            endColumn: 36,
-            endOffset: 332
-          }
+    const expectedErrorObject = {
+      type: 'https://github.com/asyncapi/parser-js/validation-errors',
+      title: 'Server security value must be an empty array if corresponding security schema type is not oauth2 or openIdConnect.',
+      parsedJSON: JSON.stringify(parsedInput),
+      validationErrors: [{
+        title: 'dummy/security/basic security info must have an empty array because its corresponding security schema type is: userPassword',
+        location: {
+          jsonPointer: '/servers/dummy/security/basic',
+          startLine: 12,
+          startColumn: 25,
+          startOffset: 248,
+          endLine: 12,
+          endColumn: 45,
+          endOffset: 268
         }
-      ]);
-    }
+      },
+      {
+        title: 'dummy/security/apikey security info must have an empty array because its corresponding security schema type is: httpApiKey',
+        location: {
+          jsonPointer: '/servers/dummy/security/apikey',
+          startLine: 15,
+          startColumn: 26,
+          startOffset: 322,
+          endLine: 15,
+          endColumn: 36,
+          endOffset: 332
+        }
+      }]
+    };
+
+    await checkErrorWrapper(async () => {
+      await validateServerSecurity(parsedInput, inputString, input, specialSecTypes);
+    }, expectedErrorObject);
   });
-}
-);
+});

--- a/test/parse_test.js
+++ b/test/parse_test.js
@@ -3,8 +3,7 @@ const chaiAsPromised = require('chai-as-promised');
 const fs = require('fs');
 const path = require('path');
 const parser = require('../lib');
-const ParserError = require('../lib/errors/parser-error');
-const { offset } = require('./testsUtils'); 
+const { offset, checkErrorWrapper } = require('./testsUtils');
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -26,36 +25,6 @@ const outputJsonWithRefs = '{"asyncapi":"2.0.0","info":{"title":"My API","versio
 const invalidAsyncAPI = '{"asyncapi":"2.0.0","info":{}}';
 const outputJSONNoChannels = '{"asyncapi":"2.0.0","info":{"title":"My API","version":"1.0.0"},"channels":{},"components":{"messages":{"testMessage":{"payload":{"type":"object","properties":{"name":{"type":"string","x-parser-schema-id":"<anonymous-schema-1>"}},"x-parser-schema-id":"testSchema"},"x-some-extension":"some extension","headers":{"type":"object","properties":{"some-common-header":{"type":"string","x-parser-schema-id":"<anonymous-schema-3>"}},"x-parser-schema-id":"<anonymous-schema-2>"},"x-parser-original-traits":[{"x-some-extension":"some extension","headers":{"type":"object","properties":{"some-common-header":{"type":"string"}}}}],"schemaFormat":"application/vnd.aai.asyncapi;version=2.0.0","x-parser-message-parsed":true,"x-parser-message-name":"testMessage"}},"schemas":{"testSchema":{"type":"object","properties":{"name":{"type":"string","x-parser-schema-id":"<anonymous-schema-1>"}},"x-parser-schema-id":"testSchema"}},"messageTraits":{"extension":{"x-some-extension":"some extension","headers":{"type":"object","properties":{"some-common-header":{"type":"string"}}}}}}}';
 const outputJSONMessagesChannels = '{"asyncapi":"2.0.0","info":{"title":"My API","version":"1.0.0"},"channels":{"mychannel":{"publish":{"message":{"x-some-extension":"some extension","headers":{"type":"object","properties":{"some-common-header":{"type":"string","x-parser-schema-id":"<anonymous-schema-2>"}},"x-parser-schema-id":"<anonymous-schema-1>"},"x-parser-original-traits":[{"x-some-extension":"some extension","headers":{"type":"object","properties":{"some-common-header":{"type":"string"}}}}],"schemaFormat":"application/vnd.aai.asyncapi;version=2.0.0","x-parser-message-parsed":true,"x-parser-message-name":"channelMessage"}}}},"components":{"messages":{"channelMessage":{"x-some-extension":"some extension","headers":{"type":"object","properties":{"some-common-header":{"type":"string","x-parser-schema-id":"<anonymous-schema-2>"}},"x-parser-schema-id":"<anonymous-schema-1>"},"x-parser-original-traits":[{"x-some-extension":"some extension","headers":{"type":"object","properties":{"some-common-header":{"type":"string"}}}}],"schemaFormat":"application/vnd.aai.asyncapi;version=2.0.0","x-parser-message-parsed":true,"x-parser-message-name":"channelMessage"},"testMessage":{"payload":{"type":"object","properties":{"name":{"type":"string","x-parser-schema-id":"<anonymous-schema-3>"}},"x-parser-schema-id":"testSchema"},"x-some-extension":"some extension","headers":{"type":"object","properties":{"some-common-header":{"type":"string","x-parser-schema-id":"<anonymous-schema-5>"}},"x-parser-schema-id":"<anonymous-schema-4>"},"x-parser-original-traits":[{"x-some-extension":"some extension","headers":{"type":"object","properties":{"some-common-header":{"type":"string"}}}}],"schemaFormat":"application/vnd.aai.asyncapi;version=2.0.0","x-parser-message-parsed":true,"x-parser-message-name":"testMessage"}},"schemas":{"testSchema":{"type":"object","properties":{"name":{"type":"string","x-parser-schema-id":"<anonymous-schema-3>"}},"x-parser-schema-id":"testSchema"}},"messageTraits":{"extension":{"x-some-extension":"some extension","headers":{"type":"object","properties":{"some-common-header":{"type":"string"}}}}}}}';
-
-/* eslint-disable sonarjs/cognitive-complexity */
-/**
- * Disabled the rule for this function as there is no way to make it shorter in a meaningfull way
- * This function should always be used in tests where errors are evaluated to make sure they always work even if proper error is not thrown
- * @private
- * @param  {Function} fn Function that you want to test
- * @param  {Object} validationObject Error object to evaluate against the error thrown by fn()
-*/
-const checkErrorWrapper = async (fn, validationObject) => {
-  const { type, message, title, refs, detail, location, validationErrors, parsedJSON } = validationObject;
-
-  try {
-    await fn();
-    throw Error('This error should not be reachable. If you reached it, it means the function did not throw a proper error and executed successfully.');
-  } catch (e) {
-    const isProperError = e instanceof ParserError;
-    if (!isProperError) console.log(e);
-
-    if (isProperError) expect(e instanceof ParserError).to.equal(true);
-    if (type) expect(e).to.have.own.property('type', type);
-    if (message) expect(e).to.have.own.property('message', message);
-    if (title) expect(e).to.have.own.property('title', title);
-    if (detail) expect(e).to.have.own.property('detail', detail);
-    if (refs) expect(e.refs).to.deep.equal(refs);
-    if (location) expect(e.location).to.deep.equal(location);
-    if (validationErrors) expect(e.validationErrors).to.deep.equal(validationErrors);
-    if (parsedJSON) expect(JSON.stringify(e.parsedJSON)).to.deep.equal(parsedJSON);
-  }
-};
 
 describe('parse()', function() {
   it('should parse YAML', async function() {
@@ -98,11 +67,11 @@ describe('parse()', function() {
         location: { 
           endColumn: 31,
           endLine: 1,
-          endOffset: offset(29, 1),
+          endOffset: 29,
           jsonPointer: '/info',
           startColumn: 29,
           startLine: 1,
-          startOffset: offset(27, 1)
+          startOffset: 27
         }
       },
       {
@@ -110,11 +79,11 @@ describe('parse()', function() {
         location: { 
           endColumn: 31,
           endLine: 1,
-          endOffset: offset(29, 1),
+          endOffset: 29,
           jsonPointer: '/info',
           startColumn: 29,
           startLine: 1,
-          startOffset: offset(27, 1) 
+          startOffset: 27 
         }
       },
       {
@@ -143,7 +112,7 @@ describe('parse()', function() {
             startOffset: offset(16, 2),
             endLine: 3,
             endColumn: 19,
-            endOffset: offset(40, 3),
+            endOffset: offset(40, 3)
           }
         }
       ]
@@ -196,7 +165,7 @@ describe('parse()', function() {
             startOffset: offset(33, 3),
             endLine: 5,
             endColumn: 4,
-            endOffset: offset(58, 5),
+            endOffset: offset(58, 5)
           }
         }
       ]
@@ -242,10 +211,10 @@ describe('parse()', function() {
           jsonPointer: '/asyncapi',
           startLine: 1,
           startColumn: 1,
-          startOffset: offset(0, 1),
+          startOffset: 0,
           endLine: 1,
           endColumn: 16,
-          endOffset: offset(15, 1),
+          endOffset: 15
         }
       ]
     };
@@ -462,7 +431,7 @@ describe('parse()', function() {
       type: 'https://github.com/asyncapi/parser-js/invalid-json',
       title: 'The provided JSON is not valid.',
       detail: 'Unexpected token j in JSON at position 12 while parsing near \' {"invalid "json" }\'',
-      location: { startOffset: offset(12, 1), startLine: 1, startColumn: 12 }
+      location: { startOffset: 12, startLine: 1, startColumn: 12 }
     };
 
     await checkErrorWrapper(async () => {

--- a/test/parse_test.js
+++ b/test/parse_test.js
@@ -61,7 +61,7 @@ describe('parse()', function() {
     const expectedErrorObject = {
       type: 'https://github.com/asyncapi/parser-js/validation-errors',
       title: 'There were errors validating the AsyncAPI document.',
-      parsedJSON: invalidAsyncAPI,
+      parsedJSON: JSON.parse(invalidAsyncAPI),
       validationErrors: [{
         title: '/info should have required property \'title\'',
         location: { 
@@ -101,7 +101,7 @@ describe('parse()', function() {
     const expectedErrorObject = {
       type: 'https://github.com/asyncapi/parser-js/validation-errors',
       title: 'There were errors validating the AsyncAPI document.',
-      parsedJSON: invalidYamlOutput,
+      parsedJSON: JSON.parse(invalidYamlOutput),
       validationErrors: [
         {
           title: '/info should have required property \'title\'',
@@ -154,7 +154,7 @@ describe('parse()', function() {
     const expectedErrorObject = {
       type: 'https://github.com/asyncapi/parser-js/validation-errors',
       title: 'There were errors validating the AsyncAPI document.',
-      parsedJSON: invalidJsonOutput,
+      parsedJSON: JSON.parse(invalidJsonOutput),
       validationErrors: [
         {
           title: '/info should have required property \'title\'',
@@ -192,7 +192,7 @@ describe('parse()', function() {
     const expectedErrorObject = {
       type: 'https://github.com/asyncapi/parser-js/missing-asyncapi-field',
       title: 'The `asyncapi` field is missing.',
-      parsedJSON: '{"bad":true}'
+      parsedJSON: JSON.parse('{"bad":true}')
     };
 
     await checkErrorWrapper(async () => {
@@ -205,7 +205,7 @@ describe('parse()', function() {
       type: 'https://github.com/asyncapi/parser-js/unsupported-version',
       title: 'Version 1.2.0 is not supported.',
       detail: 'Please use latest version of the specification.',
-      parsedJSON: '{"asyncapi":"1.2.0"}',
+      parsedJSON: JSON.parse('{"asyncapi":"1.2.0"}'),
       validationErrors: [
         {
           jsonPointer: '/asyncapi',
@@ -241,7 +241,7 @@ describe('parse()', function() {
     const expectedErrorObject = {
       type: 'https://github.com/asyncapi/parser-js/dereference-error',
       title: `Error opening file "${path.resolve(process.cwd(), 'refs/refed.yaml')}" \nENOENT: no such file or directory, open '${path.resolve(process.cwd(), 'refs/refed.yaml')}'`,
-      parsedJSON: outputJsonWithRefs,
+      parsedJSON: JSON.parse(outputJsonWithRefs),
       refs: [
         {
           jsonPointer: '/components/schemas/testSchema/properties/test/$ref',

--- a/test/testsUtils.js
+++ b/test/testsUtils.js
@@ -1,7 +1,13 @@
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
 const { EOL } = require('os');
 const eolLength = EOL.length;
+const ParserError = require('../lib/errors/parser-error');
 
-const utils = module.exports;
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+const testsUtils = module.exports;
 
 /**
  * Tests helper for testing start and end offset position of error in file to make sure tests work on Windows too
@@ -11,6 +17,35 @@ const utils = module.exports;
  * @param  {Number} oset end or start offset number
  * @param  {Number} line end or start line number
  * @returns {Number} calculated offset number
-
  */
-utils.offset = (oset, line) => (oset + ((eolLength - 1) * (line - 1)));
+testsUtils.offset = (oset, line) => (oset + ((eolLength - 1) * (line - 1)));
+
+/* eslint-disable sonarjs/cognitive-complexity */
+/**
+ * Disabled the rule for this function as there is no way to make it shorter in a meaningfull way
+ * This function should always be used in tests where errors are evaluated to make sure they always work even if proper error is not thrown
+ * @private
+ * @param  {Function} fn Function that you want to test
+ * @param  {Object} validationObject Error object to evaluate against the error thrown by fn()
+*/
+testsUtils.checkErrorWrapper = async (fn, validationObject) => {
+  const { type, message, title, refs, detail, location, validationErrors, parsedJSON } = validationObject;
+
+  try {
+    await fn();
+    throw Error('This error should not be reachable. If you reached it, it means the function did not throw a proper error and executed successfully.');
+  } catch (e) {
+    const isProperError = e instanceof ParserError;
+    if (!isProperError) console.log(e);
+
+    if (isProperError) expect(e instanceof ParserError).to.equal(true);
+    if (type) expect(e).to.have.own.property('type', type);
+    if (message) expect(e).to.have.own.property('message', message);
+    if (title) expect(e).to.have.own.property('title', title);
+    if (detail) expect(e).to.have.own.property('detail', detail);
+    if (refs) expect(e.refs).to.deep.equal(refs);
+    if (location) expect(e.location).to.deep.equal(location);
+    if (validationErrors) expect(e.validationErrors).to.deep.equal(validationErrors);
+    if (parsedJSON) expect(e.parsedJSON).to.deep.equal(JSON.parse(parsedJSON));
+  }
+};

--- a/test/testsUtils.js
+++ b/test/testsUtils.js
@@ -46,6 +46,6 @@ testsUtils.checkErrorWrapper = async (fn, validationObject) => {
     if (refs) expect(e.refs).to.deep.equal(refs);
     if (location) expect(e.location).to.deep.equal(location);
     if (validationErrors) expect(e.validationErrors).to.deep.equal(validationErrors);
-    if (parsedJSON) expect(e.parsedJSON).to.deep.equal(JSON.parse(parsedJSON));
+    if (parsedJSON) expect(e.parsedJSON).to.deep.equal(parsedJSON);
   }
 };


### PR DESCRIPTION
This PR resolves issue #140.

- moved `checkErrorWrapper` from `parse_test.js` to separate file `testsUtils.js`
- refactored `parse_test.js` to use `checkErrorWrapper` from `testsUtils.js`
- refactored `asyncapiSchemaFormatParser_test.js` to use `checkErrorWrapper` from `testsUtils.js`
- refactored `customValidators_test.js` to use `checkErrorWrapper` from `testsUtils.js`
- removed offsets where input is a string variable and not a file
- added execution of *nix commands through `shx` so they also work on Windows without any change

(`shx` wraps native Unix commands as `shx cp \"dist/bundle.js\"` to avoid errors like this on Windows platforms)
![](https://i.ibb.co/SNRdfnk/image.png)