### PR TITLE
fix: specify arguments with ParserOptions type as optionals

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -40,7 +40,7 @@ module.exports = {
  * Parses and validate an AsyncAPI document from YAML or JSON.
  * 
  * @param {(String | Object)} asyncapiYAMLorJSON An AsyncAPI document in JSON or YAML format.
- * @param {ParserOptions} options Configuration options object {@link ParserOptions}
+ * @param {ParserOptions=} options Configuration options object {@link ParserOptions}
  * @returns {Promise<AsyncAPIDocument>} The parsed AsyncAPI document.
  */
 async function parse(asyncapiYAMLorJSON, options = {}) {
@@ -122,8 +122,8 @@ async function parse(asyncapiYAMLorJSON, options = {}) {
  * Fetches an AsyncAPI document from the given URL and passes its content to the `parse` method.
  * 
  * @param {String} url URL where the AsyncAPI document is located.
- * @param {Object} [fetchOptions] Configuration to pass to the {@link https://developer.mozilla.org/en-US/docs/Web/API/Request|fetch} call.
- * @param {ParserOptions} [options] Configuration to pass to the {@link ParserOptions} method.
+ * @param {Object=} [fetchOptions] Configuration to pass to the {@link https://developer.mozilla.org/en-US/docs/Web/API/Request|fetch} call.
+ * @param {ParserOptions=} [options] Configuration to pass to the {@link ParserOptions} method.
  * @returns {Promise<AsyncAPIDocument>} The parsed AsyncAPI document.
  */
 function parseFromUrl(url, fetchOptions, options) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Specify (in TS types) arguments with ParserOptions type as optionals.

![image](https://user-images.githubusercontent.com/20404945/131840132-a7bb4eb9-ccea-483c-81e8-c169d218750d.png)

**Related issue(s)**
Fix #350 