### PR TITLE
feat: assigning schema id to parameter schemas in components

### DIFF
--- a/lib/anonymousNaming.js
+++ b/lib/anonymousNaming.js
@@ -20,7 +20,7 @@ function assignNameToComponentMessages(doc) {
 /**
  * Assign ids based on parameter keys.
  * 
- * @param {{[key:string]: Schema}} parameterObject 
+ * @param {Record<string,Schema>} parameterObject 
  */
 function assignIdToParameters(parameterObject) {
   for (const [parameterKey, parameter] of Object.entries(parameterObject)) {

--- a/lib/anonymousNaming.js
+++ b/lib/anonymousNaming.js
@@ -49,7 +49,8 @@ function assignUidToComponentSchemas(doc) {
 }
 
 /**
- * Assign uid to component parameters
+ * Assign uid to component parameters schemas
+ * 
  * @private
  * @param {AsyncAPIDocument} doc 
  */

--- a/lib/anonymousNaming.js
+++ b/lib/anonymousNaming.js
@@ -27,7 +27,9 @@ function assignUidToParameterSchemas(doc) {
   doc.channelNames().forEach(channelName => {
     const channel = doc.channel(channelName);
     for (const [parameterKey, parameterSchema] of Object.entries(channel.parameters())) {
-      parameterSchema.json()[String(xParserSchemaId)] = parameterKey;
+      if (parameterSchema.schema() !== undefined) {
+        parameterSchema.schema().json()[String(xParserSchemaId)] = parameterKey;
+      }
     }
   });
 }

--- a/lib/anonymousNaming.js
+++ b/lib/anonymousNaming.js
@@ -18,6 +18,19 @@ function assignNameToComponentMessages(doc) {
 }
 
 /**
+ * Assign ids based on parameter keys.
+ * 
+ * @param {{[key:string]: Schema}} parameterObject 
+ */
+function assignIdToParameters(parameterObject) {
+  for (const [parameterKey, parameter] of Object.entries(parameterObject)) {
+    if (parameter.schema()) {
+      parameter.schema().json()[String(xParserSchemaId)] = parameterKey;
+    }
+  }
+}
+
+/**
  * Assign parameter keys as uid for the parameter schema.
  * 
  * @private
@@ -26,11 +39,7 @@ function assignNameToComponentMessages(doc) {
 function assignUidToParameterSchemas(doc) {
   doc.channelNames().forEach(channelName => {
     const channel = doc.channel(channelName);
-    for (const [parameterKey, parameter] of Object.entries(channel.parameters())) {
-      if (parameter.schema()) {
-        parameter.schema().json()[String(xParserSchemaId)] = parameterKey;
-      }
-    }
+    assignIdToParameters(channel.parameters());
   });
 }
   
@@ -56,11 +65,7 @@ function assignUidToComponentSchemas(doc) {
  */
 function assignUidToComponentParameterSchemas(doc) {
   if (doc.hasComponents()) {
-    for (const [parameterKey, parameter] of Object.entries(doc.components().parameters())) {
-      if (parameter.schema()) {
-        parameter.schema().json()[String(xParserSchemaId)] = parameterKey;
-      }
-    }
+    assignIdToParameters(doc.components().parameters());
   }
 }
   

--- a/lib/anonymousNaming.js
+++ b/lib/anonymousNaming.js
@@ -20,6 +20,7 @@ function assignNameToComponentMessages(doc) {
 /**
  * Assign ids based on parameter keys.
  * 
+ * @private
  * @param {Record<string,Schema>} parameterObject 
  */
 function assignIdToParameters(parameterObject) {

--- a/lib/anonymousNaming.js
+++ b/lib/anonymousNaming.js
@@ -26,9 +26,9 @@ function assignNameToComponentMessages(doc) {
 function assignUidToParameterSchemas(doc) {
   doc.channelNames().forEach(channelName => {
     const channel = doc.channel(channelName);
-    for (const [parameterKey, parameterSchema] of Object.entries(channel.parameters())) {
-      if (parameterSchema.schema()) {
-        parameterSchema.schema().json()[String(xParserSchemaId)] = parameterKey;
+    for (const [parameterKey, parameter] of Object.entries(channel.parameters())) {
+      if (parameter.schema()) {
+        parameter.schema().json()[String(xParserSchemaId)] = parameterKey;
       }
     }
   });
@@ -44,6 +44,21 @@ function assignUidToComponentSchemas(doc) {
   if (doc.hasComponents()) {
     for (const [key, s] of Object.entries(doc.components().schemas())) {
       s.json()[String(xParserSchemaId)] = key;
+    }
+  }
+}
+
+/**
+ * Assign uid to component parameters
+ * @private
+ * @param {AsyncAPIDocument} doc 
+ */
+function assignUidToComponentParameterSchemas(doc) {
+  if (doc.hasComponents()) {
+    for (const [parameterKey, parameter] of Object.entries(doc.components().parameters())) {
+      if (parameter.schema()) {
+        parameter.schema().json()[String(xParserSchemaId)] = parameterKey;
+      }
     }
   }
 }
@@ -100,6 +115,7 @@ module.exports = {
   assignNameToComponentMessages,
   assignUidToParameterSchemas,
   assignUidToComponentSchemas,
+  assignUidToComponentParameterSchemas,
   assignNameToAnonymousMessages,
   assignIdToAnonymousSchemas
 };

--- a/lib/anonymousNaming.js
+++ b/lib/anonymousNaming.js
@@ -27,7 +27,7 @@ function assignUidToParameterSchemas(doc) {
   doc.channelNames().forEach(channelName => {
     const channel = doc.channel(channelName);
     for (const [parameterKey, parameterSchema] of Object.entries(channel.parameters())) {
-      if (parameterSchema.schema() !== undefined) {
+      if (parameterSchema.schema()) {
         parameterSchema.schema().json()[String(xParserSchemaId)] = parameterKey;
       }
     }

--- a/lib/models/asyncapi.js
+++ b/lib/models/asyncapi.js
@@ -9,7 +9,7 @@ const MixinExternalDocs = require('../mixins/external-docs');
 const MixinTags = require('../mixins/tags');
 const MixinSpecificationExtensions = require('../mixins/specification-extensions');
 const {xParserSpecParsed, xParserCircle, xParserCircleProps} = require('../constants');
-const {assignNameToAnonymousMessages, assignNameToComponentMessages, assignUidToComponentSchemas, assignUidToParameterSchemas, assignIdToAnonymousSchemas} = require('../anonymousNaming');
+const {assignNameToAnonymousMessages, assignNameToComponentMessages, assignUidToComponentSchemas, assignUidToParameterSchemas, assignIdToAnonymousSchemas, assignUidToComponentParameterSchemas} = require('../anonymousNaming');
 const {traverseAsyncApiDocument, SchemaIteratorCallbackType} = require('../iterators');
 
 /**
@@ -38,6 +38,7 @@ class AsyncAPIDocument extends Base {
 
     markCircularSchemas(this);
     assignUidToComponentSchemas(this);
+    assignUidToComponentParameterSchemas(this);
     assignUidToParameterSchemas(this);
     assignIdToAnonymousSchemas(this);
 

--- a/test/models/asyncapi_test.js
+++ b/test/models/asyncapi_test.js
@@ -65,6 +65,15 @@ describe('AsyncAPIDocument', function() {
     });
   });
 
+  describe('assignUidToComponentParameterSchemas()', function() {
+    it('should assign uids to component parameters', function() {
+      const inputDoc = { channels: { 'smartylighting/{streetlightId}': {}, components: { parameters: { streetlightId: { schema: { type: 'string' } } } } } };
+      const expectedDoc = { channels: { 'smartylighting/{streetlightId}': {}, components: { parameters: {streetlightId: { schema: { type: 'string', 'x-parser-schema-id': 'streetlightId' } } } } }, 'x-parser-spec-parsed': true };
+      const d = new AsyncAPIDocument(inputDoc);
+      expect(d.json()).to.be.deep.equal(expectedDoc);
+    });
+  });
+
   describe('#info()', function() {
     it('should return an info object', function() {
       const doc = { info: { title: 'Test', version: '1.2.3', license: { name: 'Apache 2.0', url: 'https://www.apache.org/licenses/LICENSE-2.0' } } };

--- a/test/models/asyncapi_test.js
+++ b/test/models/asyncapi_test.js
@@ -59,7 +59,7 @@ describe('AsyncAPIDocument', function() {
   describe('assignUidToParameterSchemas()', function() {
     it('should assign uids to parameters', function() {
       const inputDoc = { channels: { 'smartylighting/{streetlightId}': { parameters: { streetlightId: { schema: { type: 'string' } } } } } };
-      const expectedDoc = { channels: { 'smartylighting/{streetlightId}': { parameters: { streetlightId: { schema: { type: 'string', 'x-parser-schema-id': '<anonymous-schema-1>' }, 'x-parser-schema-id': 'streetlightId' } } } }, 'x-parser-spec-parsed': true };
+      const expectedDoc = { channels: { 'smartylighting/{streetlightId}': { parameters: { streetlightId: { schema: { type: 'string', 'x-parser-schema-id': 'streetlightId' } } } } }, 'x-parser-spec-parsed': true };
       const d = new AsyncAPIDocument(inputDoc);
       expect(d.json()).to.be.deep.equal(expectedDoc);
     });


### PR DESCRIPTION
**Description**
This PR fixes an issue where we assign parameters wrong ids.

**Related issue(s)**
Fixes https://github.com/asyncapi/parser-js/issues/325