### PR TITLE
fix: missing constructor type definition

### DIFF
--- a/lib/models/schema.js
+++ b/lib/models/schema.js
@@ -19,7 +19,12 @@ const MixinSpecificationExtensions = require('../mixins/specification-extensions
  */
 class Schema extends Base {
   /**
+   * Instantiates a schema object
+   *
    * @constructor
+   * @param {any} json Schema definition
+   * @param {Object=} options
+   * @param {Schema=} options.parent Parent schema definition
    */
   constructor(json, options) {
     super(json);

--- a/types.d.ts
+++ b/types.d.ts
@@ -835,9 +835,14 @@ declare module "@asyncapi/parser" {
     interface Schema extends MixinDescription, MixinExternalDocs, MixinSpecificationExtensions {
     }
     /**
-     * Implements functions to deal with a Schema object.
+     * Instantiates a schema object
+     * @param json - Schema definition
+     * @param [options.parent] - Parent schema definition
      */
     class Schema extends Base implements MixinDescription, MixinExternalDocs, MixinSpecificationExtensions {
+        constructor(json: any, options?: {
+            parent?: Schema;
+        });
         uid(): string;
         $id(): string;
         multipleOf(): number;


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
The `constructor` was missing in the `Schema` type definition. This PR adds the missing JSDoc annotation and adds it to the `types.d.ts`.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The 3rd option will not close the issue automatically after the merge. -->

Fixes #437 