### PR TITLE
refactor: add info and dependant models

### DIFF
--- a/src/models/asyncapi.ts
+++ b/src/models/asyncapi.ts
@@ -7,7 +7,6 @@ export class AsyncAPIDocument extends BaseModel {
     }
 
     info(): Info {
-        const doc = this.json("info");
-        return doc && new Info(doc);
+        return new Info(this.json("info"));
     }
 }

--- a/src/models/asyncapi.ts
+++ b/src/models/asyncapi.ts
@@ -1,3 +1,13 @@
 import { BaseModel } from "./base";
+import { Info } from "./info";
 
-export class AsyncAPIDocument extends BaseModel {}
+export class AsyncAPIDocument extends BaseModel {
+    version(): string {
+        return this.json("asyncapi");
+    }
+
+    info(): Info {
+        const doc = this.json("info");
+        return doc && new Info(doc);
+    }
+}

--- a/src/models/contact.ts
+++ b/src/models/contact.ts
@@ -1,0 +1,15 @@
+import { BaseModel } from "./base";
+
+export class Contact extends BaseModel {
+    name(): string {
+        return this.json("name");
+    }
+
+    url(): string {
+        return this.json("url");
+    }
+
+    email(): string {
+        return this.json("email");
+    }
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,2 +1,5 @@
 export * from './asyncapi';
 export * from './base';
+export * from './contact';
+export * from './info';
+export * from './license';

--- a/src/models/info.ts
+++ b/src/models/info.ts
@@ -19,12 +19,12 @@ export class Info extends BaseModel {
         return this.json("termsOfService");
     }
 
-    contact(): Contact {
+    contact(): Contact | undefined {
         const doc = this.json("contact");
         return doc && new Contact(doc);
     }
 
-    license(): License {
+    license(): License | undefined {
         const doc = this.json("license");
         return doc &&  new License(doc);
     }

--- a/src/models/info.ts
+++ b/src/models/info.ts
@@ -1,0 +1,31 @@
+import { BaseModel } from "./base";
+import { Contact } from "./contact";
+import { License } from "./license";
+
+export class Info extends BaseModel {
+    title(): string {
+        return this.json("title");
+    }
+
+    version(): string {
+        return this.json("version");
+    }
+
+    description(): string {
+        return this.json("description");
+    }
+
+    termsOfService(): string {
+        return this.json("termsOfService");
+    }
+
+    contact(): Contact {
+        const doc = this.json("contact");
+        return doc && new Contact(doc);
+    }
+
+    license(): License {
+        const doc = this.json("license");
+        return doc &&  new License(doc);
+    }
+}

--- a/src/models/license.ts
+++ b/src/models/license.ts
@@ -1,0 +1,11 @@
+import { BaseModel } from "./base";
+
+export class License extends BaseModel {
+    name(): string {
+        return this.json("name");
+    }
+
+    url(): string {
+        return this.json("url");
+    }
+}

--- a/test/models/asyncapi.spec.ts
+++ b/test/models/asyncapi.spec.ts
@@ -22,11 +22,5 @@ describe('AsyncAPIDocument model', function() {
       const d = new AsyncAPIDocument(doc);
       expect(d.info() instanceof Info).toBeTruthy();
     });
-    
-    it('should return undefined when there is no value', function() {
-      const doc = { };
-      const d = new AsyncAPIDocument(doc);
-      expect(d.info()).toBeUndefined();
-    });
   });
 });

--- a/test/models/asyncapi.spec.ts
+++ b/test/models/asyncapi.spec.ts
@@ -1,0 +1,32 @@
+import { AsyncAPIDocument } from '../../src/models/asyncapi';
+import { Info } from '../../src/models/info';
+
+describe('AsyncAPIDocument model', function() {
+  describe('.version()', function() {
+    it('should return the value', function() {
+      const doc = { asyncapi: "3.0.0" };
+      const d = new AsyncAPIDocument(doc);
+      expect(d.version()).toEqual(doc.asyncapi);
+    });
+    
+    it('should return undefined when there is no value', function() {
+      const doc = { };
+      const d = new AsyncAPIDocument(doc);
+      expect(d.version()).toBeUndefined();
+    });
+  });
+
+  describe('.info()', function() {
+    it('should return an Info object', function() {
+      const doc = { info: { name: "LeChuck" } };
+      const d = new AsyncAPIDocument(doc);
+      expect(d.info() instanceof Info).toBeTruthy();
+    });
+    
+    it('should return undefined when there is no value', function() {
+      const doc = { };
+      const d = new AsyncAPIDocument(doc);
+      expect(d.info()).toBeUndefined();
+    });
+  });
+});

