### PR TITLE
ci: set next-major branch as base branch for bump action

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   bump:
+    if: startsWith(github.event.commits[0].message, 'chore(release):')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -22,9 +23,9 @@ jobs:
       - name: Check if Node.js project and has package.json
         id: packagejson
         run: test -e ./package.json && echo "::set-output name=exists::true" || echo "::set-output name=exists::false"
-      - if: steps.packagejson.outputs.exists == 'true' && startsWith(github.event.commits[0].message, 'chore(release):')
+      - if: steps.packagejson.outputs.exists == 'true'
         name: Bumping latest version of this package in other repositories
-        uses: derberg/npm-dependency-manager-for-your-github-org@v3
+        uses: derberg/npm-dependency-manager-for-your-github-org@v4
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           committer_username: asyncapi-bot

--- a/.github/workflows/if-go-pr-testing.yml
+++ b/.github/workflows/if-go-pr-testing.yml
@@ -6,16 +6,21 @@ name: PR testing - if Go project
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
-
+    
 jobs:
   lint:
-    if: github.event.pull_request.draft == false
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - if: "github.event.pull_request.draft == false &&!((github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'ci: update global workflows')) || (github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'chore(release):')) || (github.actor == 'allcontributors' && startsWith(github.event.pull_request.title, 'docs: add')))"
+        id: should_run
+        name: Should Run
+        run: echo "::set-output name=shouldrun::true"
+      - if: steps.should_run.outputs.shouldrun == 'true' 
+        name: Checkout repository
         uses: actions/checkout@v2
-      - name: Check if Go project and has go.mod
+      - if: steps.should_run.outputs.shouldrun == 'true' 
+        name: Check if Go project and has go.mod
         id: gomod
         run: test -e ./go.mod && echo "::set-output name=exists::true" || echo "::set-output name=exists::false"
         shell: bash
@@ -31,16 +36,21 @@ jobs:
           skip-go-installation: true # we wanna control the version of Go in use
   
   test:
-    if: github.event.pull_request.draft == false
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - name: Checkout repository
+      - if: "github.event.pull_request.draft == false &&!((github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'ci: update global workflows')) || (github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'chore(release):')) || (github.actor == 'allcontributors' && startsWith(github.event.pull_request.title, 'docs: add')))"
+        id: should_run
+        name: Should Run
+        run: echo "::set-output name=shouldrun::true"
+      - if: steps.should_run.outputs.shouldrun == 'true' 
+        name: Checkout repository
         uses: actions/checkout@v2
-      - name: Check if Go project and has go.mod
+      - if: steps.should_run.outputs.shouldrun == 'true' 
+        name: Check if Go project and has go.mod
         id: gomod
         run: test -e ./go.mod && echo "::set-output name=exists::true" || echo "::set-output name=exists::false"
         shell: bash

--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -9,20 +9,26 @@ on:
 
 jobs:
   test:
-    if: github.event.pull_request.draft == false
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - name: Set git to use LF #to once and for all finish neverending fight between Unix and Windows
+      - if: "github.event.pull_request.draft == false &&!((github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'ci: update global workflows')) || (github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'chore(release):')) || (github.actor == 'allcontributors' && startsWith(github.event.pull_request.title, 'docs: add')))"
+        id: should_run
+        name: Should Run
+        run: echo "::set-output name=shouldrun::true"
+      - if: steps.should_run.outputs.shouldrun == 'true' 
+        name: Set git to use LF #to once and for all finish neverending fight between Unix and Windows
         run: |
           git config --global core.autocrlf false
           git config --global core.eol lf
-      - name: Checkout repository
+      - if: steps.should_run.outputs.shouldrun == 'true' 
+        name: Checkout repository
         uses: actions/checkout@v2
-      - name: Check if Node.js project and has package.json
+      - if: steps.should_run.outputs.shouldrun == 'true' 
+        name: Check if Node.js project and has package.json
         id: packagejson
         run: test -e ./package.json && echo "::set-output name=exists::true" || echo "::set-output name=exists::false"
         shell: bash

