### PR TITLE
feat: add security field at the operation level

### DIFF
--- a/API.md
+++ b/API.md
@@ -259,6 +259,7 @@
             * [.hasTraits()](#module_@asyncapi/parser+Operation+hasTraits) ⇒ <code>boolean</code>
             * [.messages()](#module_@asyncapi/parser+Operation+messages) ⇒ <code>Array.&lt;Message&gt;</code>
             * [.message()](#module_@asyncapi/parser+Operation+message) ⇒ <code>Message</code>
+        * [.OperationSecurityRequirement](#module_@asyncapi/parser+OperationSecurityRequirement) ⇐ <code>Base</code>
         * [.PublishOperation](#module_@asyncapi/parser+PublishOperation) ⇐ <code>Operation</code>
             * [.isPublish()](#module_@asyncapi/parser+PublishOperation+isPublish) ⇒ <code>boolean</code>
             * [.isSubscribe()](#module_@asyncapi/parser+PublishOperation+isSubscribe) ⇒ <code>boolean</code>
@@ -2079,6 +2080,7 @@ Implements functions to deal with an Operation object.
     * [.hasTraits()](#module_@asyncapi/parser+Operation+hasTraits) ⇒ <code>boolean</code>
     * [.messages()](#module_@asyncapi/parser+Operation+messages) ⇒ <code>Array.&lt;Message&gt;</code>
     * [.message()](#module_@asyncapi/parser+Operation+message) ⇒ <code>Message</code>
+    * [.security()](#module_@asyncapi/parser+Operation+security) ⇒ <code>Array.&lt;OperationSecurityRequirement&gt;</code>
 
 <a name="module_@asyncapi/parser+Operation+hasMultipleMessages"></a>
 
@@ -2099,6 +2101,10 @@ Implements functions to deal with an Operation object.
 <a name="module_@asyncapi/parser+Operation+message"></a>
 
 #### operation.message() ⇒ <code>Message</code>
+**Kind**: instance method of [<code>Operation</code>](#module_@asyncapi/parser+Operation)  
+<a name="module_@asyncapi/parser+Operation+security"></a>
+
+#### operation.security() ⇒ <code>Array.&lt;OperationSecurityRequirement&gt;</code>
 **Kind**: instance method of [<code>Operation</code>](#module_@asyncapi/parser+Operation)  
 <a name="module_@asyncapi/parser+PublishOperation"></a>
 

--- a/lib/models/operation-security-requirement.js
+++ b/lib/models/operation-security-requirement.js
@@ -1,0 +1,13 @@
+const Base = require('./base');
+
+/**
+ * Implements functions to deal with a OperationSecurityRequirement object.
+ * @class
+ * @alias module:@asyncapi/parser#OperationSecurityRequirement
+ * @extends Base
+ * @returns {OperationSecurityRequirement}
+ */
+class OperationSecurityRequirement extends Base {
+}
+
+module.exports = OperationSecurityRequirement;

--- a/lib/models/operation.js
+++ b/lib/models/operation.js
@@ -1,6 +1,7 @@
 const OperationTraitable = require('./operation-traitable');
 const Message = require('./message');
 const OperationTrait = require('./operation-trait');
+const OperationSecurityRequirement = require('./operation-security-requirement');
 
 /**
  * Implements functions to deal with an Operation object.
@@ -53,6 +54,14 @@ class Operation extends OperationTraitable {
     if (typeof index !== 'number') return null;
     if (index > this._json.message.oneOf.length - 1) return null;
     return new Message(this._json.message.oneOf[+index]);
+  }
+
+  /**
+ * @returns {OperationSecurityRequirement[]}
+ */
+  security() {
+    if (!this._json.security) return null;
+    return this._json.security.map(sec => new OperationSecurityRequirement(sec));
   }
 }
 

--- a/test/models/operation_test.js
+++ b/test/models/operation_test.js
@@ -1,5 +1,5 @@
 const { expect } = require('chai');
-const js = { summary: 't', description: 'test', traits: [{bindings: {kafka: {clientId: 'my-app-id'}}}], operationId: 'test', tags: [{name: 'tag1'}], externalDocs: { url: 'somewhere' }, bindings: { amqp: { test: true } }, message: { test: true }, 'x-test': 'testing' };
+const js = { summary: 't', description: 'test', traits: [{bindings: {kafka: {clientId: 'my-app-id'}}}], operationId: 'test', tags: [{name: 'tag1'}], externalDocs: { url: 'somewhere' }, bindings: { amqp: { test: true } }, message: { test: true }, 'x-test': 'testing', security: [{ oauth2: ['user:read'] }]};
 
 const Operation = require('../../lib/models/operation');
 
@@ -120,6 +120,17 @@ describe('Operation', function() {
       assertMixinTagsInheritance(Operation);
       assertMixinBindingsInheritance(Operation);
       assertMixinSpecificationExtensionsInheritance(Operation);
+    });
+  });
+
+  describe('#security()', function() {
+    it('should return an array of security requirements objects', function() {
+      const d = new Operation(js);
+      expect(Array.isArray(d.security())).to.equal(true);
+      d.security().forEach((s, i) => {
+        expect(s.constructor.name).to.equal('OperationSecurityRequirement');
+        expect(s.json()).to.equal(js.security[i]);
+      });
     });
   });
 });

--- a/types.d.ts
+++ b/types.d.ts
@@ -823,6 +823,12 @@ declare module "@asyncapi/parser" {
         hasTraits(): boolean;
         messages(): Message[];
         message(): Message;
+        security(): OperationSecurityRequirement[];
+    }
+    /**
+     * Implements functions to deal with a OperationSecurityRequirement object.
+    */
+    class OperationSecurityRequirement extends Base {
     }
     /**
      * Implements functions to deal with a PublishOperation object.


### PR DESCRIPTION
**Description**
We are using AsyncAPI specifications for publishing the subscriber specific details of our topics and associated payloads for our HTTP push use cases.

Our subscribable channels(or topics) are protected by a set of OAuth scopes (authorization code or client credentials) - that a potential subscriber needs to be aware of.

Here is a sample contract.

We are able to accommodate almost every detail of interest to an integrator/subscriber (THANK YOU) - with the exception of being able to call out the oauth scopes necessary for the subscription to the topic - i.e. the security aspect at the channel or rather channel/operation level.

The current specification is perhaps more aligned with a broker based topology - but ours is a pure push use case (to registered webhooks) and we need an ability to call out any security aspects at the channel operation level.

**Related issue(s)**
Resolves https://github.com/asyncapi/parser-js/issues/434