--- a/test/models/contact.spec.ts
+++ b/test/models/contact.spec.ts
@@ -1,0 +1,45 @@
+import { Contact } from '../../src/models/contact';
+
+describe('Contact model', function() {
+  describe('.name()', function() {
+    it('should return the value', function() {
+      const doc = { name: "LeChuck" };
+      const d = new Contact(doc);
+      expect(d.name()).toEqual(doc.name);
+    });
+    
+    it('should return undefined when there is no value', function() {
+      const doc = { };
+      const d = new Contact(doc);
+      expect(d.name()).toBeUndefined();
+    });
+  });
+
+  describe('.url()', function() {
+    it('should return the value', function() {
+      const doc = { url: "https://example.com" };
+      const d = new Contact(doc);
+      expect(d.url()).toEqual(doc.url);
+    });
+    
+    it('should return undefined when there is no value', function() {
+      const doc = { };
+      const d = new Contact(doc);
+      expect(d.url()).toBeUndefined();
+    });
+  });
+
+  describe('.email()', function() {
+    it('should return the value', function() {
+      const doc = { email: "lechuck@example.com" };
+      const d = new Contact(doc);
+      expect(d.email()).toEqual(doc.email);
+    });
+    
+    it('should return undefined when there is no value', function() {
+      const doc = { };
+      const d = new Contact(doc);
+      expect(d.email()).toBeUndefined();
+    });
+  });
+});

--- a/test/models/info.spec.ts
+++ b/test/models/info.spec.ts
@@ -1,0 +1,89 @@
+import { Contact } from '../../src/models/contact';
+import { Info } from '../../src/models/info';
+import { License } from '../../src/models/license';
+
+describe('Info model', function() {
+  describe('.title()', function() {
+    it('should return the value', function() {
+      const doc = { title: "Example API" };
+      const d = new Info(doc);
+      expect(d.title()).toEqual(doc.title);
+    });
+    
+    it('should return undefined when there is no value', function() {
+      const doc = { };
+      const d = new Info(doc);
+      expect(d.title()).toBeUndefined();
+    });
+  });
+
+  describe('.version()', function() {
+    it('should return the value', function() {
+      const doc = { version: "1.0.0" };
+      const d = new Info(doc);
+      expect(d.version()).toEqual(doc.version);
+    });
+    
+    it('should return undefined when there is no value', function() {
+      const doc = { };
+      const d = new Info(doc);
+      expect(d.version()).toBeUndefined();
+    });
+  });
+
+  describe('.description()', function() {
+    it('should return the value', function() {
+      const doc = { description: "This is the API of Example" };
+      const d = new Info(doc);
+      expect(d.description()).toEqual(doc.description);
+    });
+    
+    it('should return undefined when there is no value', function() {
+      const doc = { };
+      const d = new Info(doc);
+      expect(d.description()).toBeUndefined();
+    });
+  });
+
+  describe('.termsOfService()', function() {
+    it('should return the value', function() {
+      const doc = { termsOfService: "These are the terms of service" };
+      const d = new Info(doc);
+      expect(d.termsOfService()).toEqual(doc.termsOfService);
+    });
+    
+    it('should return undefined when there is no value', function() {
+      const doc = { };
+      const d = new Info(doc);
+      expect(d.termsOfService()).toBeUndefined();
+    });
+  });
+
+  describe('.contact()', function() {
+    it('should return a Contact object', function() {
+      const doc = { contact: { name: "LeChuck" } };
+      const d = new Info(doc);
+      expect(d.contact() instanceof Contact).toBeTruthy();
+    });
+    
+    it('should return undefined when there is no value', function() {
+      const doc = { };
+      const d = new Info(doc);
+      expect(d.contact()).toBeUndefined();
+    });
+  });
+
+  describe('.license()', function() {
+    it('should return a License object', function() {
+      const doc = { license: { name: "Apache 2.0" } };
+      const d = new Info(doc);
+      expect(d.license() instanceof License).toBeTruthy();
+    });
+    
+    it('should return undefined when there is no value', function() {
+      const doc = { };
+      const d = new Info(doc);
+      expect(d.license()).toBeUndefined();
+    });
+  });
+});

--- a/test/models/license.spec.ts
+++ b/test/models/license.spec.ts
@@ -1,0 +1,31 @@
+import { License } from '../../src/models/license';
+
+describe('License model', function() {
+  describe('.name()', function() {
+    it('should return the value', function() {
+      const doc = { name: "Apache 2.0" };
+      const d = new License(doc);
+      expect(d.name()).toEqual(doc.name);
+    });
+    
+    it('should return undefined when there is no value', function() {
+      const doc = { };
+      const d = new License(doc);
+      expect(d.name()).toBeUndefined();
+    });
+  });
+
+  describe('.url()', function() {
+    it('should return the value', function() {
+      const doc = { url: "https://www.apache.org/licenses/LICENSE-2.0.html" };
+      const d = new License(doc);
+      expect(d.url()).toEqual(doc.url);
+    });
+    
+    it('should return undefined when there is no value', function() {
+      const doc = { };
+      const d = new License(doc);
+      expect(d.url()).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
**Description**

This PR adds Info and the dependant models (Contact, License). It also allows to retrieve Info from the document root.
The models are based on the new Intent API (even though Info looks the same by now).

Pending things that can be out of this PR:

- How to handle retrocompatibility.

**Related issue(s)**
https://github.com/asyncapi/parser-js/issues/482