--- a/.github/workflows/notify-tsc-members-mention.yml
+++ b/.github/workflows/notify-tsc-members-mention.yml
@@ -1,0 +1,142 @@
+#This action is centrally managed in https://github.com/asyncapi/.github/
+#Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in above mentioned repo
+
+#This action notifies community on slack whenever there is a new issue, PR or discussion started in given repository
+name: Notify slack whenever TSC members are mentioned in GitHub
+
+on:
+    issue_comment:
+      types: 
+        - created
+        - edited
+        
+    discussion_comment:
+      types: 
+        - created
+        - edited
+        
+    issues:
+      types:
+        - opened
+        - reopened
+
+    pull_request_target:
+      types: 
+        - opened
+        - reopened
+        - ready_for_review
+
+    discussion:
+      types: 
+        - created
+        - edited
+
+jobs:
+
+    issue:
+      if: github.event_name == 'issues' && contains(github.event.issue.body, '@asyncapi/tsc_members')
+      name: On every new issue
+      runs-on: ubuntu-latest
+      steps:
+        - name: Convert markdown to slack markdown
+          uses: LoveToKnow/slackify-markdown-action@v1.0.0
+          id: issuemarkdown
+          with:
+            text: "[${{github.event.issue.title}}](${{github.event.issue.html_url}}) \n ${{github.event.issue.body}}"
+        - name: Send info about issue
+          uses: rtCamp/action-slack-notify@v2
+          env:
+            SLACK_WEBHOOK: ${{secrets.SLACK_TSC_MEMBERS_NOTIFY}}
+            SLACK_TITLE: 🆘 New issue that requires TSC Members attention 🆘
+            SLACK_MESSAGE: ${{steps.issuemarkdown.outputs.text}}
+            MSG_MINIMAL: true
+
+    pull_request:
+      if: github.event_name == 'pull_request_target' && contains(github.event.pull_request.body, '@asyncapi/tsc_members')
+      name: On every new pull request
+      runs-on: ubuntu-latest
+      steps:
+        - name: Convert markdown to slack markdown
+          uses: LoveToKnow/slackify-markdown-action@v1.0.0
+          id: prmarkdown
+          with:
+            text: "[${{github.event.pull_request.title}}](${{github.event.pull_request.html_url}}) \n ${{github.event.pull_request.body}}"
+        - name: Send info about pull request
+          uses: rtCamp/action-slack-notify@v2
+          env:
+            SLACK_WEBHOOK: ${{secrets.SLACK_TSC_MEMBERS_NOTIFY}}
+            SLACK_TITLE: 🆘 New PR that requires TSC Members attention 🆘
+            SLACK_MESSAGE: ${{steps.prmarkdown.outputs.text}}
+            MSG_MINIMAL: true
+    
+    discussion:
+      if: github.event_name == 'discussion' && contains(github.event.discussion.body, '@asyncapi/tsc_members')
+      name: On every new discussion
+      runs-on: ubuntu-latest
+      steps:
+        - name: Convert markdown to slack markdown
+          uses: LoveToKnow/slackify-markdown-action@v1.0.0
+          id: discussionmarkdown
+          with:
+            text: "[${{github.event.discussion.title}}](${{github.event.discussion.html_url}}) \n ${{github.event.discussion.body}}"
+        - name: Send info about pull request
+          uses: rtCamp/action-slack-notify@v2
+          env:
+            SLACK_WEBHOOK: ${{secrets.SLACK_TSC_MEMBERS_NOTIFY}}
+            SLACK_TITLE: 🆘 New discussion that requires TSC Members attention 🆘
+            SLACK_MESSAGE: ${{steps.discussionmarkdown.outputs.text}}
+            MSG_MINIMAL: true
+
+    issue_comment:
+      if: ${{ github.event_name == 'issue_comment' && !github.event.issue.pull_request && contains(github.event.comment.body, '@asyncapi/tsc_members') }}
+      name: On every new comment in issue
+      runs-on: ubuntu-latest
+      steps:
+        - name: Convert markdown to slack markdown
+          uses: LoveToKnow/slackify-markdown-action@v1.0.0
+          id: issuemarkdown
+          with:
+            text: "[${{github.event.issue.title}}](${{github.event.comment.html_url}}) \n ${{github.event.comment.body}}"
+        - name: Send info about issue comment
+          uses: rtCamp/action-slack-notify@v2
+          env:
+            SLACK_WEBHOOK: ${{secrets.SLACK_TSC_MEMBERS_NOTIFY}}
+            SLACK_TITLE: 🆘 New comment under existing issue that requires TSC Members attention 🆘
+            SLACK_MESSAGE: ${{steps.issuemarkdown.outputs.text}}
+            MSG_MINIMAL: true
+
+    pr_comment:
+      if: github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@asyncapi/tsc_members')
+      name: On every new comment in pr
+      runs-on: ubuntu-latest
+      steps:
+        - name: Convert markdown to slack markdown
+          uses: LoveToKnow/slackify-markdown-action@v1.0.0
+          id: prmarkdown
+          with:
+            text: "[${{github.event.issue.title}}](${{github.event.comment.html_url}}) \n ${{github.event.comment.body}}"
+        - name: Send info about PR comment
+          uses: rtCamp/action-slack-notify@v2
+          env:
+            SLACK_WEBHOOK: ${{secrets.SLACK_TSC_MEMBERS_NOTIFY}}
+            SLACK_TITLE: 🆘 New comment under existing PR that requires TSC Members attention 🆘
+            SLACK_MESSAGE: ${{steps.prmarkdown.outputs.text}}
+            MSG_MINIMAL: true
+
+    discussion_comment:
+      if: github.event_name == 'discussion_comment' && contains(github.event.comment.body, '@asyncapi/tsc_members')
+      name: On every new comment in discussion
+      runs-on: ubuntu-latest
+      steps:
+        - name: Convert markdown to slack markdown
+          uses: LoveToKnow/slackify-markdown-action@v1.0.0
+          id: discussionmarkdown
+          with:
+            text: "[${{github.event.discussion.title}}](${{github.event.comment.html_url}}) \n ${{github.event.comment.body}}"
+        - name: Send info about discussion comment
+          uses: rtCamp/action-slack-notify@v2
+          env:
+            SLACK_WEBHOOK: ${{secrets.SLACK_TSC_MEMBERS_NOTIFY}}
+            SLACK_TITLE: 🆘 New comment under existing discussion that requires TSC Members attention 🆘
+            SLACK_MESSAGE: ${{steps.discussionmarkdown.outputs.text}}
+            MSG_MINIMAL: true


### PR DESCRIPTION
**Description**

This PR changes the base branch for the bump action so it only applies to dependants of the`next-major` branch, a branch that was recently created to work on the next major version (https://github.com/asyncapi/parser-js/issues/401).

Note that the target branch is (and should be) `next-major`. 

**Related issue(s)**
https://github.com/asyncapi/parser-js/issues/401