### PR TITLE
fix: type of json() method

### DIFF
--- a/lib/models/base.js
+++ b/lib/models/base.js
@@ -13,6 +13,7 @@ class Base {
   }
 
   /**
+   * @param {string} [key] A key to retrieve from the JSON object.
    * @returns {any}
    */
   json(key) {

--- a/types.d.ts
+++ b/types.d.ts
@@ -288,7 +288,7 @@ declare module "@asyncapi/parser" {
      */
     type TraverseSchemas = (schema: Schema, propName: string, callbackType: SchemaIteratorCallbackType) => boolean;
     class Base {
-        json(key?: string): any;
+        json(): any;
     }
     interface ChannelParameter extends MixinDescription, MixinSpecificationExtensions {
     }

--- a/types.d.ts
+++ b/types.d.ts
@@ -288,7 +288,7 @@ declare module "@asyncapi/parser" {
      */
     type TraverseSchemas = (schema: Schema, propName: string, callbackType: SchemaIteratorCallbackType) => boolean;
     class Base {
-        json(key: string): any;
+        json(key?: string): any;
     }
     interface ChannelParameter extends MixinDescription, MixinSpecificationExtensions {
     }

--- a/types.d.ts
+++ b/types.d.ts
@@ -288,7 +288,7 @@ declare module "@asyncapi/parser" {
      */
     type TraverseSchemas = (schema: Schema, propName: string, callbackType: SchemaIteratorCallbackType) => boolean;
     class Base {
-        json(): any;
+        json(key: string): any;
     }
     interface ChannelParameter extends MixinDescription, MixinSpecificationExtensions {
     }


### PR DESCRIPTION
**Description**

The `json()` method accepts an optional `key` argument. I'm fixing the TypeScript type definition.
