### PR TITLE
feat: added servers field to channel object

### DIFF
--- a/lib/customValidators.js
+++ b/lib/customValidators.js
@@ -5,7 +5,8 @@ const {
   groupValidationErrors,
   tilde,
   parseUrlQueryParameters,
-  setNotProvidedParams
+  setNotProvidedParams,
+  getUnknownServers
 } = require('./utils');
 const validationError = 'validation-errors';
 
@@ -298,7 +299,8 @@ function isSrvrSecProperArray(schemaType, specialSecTypes, secObj, secName) {
 }
 
 /**
- * Validates if parameters specified in the channel have corresponding parameters object defined and if name does not contain url parameters
+ * Validates if parameters specified in the channel have corresponding parameters object defined and if name does not contain url parameters.
+ * Also validates that all servers listed for this channel are declared in the top-level servers object.
  *
  * @private
  * @param  {Object} parsedJSON parsed AsyncAPI document
@@ -313,11 +315,13 @@ function validateChannels(parsedJSON, asyncapiYAMLorJSON, initialFormat) {
   const chnlsMap = new Map(Object.entries(chnls));
   const notProvidedParams = new Map(); //return object for missing parameters
   const invalidChannelName = new Map(); //return object for invalid channel names with query parameters
+  const unknownServers = new Map(); //return object for server names not declared in top-level servers object
 
   chnlsMap.forEach((val, key) => {
     const variables = parseUrlVariables(key);
     const notProvidedChannelParams = notProvidedParams.get(tilde(key));
     const queryParameters = parseUrlQueryParameters(key);
+    const unknownServerNames = getUnknownServers(parsedJSON, val);
 
     //channel variable validation: fill return obeject with missing parameters
     if (variables) {
@@ -333,6 +337,11 @@ function validateChannels(parsedJSON, asyncapiYAMLorJSON, initialFormat) {
     //channel name validation: fill return object with channels containing query parameters
     if (queryParameters) {
       invalidChannelName.set(tilde(key), queryParameters);
+    }
+
+    //server validatoin: fill return object with unknown server names
+    if (unknownServerNames.length > 0) {
+      unknownServers.set(tilde(key), unknownServerNames);
     }
   });
 
@@ -351,12 +360,17 @@ function validateChannels(parsedJSON, asyncapiYAMLorJSON, initialFormat) {
     asyncapiYAMLorJSON,
     initialFormat
   );
-  const allValidationErrors = parameterValidationErrors.concat(
-    nameValidationErrors
+  const serverValidationErrors = groupValidationErrors(
+    'channels',
+    'channel does not have a corresponding server object for',
+    unknownServers,
+    asyncapiYAMLorJSON,
+    initialFormat
   );
+  const allValidationErrors = parameterValidationErrors.concat(nameValidationErrors).concat(serverValidationErrors);
 
   //channel variable validation: throw exception if channel validation failes
-  if (notProvidedParams.size || invalidChannelName.size) {
+  if (notProvidedParams.size || invalidChannelName.size || unknownServers.size) {
     throw new ParserError({
       type: validationError,
       title: 'Channel validation failed',

--- a/lib/customValidators.js
+++ b/lib/customValidators.js
@@ -362,7 +362,7 @@ function validateChannels(parsedJSON, asyncapiYAMLorJSON, initialFormat) {
   );
   const serverValidationErrors = groupValidationErrors(
     'channels',
-    'channel does not have a corresponding server object for',
+    'channel is defined for servers that are not defined in the document',
     unknownServers,
     asyncapiYAMLorJSON,
     initialFormat

--- a/lib/models/channel.js
+++ b/lib/models/channel.js
@@ -43,6 +43,31 @@ class Channel extends Base {
   }
 
   /**
+   * @returns {boolean}
+   */
+  hasServers() {
+    return !!this._json.servers;
+  }
+
+  /**
+   * @returns {String[]}
+   */
+  servers() {
+    if (!this._json.servers) return [];
+    return this._json.servers;
+  }
+
+  /**
+   * @returns {String}
+   */
+  server(index) {
+    if (!this._json.servers) return null;
+    if (typeof index !== 'number') return null;
+    if (index > this._json.servers.length - 1) return null;
+    return this._json.servers[+index];
+  }
+
+  /**
    * @returns {PublishOperation}
    */
   publish() {

--- a/lib/models/channel.js
+++ b/lib/models/channel.js
@@ -58,6 +58,7 @@ class Channel extends Base {
   }
 
   /**
+   * @param {number} index - Index of the server.
    * @returns {String}
    */
   server(index) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -289,7 +289,7 @@ utils.setNotProvidedParams = (variables, val, key, notProvidedChannelParams, not
  * Returns an array of server names listed in a channel's servers list that are not declared in the top-level servers object.
  * 
  * @param {Map} parsedJSON the parsed AsyncAPI document, with potentially a top-level map of servers (keys are server names)
- * @param {Array<String>} channel the channel object for which to validate the servers list (array elements are server names)
+ * @param {Object} channel the channel object for which to validate the servers list (array elements are server names)
  * @private
  */
 utils.getUnknownServers = (parsedJSON, channel) => {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -29,7 +29,7 @@ const findNodeInAST = (ast, location) => {
     if (!Array.isArray(obj.children)) return;
     let childArray;
 
-    const child = obj.children.find(c => {    
+    const child = obj.children.find(c => {
       if (!c) return;
 
       if (c.type === 'Object') return childArray = c.children.find(a => a.key.value === utils.untilde(key));
@@ -44,7 +44,7 @@ const findNodeInAST = (ast, location) => {
 
 const findLocationOf = (keys, ast, initialFormat) => {
   if (initialFormat === 'js') return { jsonPointer: `/${keys.join('/')}` };
-  
+
   let node;
   if (initialFormat === 'yaml') {
     node = findNode(ast, keys);
@@ -111,7 +111,7 @@ utils.toJS = (asyncapiYAMLorJSON) => {
       parsedJSON: asyncapiYAMLorJSON,
     };
   }
-  
+
   if (typeof asyncapiYAMLorJSON !== 'string') {
     throw new ParserError({
       type: 'invalid-document-type',
@@ -205,7 +205,7 @@ utils.improveAjvErrors = (errors, asyncapiYAMLorJSON, initialFormat) => {
 utils.parseUrlVariables = str => {
   if (typeof str !== 'string') return;
 
-  return str.match(/{(.+?)}/g); 
+  return str.match(/{(.+?)}/g);
 };
 
 /**
@@ -215,8 +215,8 @@ utils.parseUrlVariables = str => {
  */
 utils.parseUrlQueryParameters = str => {
   if (typeof str !== 'string') return;
-  
-  return str.match(/\?((.*=.*)(&?))/g); 
+
+  return str.match(/\?((.*=.*)(&?))/g);
 };
 
 /**
@@ -228,7 +228,7 @@ utils.getMissingProps = (arr, obj) => {
   arr = arr.map(val => val.replace(/[{}]/g, ''));
 
   if (!obj) return arr;
-  
+
   return arr.filter(val => {
     return !obj.hasOwnProperty(val);
   });
@@ -283,6 +283,30 @@ utils.setNotProvidedParams = (variables, val, key, notProvidedChannelParams, not
         ? notProvidedChannelParams.concat(missingChannelParams)
         : missingChannelParams);
   }
+};
+
+/**
+ * Returns an array of server names listed in a channel's servers list that are not declared in the top-level servers object.
+ * 
+ * @param {Map} parsedJSON the parsed AsyncAPI document, with potentially a top-level map of servers (keys are server names)
+ * @param {Array<String>} channel the channel object for which to validate the servers list (array elements are server names)
+ * @private
+ */
+utils.getUnknownServers = (parsedJSON, channel) => {
+  // servers list on channel
+  if (!channel) return []; // no channel: no unknown servers
+  const channelServers = channel.servers;
+  if (!channelServers || channelServers.length === 0) return []; // no servers listed on channel: no unknown servers
+
+  // top-level servers map
+  const servers = parsedJSON.servers;
+  if (!servers) return channelServers; // servers list on channel but no top-level servers: all servers are unknown
+  const serversMap = new Map(Object.entries(servers));
+
+  // retain only servers listed on channel that are not defined in the top-level servers map
+  return channelServers.filter(serverName => {
+    return !serversMap.has(serverName);
+  });
 };
 
 /**

--- a/test/customValidators_test.js
+++ b/test/customValidators_test.js
@@ -882,7 +882,7 @@ describe('validateChannel()', function () {
       validationErrors: [
         {
           title:
-            'jmsQueue channel does not have a corresponding server object for: unknownServer',
+            'jmsQueue channel is defined for servers that are not defined in the document: unknownServer',
           location: {
             endColumn: 11,
             endLine: 15,

--- a/test/customValidators_test.js
+++ b/test/customValidators_test.js
@@ -254,7 +254,7 @@ describe('validateServerVariables()', function () {
 
     checkErrorWrapper(() => {
       validateServerVariables(parsedInput, inputString, input);
-    } ,expectedErrorObject);
+    }, expectedErrorObject);
   });
 
   // server with a variable that has more than one example and only one of them match enum list,
@@ -831,7 +831,77 @@ describe('validateChannel()', function () {
       validateChannels(parsedInput, inputString, input);
     }, expectedErrorObject);
   });
+
+  it('should successfully validate channel with servers that are all declared in servers object', async function () {
+    const inputString = `{
+      "servers": {
+        "server1": {
+          "url": "http://localhost",
+          "protocol": "kafka"
+        },
+        "server2": {
+          "url": "http://test.org",
+          "protocol": "jms"
+        }
+      },
+      "channels": {
+        "jmsQueue": {
+          "servers": ["server2"]
+        }
+      }
+    }`;
+    const parsedInput = JSON.parse(inputString);
+
+    expect(validateChannels(parsedInput, inputString, input)).to.equal(true);
+  });
+
+  it('should throw error that servers list references an unknown server', async function () {
+    const inputString = `{
+      "servers": {
+        "server1": {
+          "url": "http://localhost",
+          "protocol": "kafka"
+        },
+        "server2": {
+          "url": "http://test.org",
+          "protocol": "jms"
+        }
+      },
+      "channels": {
+        "jmsQueue": {
+          "servers": ["server2", "unknownServer"]
+        }
+      }
+    }`;
+    const parsedInput = JSON.parse(inputString);
+
+    const expectedErrorObject = {
+      type: 'https://github.com/asyncapi/parser-js/validation-errors',
+      title: 'Channel validation failed',
+      parsedJSON: parsedInput,
+      validationErrors: [
+        {
+          title:
+            'jmsQueue channel does not have a corresponding server object for: unknownServer',
+          location: {
+            endColumn: 11,
+            endLine: 15,
+            endOffset: 325,
+            jsonPointer: '/channels/jmsQueue',
+            startColumn: 22,
+            startLine: 13,
+            startOffset: 264,
+          }
+        }
+      ]
+    };
+
+    await checkErrorWrapper(async () => {
+      await validateChannels(parsedInput, inputString, input);
+    }, expectedErrorObject);
+  });
 });
+
 describe('validateOperationId()', function () {
   const operations = ['subscribe', 'publish'];
 

--- a/test/models/channel_test.js
+++ b/test/models/channel_test.js
@@ -10,9 +10,9 @@ const { assertMixinBindingsInheritance } = require('../mixins/bindings_test');
 const { assertMixinSpecificationExtensionsInheritance } = require('../mixins/specification-extensions_test');
 const { isString } = require('lodash');
 
-describe('Channel', function () {
-  describe('#hasParameters()', function () {
-    it('should return a boolean indicating if the AsyncAPI document has channel parameters', function () {
+describe('Channel', function() {
+  describe('#hasParameters()', function() {
+    it('should return a boolean indicating if the AsyncAPI document has channel parameters', function() {
       const doc = { parameters: { test1param: { description: 'test1param' } } };
       const docNoChannelParams = { description: 'test' };
       const d = new Channel(doc);
@@ -22,8 +22,8 @@ describe('Channel', function () {
     });
   });
 
-  describe('#parameters()', function () {
-    it('should return a map of ChannelParameter objects', function () {
+  describe('#parameters()', function() {
+    it('should return a map of ChannelParameter objects', function() {
       const d = new Channel(js);
       expect(typeof d.parameters()).to.be.equal('object');
       expect(d.parameters().param1.constructor.name).to.equal('ChannelParameter');
@@ -31,16 +31,16 @@ describe('Channel', function () {
     });
   });
 
-  describe('#parameter()', function () {
-    it('should return a specific ChannelParameter object', function () {
+  describe('#parameter()', function() {
+    it('should return a specific ChannelParameter object', function() {
       const d = new Channel(js);
       expect(d.parameter('param1').constructor.name).to.be.equal('ChannelParameter');
       expect(d.parameter('param1').json()).to.equal(js.parameters.param1);
     });
   });
 
-  describe('#hasServers()', function () {
-    it('should return a boolean indicating if the channel has a servers list', function () {
+  describe('#hasServers()', function() {
+    it('should return a boolean indicating if the channel has a servers list', function() {
       const d1 = new Channel(jsWithServers);
       const d2 = new Channel(jsWithoutServers);
       expect(d1.hasServers()).to.equal(true);
@@ -48,8 +48,8 @@ describe('Channel', function () {
     });
   });
 
-  describe('#servers()', function () {
-    it('should return an array of String server names or an empty array', function () {
+  describe('#servers()', function() {
+    it('should return an array of String server names or an empty array', function() {
       const d1 = new Channel(jsWithServers);
       const d2 = new Channel(jsWithoutServers);
       expect(Array.isArray(d1.servers())).to.equal(true);
@@ -62,34 +62,34 @@ describe('Channel', function () {
     });
   });
 
-  describe('#server()', function () {
-    it('should return null if the channel doesn\'t have servers', function () {
+  describe('#server()', function() {
+    it('should return null if the channel doesn\'t have servers', function() {
       const d = new Channel(jsWithoutServers);
       expect(d.server()).to.be.equal(null);
     });
 
-    it('should return a specific server String name', function () {
+    it('should return a specific server String name', function() {
       const d = new Channel(jsWithServers);
       jsWithServers.servers.forEach((s, i) => {
         expect(d.server(i)).to.equal(s);
       });
     });
 
-    it('should return null when index is out of bounds', function () {
+    it('should return null when index is out of bounds', function() {
       const d1 = new Channel(jsWithServers);
       const d2 = new Channel(jsWithoutServers);
       expect(d1.server(100)).to.equal(null);
       expect(d2.server(1)).to.equal(null);
     });
 
-    it('should return null if index is not a number', function () {
+    it('should return null if index is not a number', function() {
       const d = new Channel(jsWithServers);
       expect(d.server('0')).to.equal(null);
     });
   });
 
-  describe('#publish()', function () {
-    it('should return a PublishOperation object', function () {
+  describe('#publish()', function() {
+    it('should return a PublishOperation object', function() {
       const jsWithPub = { publish: { description: 'pub' } };
       const d = new Channel(jsWithPub);
       expect(d.publish().constructor.name).to.be.equal('PublishOperation');
@@ -97,8 +97,8 @@ describe('Channel', function () {
     });
   });
 
-  describe('#subscribe()', function () {
-    it('should return a SubscribeOperation object', function () {
+  describe('#subscribe()', function() {
+    it('should return a SubscribeOperation object', function() {
       const jsWithSub = { subscribe: { description: 'sub' } };
       const d = new Channel(jsWithSub);
       expect(d.subscribe().constructor.name).to.be.equal('SubscribeOperation');
@@ -106,8 +106,8 @@ describe('Channel', function () {
     });
   });
 
-  describe('#hasPublish()', function () {
-    it('should return true if the channel contains the publish operation', function () {
+  describe('#hasPublish()', function() {
+    it('should return true if the channel contains the publish operation', function() {
       const d = new Channel({ publish: { description: 'pub' } });
       expect(d.hasPublish()).to.be.equal(true);
       const d2 = new Channel({ subscribe: { description: 'sub' } });
@@ -115,8 +115,8 @@ describe('Channel', function () {
     });
   });
 
-  describe('#hasSubscribe()', function () {
-    it('should return true if the channel contains the publish operation', function () {
+  describe('#hasSubscribe()', function() {
+    it('should return true if the channel contains the publish operation', function() {
       const d = new Channel({ publish: { description: 'pub' } });
       expect(d.hasSubscribe()).to.be.equal(false);
       const d2 = new Channel({ subscribe: { description: 'sub' } });
@@ -124,8 +124,8 @@ describe('Channel', function () {
     });
   });
 
-  describe('#mixins', function () {
-    it('model should inherit from mixins', function () {
+  describe('#mixins', function() {
+    it('model should inherit from mixins', function() {
       assertMixinDescriptionInheritance(Channel);
       assertMixinBindingsInheritance(Channel);
       assertMixinSpecificationExtensionsInheritance(Channel);

--- a/test/models/channel_test.js
+++ b/test/models/channel_test.js
@@ -1,15 +1,18 @@
 const { expect } = require('chai');
 const js = { description: 'test', parameters: { param1: { description: 'param1', location: '$message.headers#/x-param1', schema: { type: 'string' } } }, bindings: { amqp: 'test' }, 'x-test': 'testing' };
+const jsWithServers = { description: 'channel with servers', servers: ['server1', 'server2'] };
+const jsWithoutServers = { description: 'channel without servers' };
 
 const Channel = require('../../lib/models/channel');
 
 const { assertMixinDescriptionInheritance } = require('../mixins/description_test');
 const { assertMixinBindingsInheritance } = require('../mixins/bindings_test');
 const { assertMixinSpecificationExtensionsInheritance } = require('../mixins/specification-extensions_test');
+const { isString } = require('lodash');
 
-describe('Channel', function() {  
-  describe('#hasParameters()', function() {
-    it('should return a boolean indicating if the AsyncAPI document has channel parameters', function() {
+describe('Channel', function () {
+  describe('#hasParameters()', function () {
+    it('should return a boolean indicating if the AsyncAPI document has channel parameters', function () {
       const doc = { parameters: { test1param: { description: 'test1param' } } };
       const docNoChannelParams = { description: 'test' };
       const d = new Channel(doc);
@@ -19,52 +22,101 @@ describe('Channel', function() {
     });
   });
 
-  describe('#parameters()', function() {
-    it('should return a map of ChannelParameter objects', function() {
+  describe('#parameters()', function () {
+    it('should return a map of ChannelParameter objects', function () {
       const d = new Channel(js);
       expect(typeof d.parameters()).to.be.equal('object');
       expect(d.parameters().param1.constructor.name).to.equal('ChannelParameter');
       expect(d.parameters().param1.json()).to.equal(js.parameters.param1);
     });
   });
-   
-  describe('#parameter()', function() {
-    it('should return a specific ChannelParameter object', function() {
+
+  describe('#parameter()', function () {
+    it('should return a specific ChannelParameter object', function () {
       const d = new Channel(js);
       expect(d.parameter('param1').constructor.name).to.be.equal('ChannelParameter');
       expect(d.parameter('param1').json()).to.equal(js.parameters.param1);
     });
   });
-  
-  describe('#publish()', function() {
-    it('should return a PublishOperation object', function() {
+
+  describe('#hasServers()', function () {
+    it('should return a boolean indicating if the channel has a servers list', function () {
+      const d1 = new Channel(jsWithServers);
+      const d2 = new Channel(jsWithoutServers);
+      expect(d1.hasServers()).to.equal(true);
+      expect(d2.hasServers()).to.equal(false);
+    });
+  });
+
+  describe('#servers()', function () {
+    it('should return an array of String server names or an empty array', function () {
+      const d1 = new Channel(jsWithServers);
+      const d2 = new Channel(jsWithoutServers);
+      expect(Array.isArray(d1.servers())).to.equal(true);
+      expect(Array.isArray(d2.servers())).to.equal(true);
+      d1.servers().forEach((s, i) => {
+        expect(isString(s)).to.equal(true);
+        expect(s).to.equal(jsWithServers.servers[i]);
+      });
+      expect(d2.servers().length).to.equal(0);
+    });
+  });
+
+  describe('#server()', function () {
+    it('should return null if the channel doesn\'t have servers', function () {
+      const d = new Channel(jsWithoutServers);
+      expect(d.server()).to.be.equal(null);
+    });
+
+    it('should return a specific server String name', function () {
+      const d = new Channel(jsWithServers);
+      jsWithServers.servers.forEach((s, i) => {
+        expect(d.server(i)).to.equal(s);
+      });
+    });
+
+    it('should return null when index is out of bounds', function () {
+      const d1 = new Channel(jsWithServers);
+      const d2 = new Channel(jsWithoutServers);
+      expect(d1.server(100)).to.equal(null);
+      expect(d2.server(1)).to.equal(null);
+    });
+
+    it('should return null if index is not a number', function () {
+      const d = new Channel(jsWithServers);
+      expect(d.server('0')).to.equal(null);
+    });
+  });
+
+  describe('#publish()', function () {
+    it('should return a PublishOperation object', function () {
       const jsWithPub = { publish: { description: 'pub' } };
       const d = new Channel(jsWithPub);
       expect(d.publish().constructor.name).to.be.equal('PublishOperation');
       expect(d.publish().json()).to.equal(jsWithPub.publish);
     });
   });
-  
-  describe('#subscribe()', function() {
-    it('should return a SubscribeOperation object', function() {
+
+  describe('#subscribe()', function () {
+    it('should return a SubscribeOperation object', function () {
       const jsWithSub = { subscribe: { description: 'sub' } };
       const d = new Channel(jsWithSub);
       expect(d.subscribe().constructor.name).to.be.equal('SubscribeOperation');
       expect(d.subscribe().json()).to.equal(jsWithSub.subscribe);
     });
   });
-   
-  describe('#hasPublish()', function() {
-    it('should return true if the channel contains the publish operation', function() {
+
+  describe('#hasPublish()', function () {
+    it('should return true if the channel contains the publish operation', function () {
       const d = new Channel({ publish: { description: 'pub' } });
       expect(d.hasPublish()).to.be.equal(true);
       const d2 = new Channel({ subscribe: { description: 'sub' } });
       expect(d2.hasPublish()).to.be.equal(false);
     });
   });
-  
-  describe('#hasSubscribe()', function() {
-    it('should return true if the channel contains the publish operation', function() {
+
+  describe('#hasSubscribe()', function () {
+    it('should return true if the channel contains the publish operation', function () {
       const d = new Channel({ publish: { description: 'pub' } });
       expect(d.hasSubscribe()).to.be.equal(false);
       const d2 = new Channel({ subscribe: { description: 'sub' } });
@@ -72,8 +124,8 @@ describe('Channel', function() {
     });
   });
 
-  describe('#mixins', function() {
-    it('model should inherit from mixins', function() {
+  describe('#mixins', function () {
+    it('model should inherit from mixins', function () {
       assertMixinDescriptionInheritance(Channel);
       assertMixinBindingsInheritance(Channel);
       assertMixinSpecificationExtensionsInheritance(Channel);

--- a/test/models/channel_test.js
+++ b/test/models/channel_test.js
@@ -49,16 +49,19 @@ describe('Channel', function() {
   });
 
   describe('#servers()', function() {
-    it('should return an array of String server names or an empty array', function() {
-      const d1 = new Channel(jsWithServers);
-      const d2 = new Channel(jsWithoutServers);
-      expect(Array.isArray(d1.servers())).to.equal(true);
-      expect(Array.isArray(d2.servers())).to.equal(true);
-      d1.servers().forEach((s, i) => {
+    it('should return an array of String server names if the channel has a servers list', function() {
+      const d = new Channel(jsWithServers);
+      expect(Array.isArray(d.servers())).to.equal(true);
+      d.servers().forEach((s, i) => {
         expect(isString(s)).to.equal(true);
         expect(s).to.equal(jsWithServers.servers[i]);
       });
-      expect(d2.servers().length).to.equal(0);
+    });
+
+    it('should return an empty array if the channel doesn\'t have servers', function() {
+      const d = new Channel(jsWithoutServers);
+      expect(Array.isArray(d.servers())).to.equal(true);
+      expect(d.servers().length).to.equal(0);
     });
   });
 


### PR DESCRIPTION
**Description**

JS parser changes to support a new `servers` field on the `channel` object.

Relates to PR https://github.com/asyncapi/spec/pull/531

**Related issue(s)**

https://github.com/asyncapi/spec/issues/244
https://github.com/asyncapi/spec/issues/255
https://github.com/asyncapi/spec/issues/475
