### PR TITLE
refactor: init parse, lint and validate functions

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -10,6 +10,11 @@ const config: Config.InitialOptions = {
   // The root of your source code, typically /src
   // `<rootDir>` is a token Jest substitutes
   roots: ['<rootDir>'],
+  moduleNameMapper: {
+    '^nimma/legacy$': '<rootDir>/node_modules/nimma/dist/legacy/cjs/index.js',
+    '^nimma/(.*)': '<rootDir>/node_modules/nimma/dist/cjs/$1',
+    '^@stoplight/spectral-ruleset-bundler/(.*)$': '<rootDir>/node_modules/@stoplight/spectral-ruleset-bundler/dist/$1'
+  },
   
   // Test spec file resolution pattern
   // Matches parent folder `__tests__` and filename

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -1,0 +1,76 @@
+import {
+  IConstructorOpts,
+  ISpectralDiagnostic,
+  IRunOpts,
+  Spectral,
+  Ruleset,
+  RulesetDefinition,
+} from "@stoplight/spectral-core";
+import { asyncapi as aasRuleset } from "@stoplight/spectral-rulesets";
+
+import { toAsyncAPIDocument, normalizeInput, hasWarningDiagnostic, hasErrorDiagnostic } from "./utils";
+
+import type { AsyncAPIDocument } from "./models/asyncapi";
+import type { ParserInput } from "./types";
+
+export interface LintOptions extends IConstructorOpts, IRunOpts {
+  ruleset?: RulesetDefinition | Ruleset;
+}
+
+export interface ValidateOptions extends LintOptions {
+  allowedSeverity?: {
+    warning?: boolean;
+  };
+}
+
+export interface ValidateOutput {
+  validated: unknown;
+  diagnostics: ISpectralDiagnostic[];
+}
+
+export async function lint(asyncapi: ParserInput, options?: LintOptions): Promise<ISpectralDiagnostic[] | undefined> {
+  if (toAsyncAPIDocument(asyncapi)) {
+    return;
+  }
+  const document = normalizeInput(asyncapi as Exclude<ParserInput, AsyncAPIDocument>);
+  return (await validate(document, options)).diagnostics;
+}
+
+export async function validate(asyncapi: string, options?: ValidateOptions): Promise<ValidateOutput> {
+  const { ruleset, allowedSeverity, ...restOptions } = normalizeOptions(options);
+  const spectral = new Spectral(restOptions);
+
+  spectral.setRuleset(ruleset!);
+  let { resolved, results } = await spectral.runWithResolved(asyncapi);
+
+  if (
+    hasErrorDiagnostic(results) ||
+    (!allowedSeverity?.warning && hasWarningDiagnostic(results))
+  ) {
+    resolved = undefined;
+  }
+
+  return { validated: resolved, diagnostics: results };
+}
+
+const defaultOptions: ValidateOptions = {
+  // TODO: fix that type
+  ruleset: aasRuleset as any,
+  allowedSeverity: {
+    warning: true,
+  }
+};
+function normalizeOptions(options?: ValidateOptions): ValidateOptions {
+  if (!options || typeof options !== 'object') {
+    return defaultOptions;
+  }
+  // shall copy
+  options = { ...defaultOptions, ...options };
+
+  // ruleset
+  options.ruleset = options.ruleset || defaultOptions.ruleset;
+  // severity
+  options.allowedSeverity = { ...defaultOptions.allowedSeverity, ...(options.allowedSeverity || {}) };
+
+  return options;
+}

--- a/src/models/base.ts
+++ b/src/models/base.ts
@@ -3,8 +3,8 @@ export class BaseModel {
     private readonly _json: Record<string, any>,
   ) {}
 
-  json<T = Record<string, unknown>>(): T;
-  json<T = unknown>(key: string | number): T;
+  json<T = Record<string, any>>(): T;
+  json<T = any>(key: string | number): T;
   json(key?: string | number) {
     if (key === undefined) return this._json;
     if (!this._json) return;

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,0 +1,64 @@
+import { AsyncAPIDocument } from "./models";
+import { hasErrorDiagnostic, normalizeInput, toAsyncAPIDocument } from "./utils";
+import { validate } from "./lint";
+
+import type { ParserInput, ParserOutput } from './types';
+import type { ValidateOptions } from './lint';
+
+export interface ParseOptions {
+  applyTraits?: boolean;
+  validateOptions?: ValidateOptions;
+}
+
+export async function parse(asyncapi: ParserInput, options?: ParseOptions): Promise<ParserOutput> {
+  let maybeDocument = toAsyncAPIDocument(asyncapi);
+  if (maybeDocument) {
+    return { 
+      source: asyncapi,
+      parsed: maybeDocument,
+      diagnostics: [],
+    };
+  }
+
+  try {
+    const document = normalizeInput(asyncapi as Exclude<ParserInput, AsyncAPIDocument>);
+    options = normalizeOptions(options);
+
+    const { validated, diagnostics } = await validate(document, options.validateOptions);
+    if (validated === undefined) {
+      return {
+        source: asyncapi,
+        parsed: undefined,
+        diagnostics,
+      };
+    }
+
+    const parsed = new AsyncAPIDocument(validated as Record<string, unknown>);
+    return { 
+      source: asyncapi,
+      parsed,
+      diagnostics,
+    };
+  } catch(err) {
+    // TODO: throw proper error
+    throw Error();
+  }
+}
+
+const defaultOptions: ParseOptions = {
+  applyTraits: true,
+};
+function normalizeOptions(options?: ParseOptions): ParseOptions {
+  if (!options || typeof options !== 'object') {
+    return defaultOptions;
+  }
+  // shall copy
+  options = { ...defaultOptions, ...options };
+
+  // traits
+  if (options.applyTraits === undefined) {
+    options.applyTraits = true;
+  }
+
+  return options;
+}

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -3,7 +3,11 @@ import { AsyncAPIDocument } from './models';
 import { isAsyncAPIDocument, isParsedDocument, isStringifiedDocument } from './utils';
 import { xParserSpecStringified } from './constants';
 
-export function stringify(document: unknown, space?: string | number): string | undefined {
+export interface StringifyOptions {
+  space?: string | number;
+}
+
+export function stringify(document: unknown, options: StringifyOptions = {}): string | undefined {
   if (isAsyncAPIDocument(document)) {
     document = document.json();
   } else if (isParsedDocument(document)) {
@@ -18,7 +22,7 @@ export function stringify(document: unknown, space?: string | number): string | 
   return JSON.stringify({ 
     ...document as Record<string, unknown>,
     [String(xParserSpecStringified)]: true,
-  }, refReplacer(), space);
+  }, refReplacer(), options.space || 2);
 }
 
 export function unstringify(document: unknown): AsyncAPIDocument | undefined {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,10 @@
+import type { ISpectralDiagnostic } from '@stoplight/spectral-core';
+import type { AsyncAPIDocument } from './models/asyncapi';
+
+export type MaybeAsyncAPI = { asyncapi: unknown } & Record<string, unknown>;
+export type ParserInput = string | MaybeAsyncAPI | AsyncAPIDocument;
+export interface ParserOutput {
+  source: ParserInput;
+  parsed: AsyncAPIDocument | undefined;
+  diagnostics: ISpectralDiagnostic[]; 
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import { DiagnosticSeverity } from '@stoplight/types';
 import { AsyncAPIDocument } from './models';
 import { unstringify } from './stringify';
 
@@ -5,6 +6,9 @@ import {
   xParserSpecParsed,
   xParserSpecStringified,
 } from './constants';
+
+import type { ISpectralDiagnostic } from '@stoplight/spectral-core';
+import type { MaybeAsyncAPI } from 'types';
 
 export function toAsyncAPIDocument(maybeDoc: unknown): AsyncAPIDocument | undefined {
   if (isAsyncAPIDocument(maybeDoc)) {
@@ -35,4 +39,16 @@ export function isStringifiedDocument(maybeDoc: unknown): maybeDoc is Record<str
     Boolean((maybeDoc as Record<string, unknown>)[xParserSpecParsed]) &&
     Boolean((maybeDoc as Record<string, unknown>)[xParserSpecStringified])
   );
+}
+
+export function normalizeInput(asyncapi: string | MaybeAsyncAPI): string {
+  return JSON.stringify(asyncapi, undefined, 2);
+};
+
+export function hasErrorDiagnostic(diagnostics: ISpectralDiagnostic[]): boolean {
+  return diagnostics.some(diagnostic => diagnostic.severity === DiagnosticSeverity.Error);
+}
+
+export function hasWarningDiagnostic(diagnostics: ISpectralDiagnostic[]): boolean {
+  return diagnostics.some(diagnostic => diagnostic.severity === DiagnosticSeverity.Warning);
 }

--- a/test/lint.spec.ts
+++ b/test/lint.spec.ts
@@ -1,0 +1,68 @@
+import { lint, validate } from '../src/lint';
+
+describe('lint() & validate()', function() {
+  describe('lint()', function() {
+    it('should lint invalid document', async function() {
+      const document = {
+        asyncapi: '2.0.0',
+        info: {
+          title: 'Valid AsyncApi document',
+          version: '1.0',
+        },
+      }
+
+      const diagnostics = await lint(document);
+      if (!diagnostics) {
+        return;
+      }
+
+      expect(diagnostics.length > 0).toEqual(true);
+    });
+  });
+
+  describe('validate()', function() {
+    it('should validate invalid document', async function() {
+      const document = JSON.stringify({
+        asyncapi: '2.0.0',
+        info: {
+          title: 'Valid AsyncApi document',
+          version: '1.0',
+        },
+      }, undefined, 2);
+      const { validated, diagnostics } = await validate(document);
+
+      expect(validated).toBeUndefined();
+      expect(diagnostics.length > 0).toEqual(true);
+    });
+
+    it('should validate valid document', async function() {
+      const document = JSON.stringify({
+        asyncapi: '2.0.0',
+        info: {
+          title: 'Valid AsyncApi document',
+          version: '1.0',
+        },
+        channels: {}
+      }, undefined, 2);
+      const { validated, diagnostics } = await validate(document);
+      
+      expect(validated).not.toBeUndefined();
+      expect(diagnostics.length > 0).toEqual(true);
+    });
+
+    it('should validate valid document - do not allow warning severity', async function() {
+      const document = JSON.stringify({
+        asyncapi: '2.0.0',
+        info: {
+          title: 'Valid AsyncApi document',
+          version: '1.0',
+        },
+        channels: {}
+      }, undefined, 2);
+      const { validated, diagnostics } = await validate(document, { allowedSeverity: { warning: false } });
+      
+      expect(validated).toBeUndefined();
+      expect(diagnostics.length > 0).toEqual(true);
+    });
+  });
+});

--- a/test/parse.spec.ts
+++ b/test/parse.spec.ts
@@ -1,0 +1,33 @@
+import { AsyncAPIDocument } from '../src/models/asyncapi';
+import { parse } from '../src/parse';
+
+describe('parse()', function() {
+  it('should parse valid document', async function() {
+    const document = {
+      asyncapi: '2.0.0',
+      info: {
+        title: 'Valid AsyncApi document',
+        version: '1.0',
+      },
+      channels: {}
+    }
+    const { parsed, diagnostics } = await parse(document);
+    
+    expect(parsed).toBeInstanceOf(AsyncAPIDocument);
+    expect(diagnostics.length > 0).toEqual(true);
+  });
+
+  it('should parse invalid document', async function() {
+    const document = {
+      asyncapi: '2.0.0',
+      info: {
+        title: 'Valid AsyncApi document',
+        version: '1.0',
+      },
+    }
+    const { parsed, diagnostics } = await parse(document);
+    
+    expect(parsed).toEqual(undefined);
+    expect(diagnostics.length > 0).toEqual(true);
+  });
+});


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- add `parse` function:
  - init function's logic
  - add needed types
  - add relevant unit tests - small, in next PRs I will add more complex cases
- Add `lint` function:
  - init function's logic
  - add needed types
  - add relevant unit tests - small, in next PRs I will add more complex cases
- Add `validate` function:
  - init function's logic
  - add needed types
  - add relevant unit tests - small, in next PRs I will add more complex cases
  
> NOTE: `lint` and `validate` differ in that `lint` only returns errors, while `validate` also returns a validated object.

**Related issue(s)**
Part of #482 