### PR TITLE
fix: export Schema model

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -8,6 +8,7 @@ const ParserError = require('./errors/parser-error');
 const { validateChannels, validateTags, validateServerVariables, validateOperationId, validateServerSecurity } = require('./customValidators.js');
 const { toJS, findRefs, getLocationOf, improveAjvErrors, getDefaultSchemaFormat } = require('./utils');
 const AsyncAPIDocument = require('./models/asyncapi');
+const Schema = require('./models/schema');
 
 const OPERATIONS = ['publish', 'subscribe'];
 //the only security types that can have a non empty array in the server security item
@@ -33,6 +34,7 @@ module.exports = {
   registerSchemaParser,
   ParserError,
   AsyncAPIDocument,
+  Schema,
 };
 
 /**


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
So far a `ts-ignore` and a direct import was necessary to make use of the Schema - like it is done in the [asyncapi-react](https://github.com/asyncapi/asyncapi-react/blob/next/library/src/components/__tests__/Schema.test.tsx#L8-L9) package. To get rid of this workaround, we have to export the `Schema`. This is done within this PR.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The 3rd option will not close the issue automatically after the merge. -->
- none