### PR TITLE
fix: support true/false JSON Schemas

### DIFF
--- a/lib/models/schema.js
+++ b/lib/models/schema.js
@@ -17,6 +17,12 @@ const MixinSpecificationExtensions = require('../mixins/specification-extensions
  * @returns {Schema}
  */
 class Schema extends Base {
+  constructor (json) {
+    const isBoolSchema = typeof json === 'boolean';
+    super(isBoolSchema ? {} : json);
+    this.isBoolSchema = isBoolSchema;
+  }
+
   /**
    * @returns {string}
    */
@@ -360,6 +366,13 @@ class Schema extends Base {
    */
   examples() {
     return this._json.examples;
+  }
+
+  /**
+   * @returns {boolean}
+   */
+  isBooleanSchema() {
+    return this.isBoolSchema;
   }
 
   /**

--- a/test/asyncapiSchemaFormatParser_test.js
+++ b/test/asyncapiSchemaFormatParser_test.js
@@ -48,18 +48,6 @@ describe('asyncapiSchemaFormatParser', function() {
         }
       },
       {
-        title: '/channels/mychannel/publish/message/payload/additionalProperties should be object',
-        location: {
-          jsonPointer: '/channels/mychannel/publish/message/payload/additionalProperties',
-          startLine: 13,
-          startColumn: 38,
-          startOffset: offset(252, 13),
-          endLine: 15,
-          endColumn: 15,
-          endOffset: offset(297, 15)
-        }
-      },
-      {
         title: '/channels/mychannel/publish/message/payload/additionalProperties should be boolean',
         location: {
           jsonPointer: '/channels/mychannel/publish/message/payload/additionalProperties',
@@ -108,6 +96,50 @@ describe('asyncapiSchemaFormatParser', function() {
     const parsedInput = JSON.parse(inputString);
 
     expect(async () => await parser.parse(parsedInput)).to.not.throw();
+  });
+
+  it('should handle true/false JSON Schemas', async function() {
+    const inputSpec = {
+      asyncapi: '2.0.0',
+      info: {
+        title: 'Example Spec',
+        version: '1.0.0',
+      },
+      channels: {
+        testChannel: {
+          publish: {
+            message: {
+              payload: {
+                type: 'object',
+                properties: {
+                  trueSchema: true,
+                  falseSchema: false,
+                  normalSchema: {
+                    type: 'string',
+                  }
+                },
+              }
+            }
+          }
+        }
+      },
+      components: {
+        schemas: {
+          testSchema: {
+            type: 'object',
+            properties: {
+              trueSchema: true,
+              falseSchema: false,
+              normalSchema: {
+                type: 'string',
+              }
+            },
+          }
+        }
+      }
+    };
+  
+    expect(async () => await parser.parse(inputSpec)).to.not.throw();
   });
 
   it('should deep clone schema into x-parser-original-payload', async function() {

--- a/test/models/schema_test.js
+++ b/test/models/schema_test.js
@@ -573,6 +573,18 @@ describe('Schema', function() {
     });
   });
 
+  describe('#isBooleanSchema()', function() {
+    it('should return a true when schema is true', function() {
+      const d = new Schema(true);
+      expect(d.isBooleanSchema()).to.be.equal(true);
+    });
+
+    it('should return a true when schema is false', function() {
+      const d = new Schema(false);
+      expect(d.isBooleanSchema()).to.be.equal(true);
+    });
+  });
+
   describe('#isCircular()', function() {
     it('should return a boolean', function() {
       const doc = { 'x-parser-circular': true};


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

As in title. As we support JSON Schema draft-07 as schema, then we should also support `true/false` schemas in JSON Schema of our spec and of course in parser. More info https://github.com/asyncapi/parser-js/issues/232 

**Related issue(s)**
Fixes https://github.com/asyncapi/parser-js/issues/232
Blocked by https://github.com/asyncapi/asyncapi-node/pull/63