### PR TITLE
feat: update specs dependency to use release candidate with solace binding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,11 +6,11 @@
   "packages": {
     "": {
       "name": "@asyncapi/parser",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
-        "@asyncapi/specs": "^2.11.0",
+        "@asyncapi/specs": "2.13.0-2022-01-release.1",
         "@fmvilas/pseudo-yaml-ast": "^0.3.1",
         "ajv": "^6.10.1",
         "js-yaml": "^3.13.1",
@@ -58,9 +58,9 @@
       }
     },
     "node_modules/@asyncapi/specs": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.11.0.tgz",
-      "integrity": "sha512-H2GNlAgrI9TZGWdlTUit4Ue7YFCTmELY1vMmDtgNTsFtpWQOTRf6NlTcItagrKHSo7zh6gnyhGLQCFC/rSfjUg=="
+      "version": "2.13.0-2022-01-release.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.13.0-2022-01-release.1.tgz",
+      "integrity": "sha512-I9nqLGszgn1mjbUwy6vltEUrKO2N3tueRCGVpOyRNjbotbGQ1jry/FGwa8MXgZn+zYHRp1ZGOwSn+NPNZLbayA=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.8.3",
@@ -11688,7 +11688,7 @@
       }
     },
     "node_modules/npm/node_modules/yargs/node_modules/y18n": {
-      "version": "3.2.1",
+      "version": "3.2.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
@@ -15639,9 +15639,9 @@
       }
     },
     "@asyncapi/specs": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.11.0.tgz",
-      "integrity": "sha512-H2GNlAgrI9TZGWdlTUit4Ue7YFCTmELY1vMmDtgNTsFtpWQOTRf6NlTcItagrKHSo7zh6gnyhGLQCFC/rSfjUg=="
+      "version": "2.13.0-2022-01-release.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.13.0-2022-01-release.1.tgz",
+      "integrity": "sha512-I9nqLGszgn1mjbUwy6vltEUrKO2N3tueRCGVpOyRNjbotbGQ1jry/FGwa8MXgZn+zYHRp1ZGOwSn+NPNZLbayA=="
     },
     "@babel/code-frame": {
       "version": "7.8.3",
@@ -24859,7 +24859,7 @@
           },
           "dependencies": {
             "y18n": {
-              "version": "3.2.1",
+              "version": "3.2.2",
               "bundled": true,
               "dev": true
             }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.0.6",
-    "@asyncapi/specs": "^2.11.0",
+    "@asyncapi/specs": "2.13.0-2022-01-release.1",
     "@fmvilas/pseudo-yaml-ast": "^0.3.1",
     "ajv": "^6.10.1",
     "js-yaml": "^3.13.1",


### PR DESCRIPTION

**Description**
This updates the asyncapi/specs dependency to 2.13.0-2022-01-release.1.

