### PR TITLE
fix: use proper json schema and tests to point to 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ npm install @asyncapi/parser
 const parser = require('@asyncapi/parser');
 
 const doc = await parser.parse(`
-  asyncapi: '2.0.0'
+  asyncapi: '2.1.0'
   info:
     title: Example
     version: '0.1.0'

--- a/lib/asyncapiSchemaFormatParser.js
+++ b/lib/asyncapiSchemaFormatParser.js
@@ -43,8 +43,11 @@ async function parse({ message, originalAsyncAPIDocument, fileFormat, parsedAsyn
 function getMimeTypes() {
   return [
     'application/vnd.aai.asyncapi;version=2.0.0',
+    'application/vnd.aai.asyncapi;version=2.1.0',
     'application/vnd.aai.asyncapi+json;version=2.0.0',
+    'application/vnd.aai.asyncapi+json;version=2.1.0',
     'application/vnd.aai.asyncapi+yaml;version=2.0.0',
+    'application/vnd.aai.asyncapi+yaml;version=2.1.0',
     'application/schema;version=draft-07',
     'application/schema+json;version=draft-07',
     'application/schema+yaml;version=draft-07',

--- a/lib/models/message-traitable.js
+++ b/lib/models/message-traitable.js
@@ -52,7 +52,7 @@ class MessageTraitable extends Base {
    * @returns {string}
    */
   schemaFormat() {
-    return 'application/schema+json;version=draft-07';
+    return this._json.schemaFormat;
   }
 
   /**

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -6,10 +6,9 @@ const $RefParser = require('@apidevtools/json-schema-ref-parser');
 const mergePatch = require('tiny-merge-patch').apply;
 const ParserError = require('./errors/parser-error');
 const { validateChannels, validateServerVariables, validateOperationId, validateServerSecurity } = require('./customValidators.js');
-const { toJS, findRefs, getLocationOf, improveAjvErrors } = require('./utils');
+const { toJS, findRefs, getLocationOf, improveAjvErrors, getDefaultSchemaFormat } = require('./utils');
 const AsyncAPIDocument = require('./models/asyncapi');
 
-const DEFAULT_SCHEMA_FORMAT = 'application/vnd.aai.asyncapi;version=2.0.0';
 const OPERATIONS = ['publish', 'subscribe'];
 //the only security types that can have a non empty array in the server security item
 const SPECIAL_SECURITY_TYPES = ['oauth2', 'openIdConnect'];
@@ -187,20 +186,20 @@ async function customDocumentOperations(parsedJSON, asyncapiYAMLorJSON, initialF
 async function validateAndConvertMessage(msg, originalAsyncAPIDocument, fileFormat, parsedAsyncAPIDocument, pathToPayload) {
   //check if the message has been parsed before
   if (xParserMessageParsed in msg && msg[String(xParserMessageParsed)] === true) return;
-
-  const schemaFormat = msg.schemaFormat || DEFAULT_SCHEMA_FORMAT;
+  const defaultSchemaFormat = getDefaultSchemaFormat(parsedAsyncAPIDocument.asyncapi);
+  const schemaFormat = msg.schemaFormat || defaultSchemaFormat;
 
   await PARSERS[String(schemaFormat)]({
     schemaFormat,
     message: msg,
-    defaultSchemaFormat: DEFAULT_SCHEMA_FORMAT,
+    defaultSchemaFormat,
     originalAsyncAPIDocument,
     parsedAsyncAPIDocument,
     fileFormat, 
     pathToPayload
   });
 
-  msg.schemaFormat = DEFAULT_SCHEMA_FORMAT;
+  msg.schemaFormat = defaultSchemaFormat;
   msg[String(xParserMessageParsed)] = true;
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -284,3 +284,19 @@ utils.setNotProvidedParams = (variables, val, key, notProvidedChannelParams, not
         : missingChannelParams);
   }
 };
+
+/**
+ * returns default schema format for a given asyncapi version
+ *
+ * @function getDefaultSchemaFormat
+ * @private
+ * @param  {String} asyncapiVersion AsyncAPI spec version. 
+ */
+utils.getDefaultSchemaFormat = (asyncapiVersion) => {
+  const schemaMatrix = {
+    '2.0.0': 'application/vnd.aai.asyncapi;version=2.0.0',
+    '2.1.0': 'application/vnd.aai.asyncapi;version=2.1.0',
+  };
+
+  return schemaMatrix[String(asyncapiVersion)];
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -293,10 +293,5 @@ utils.setNotProvidedParams = (variables, val, key, notProvidedChannelParams, not
  * @param  {String} asyncapiVersion AsyncAPI spec version. 
  */
 utils.getDefaultSchemaFormat = (asyncapiVersion) => {
-  const schemaMatrix = {
-    '2.0.0': 'application/vnd.aai.asyncapi;version=2.0.0',
-    '2.1.0': 'application/vnd.aai.asyncapi;version=2.1.0',
-  };
-
-  return schemaMatrix[String(asyncapiVersion)];
+  return `application/vnd.aai.asyncapi;version=${asyncapiVersion}`;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
       }
     },
     "@asyncapi/specs": {
-      "version": "2.8.0-2021-06-release.3",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.8.0-2021-06-release.3.tgz",
-      "integrity": "sha512-IbsTNMYR3fzhZRljHu/U5NrJlOQuH/MkkdmSP/zThGBzY+tHS9Rf7bDxP6ndpKN6hIMns+q8B5iNx81S7i0RTg=="
+      "version": "2.8.0-2021-06-release.5",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.8.0-2021-06-release.5.tgz",
+      "integrity": "sha512-BrswD9gvd0+MKAe8wcay5GPNie1F7wQ5IsUb690t3IySIgbcEnZU99FlDUsaiDANR5Rz7Y3K7pi2gnFnUB3U3g=="
     },
     "@babel/code-frame": {
       "version": "7.8.3",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.0.6",
-    "@asyncapi/specs": "2.8.0-2021-06-release.3",
+    "@asyncapi/specs": "2.8.0-2021-06-release.5",
     "@fmvilas/pseudo-yaml-ast": "^0.3.1",
     "ajv": "^6.10.1",
     "js-yaml": "^3.13.1",

--- a/test/good/asyncapi-messages-example-headers.yml
+++ b/test/good/asyncapi-messages-example-headers.yml
@@ -1,4 +1,4 @@
-asyncapi: 2.0.0
+asyncapi: 2.1.0
 info:
   title: My API
   version: '1.0.0'

--- a/test/good/asyncapi-messages-example-optional.yml
+++ b/test/good/asyncapi-messages-example-optional.yml
@@ -1,4 +1,4 @@
-asyncapi: 2.0.0
+asyncapi: 2.1.0
 info:
   title: My API
   version: '1.0.0'

--- a/test/good/asyncapi-messages-example-payload.yml
+++ b/test/good/asyncapi-messages-example-payload.yml
@@ -1,4 +1,4 @@
-asyncapi: 2.0.0
+asyncapi: 2.1.0
 info:
   title: My API
   version: '1.0.0'

--- a/test/good/asyncapi-messages-example.yml
+++ b/test/good/asyncapi-messages-example.yml
@@ -1,4 +1,4 @@
-asyncapi: 2.0.0
+asyncapi: 2.1.0
 info:
   title: My API
   version: '1.0.0'

--- a/test/models/message-trait_test.js
+++ b/test/models/message-trait_test.js
@@ -1,5 +1,5 @@
 const { expect } = require('chai');
-const js = { headers: { properties: { test1: { type: 'string' }, test2: { type: 'number' } } }, correlationId: { test: true }, contentType: 'application/json', name: 'test', title: 'Test', summary: 'test', description: 'testing', externalDocs: { test: true }, tags: [{ name: 'tag1' }], bindings: { amqp: { test: true } }, examples: [{name: 'test', summary: 'test summary', payload: {test: true}}], 'x-test': 'testing' };
+const js = { schemaFormat: 'mySchema', headers: { properties: { test1: { type: 'string' }, test2: { type: 'number' } } }, correlationId: { test: true }, contentType: 'application/json', name: 'test', title: 'Test', summary: 'test', description: 'testing', externalDocs: { test: true }, tags: [{ name: 'tag1' }], bindings: { amqp: { test: true } }, examples: [{name: 'test', summary: 'test summary', payload: {test: true}}], 'x-test': 'testing' };
 
 const MessageTrait = require('../../lib/models/message-trait');
 
@@ -50,7 +50,7 @@ describe('MessageTrait', function() {
   describe('#schemaFormat()', function() {
     it('should return a string', function() {
       const d = new MessageTrait(js);
-      expect(d.schemaFormat()).to.equal('application/schema+json;version=draft-07');
+      expect(d.schemaFormat()).to.equal('mySchema');
     });
   });
 

--- a/test/models/message-traitable_test.js
+++ b/test/models/message-traitable_test.js
@@ -1,5 +1,5 @@
 const { expect } = require('chai');
-const js = { headers: { properties: { test1: { type: 'string' }, test2: { type: 'number' } } }, correlationId: { test: true }, contentType: 'application/json', name: 'test', title: 'Test', summary: 'test', description: 'testing', externalDocs: { test: true }, tags: [{ name: 'tag1' }], bindings: { amqp: { test: true } }, examples: [{name: 'test', summary: 'test summary', payload: {test: true}}], 'x-test': 'testing' };
+const js = { schemaFormat: 'mySchema', headers: { properties: { test1: { type: 'string' }, test2: { type: 'number' } } }, correlationId: { test: true }, contentType: 'application/json', name: 'test', title: 'Test', summary: 'test', description: 'testing', externalDocs: { test: true }, tags: [{ name: 'tag1' }], bindings: { amqp: { test: true } }, examples: [{name: 'test', summary: 'test summary', payload: {test: true}}], 'x-test': 'testing' };
 
 const MessageTraitable = require('../../lib/models/message-traitable');
 
@@ -50,7 +50,7 @@ describe('MessageTraitable', function() {
   describe('#schemaFormat()', function() {
     it('should return a string', function() {
       const d = new MessageTraitable(js);
-      expect(d.schemaFormat()).to.equal('application/schema+json;version=draft-07');
+      expect(d.schemaFormat()).to.equal('mySchema');
     });
   });
 

--- a/test/models/message_test.js
+++ b/test/models/message_test.js
@@ -1,5 +1,5 @@
 const { expect } = require('chai');
-const js = { headers: { properties: { test1: { type: 'string' }, test2: { type: 'number' } } }, payload: { test: true }, 'x-parser-original-payload': { testing: true }, correlationId: { test: true }, 'x-parser-original-schema-format': 'application/vnd.apache.avro;version=1.9.0', contentType: 'application/json', name: 'test', title: 'Test', summary: 'test', description: 'testing', externalDocs: { test: true }, tags: [{ name: 'tag1' }], bindings: { amqp: { test: true } }, examples: [{name: 'test', summary: 'test summary', payload: {test: true}}], 'x-test': 'testing' };
+const js = { schemaFormat: 'mySchema', headers: { properties: { test1: { type: 'string' }, test2: { type: 'number' } } }, payload: { test: true }, 'x-parser-original-payload': { testing: true }, correlationId: { test: true }, 'x-parser-original-schema-format': 'application/vnd.apache.avro;version=1.9.0', contentType: 'application/json', name: 'test', title: 'Test', summary: 'test', description: 'testing', externalDocs: { test: true }, tags: [{ name: 'tag1' }], bindings: { amqp: { test: true } }, examples: [{name: 'test', summary: 'test summary', payload: {test: true}}], 'x-test': 'testing' };
 
 const Message = require('../../lib/models/message');
 
@@ -25,7 +25,7 @@ describe('Message', function() {
     it('should return a string with the base64 representation of the object when x-parser-message-name extension and name are not available', function() {
       const msg = { ...js, ...{ name: undefined } };
       const d = new Message(msg);
-      expect(d.uid()).to.be.equal('eyJoZWFkZXJzIjp7InByb3BlcnRpZXMiOnsidGVzdDEiOnsidHlwZSI6InN0cmluZyJ9LCJ0ZXN0MiI6eyJ0eXBlIjoibnVtYmVyIn19fSwicGF5bG9hZCI6eyJ0ZXN0Ijp0cnVlfSwieC1wYXJzZXItb3JpZ2luYWwtcGF5bG9hZCI6eyJ0ZXN0aW5nIjp0cnVlfSwiY29ycmVsYXRpb25JZCI6eyJ0ZXN0Ijp0cnVlfSwieC1wYXJzZXItb3JpZ2luYWwtc2NoZW1hLWZvcm1hdCI6ImFwcGxpY2F0aW9uL3ZuZC5hcGFjaGUuYXZybzt2ZXJzaW9uPTEuOS4wIiwiY29udGVudFR5cGUiOiJhcHBsaWNhdGlvbi9qc29uIiwidGl0bGUiOiJUZXN0Iiwic3VtbWFyeSI6InRlc3QiLCJkZXNjcmlwdGlvbiI6InRlc3RpbmciLCJleHRlcm5hbERvY3MiOnsidGVzdCI6dHJ1ZX0sInRhZ3MiOlt7Im5hbWUiOiJ0YWcxIn1dLCJiaW5kaW5ncyI6eyJhbXFwIjp7InRlc3QiOnRydWV9fSwiZXhhbXBsZXMiOlt7Im5hbWUiOiJ0ZXN0Iiwic3VtbWFyeSI6InRlc3Qgc3VtbWFyeSIsInBheWxvYWQiOnsidGVzdCI6dHJ1ZX19XSwieC10ZXN0IjoidGVzdGluZyJ9');
+      expect(d.uid()).to.be.equal('eyJzY2hlbWFGb3JtYXQiOiJteVNjaGVtYSIsImhlYWRlcnMiOnsicHJvcGVydGllcyI6eyJ0ZXN0MSI6eyJ0eXBlIjoic3RyaW5nIn0sInRlc3QyIjp7InR5cGUiOiJudW1iZXIifX19LCJwYXlsb2FkIjp7InRlc3QiOnRydWV9LCJ4LXBhcnNlci1vcmlnaW5hbC1wYXlsb2FkIjp7InRlc3RpbmciOnRydWV9LCJjb3JyZWxhdGlvbklkIjp7InRlc3QiOnRydWV9LCJ4LXBhcnNlci1vcmlnaW5hbC1zY2hlbWEtZm9ybWF0IjoiYXBwbGljYXRpb24vdm5kLmFwYWNoZS5hdnJvO3ZlcnNpb249MS45LjAiLCJjb250ZW50VHlwZSI6ImFwcGxpY2F0aW9uL2pzb24iLCJ0aXRsZSI6IlRlc3QiLCJzdW1tYXJ5IjoidGVzdCIsImRlc2NyaXB0aW9uIjoidGVzdGluZyIsImV4dGVybmFsRG9jcyI6eyJ0ZXN0Ijp0cnVlfSwidGFncyI6W3sibmFtZSI6InRhZzEifV0sImJpbmRpbmdzIjp7ImFtcXAiOnsidGVzdCI6dHJ1ZX19LCJleGFtcGxlcyI6W3sibmFtZSI6InRlc3QiLCJzdW1tYXJ5IjoidGVzdCBzdW1tYXJ5IiwicGF5bG9hZCI6eyJ0ZXN0Ijp0cnVlfX1dLCJ4LXRlc3QiOiJ0ZXN0aW5nIn0=');
     });
   });
   
@@ -70,7 +70,7 @@ describe('Message', function() {
   describe('#schemaFormat()', function() {
     it('should return a string', function() {
       const d = new Message(js);
-      expect(d.schemaFormat()).to.equal('application/schema+json;version=draft-07');
+      expect(d.schemaFormat()).to.equal('mySchema');
     });
   });
 

--- a/test/parse_test.js
+++ b/test/parse_test.js
@@ -663,4 +663,12 @@ describe('registerSchemaParser()', function() {
       parser.registerSchemaParser(parserModule);
     }, expectedErrorObject);
   });
+
+  it('should show that for 2.0 default schema format is 2.0 and for 2.1 it is 2.1', async function() {
+    const result20 = await parser.parse(inputYAML, { path: __filename });
+    const result21 = await parser.parse(fs.readFileSync(path.resolve(__dirname, './good/asyncapi-messages-example.yml'), 'utf8'), { path: __filename });
+    console.log(result20.channel('mychannel').publish().messages()[0]._json);
+    expect(result20.channel('mychannel').publish().messages()[0].schemaFormat()).to.equal('application/vnd.aai.asyncapi;version=2.0.0');
+    expect(result21.channel('myChannel').subscribe().messages()[0].schemaFormat()).to.equal('application/vnd.aai.asyncapi;version=2.1.0');
+  });
 });

--- a/test/wrong/invalid-asyncapi-messages-example.yml
+++ b/test/wrong/invalid-asyncapi-messages-example.yml
@@ -1,4 +1,4 @@
-asyncapi: 2.0.0
+asyncapi: 2.1.0
 info:
   title: My API
   version: '1.0.0'


### PR DESCRIPTION
I had to make fixes to PR from Laurent as like in case of `asyncapi-node` I did not notice changes were against 2.1

anyway, I'm confused about one thing, should these be changed too?:
- https://github.com/asyncapi/parser-js/blob/master/lib/parser.js#L12
- https://github.com/asyncapi/parser-js/blob/master/lib/asyncapiSchemaFormatParser.js#L44-L51

or should now the default schema depend on the version of the spec user uses, so if 2.0 then 2.0 and if 2.1 then 2.1?

Thoughts?