### PR TITLE
chore: update 2022-04-release branch

### DIFF
--- a/lib/asyncapiSchemaFormatParser.js
+++ b/lib/asyncapiSchemaFormatParser.js
@@ -48,7 +48,7 @@ function getMimeTypes() {
     'application/schema+json;version=draft-07',
     'application/schema+yaml;version=draft-07',
   ];
-  ['2.0.0', '2.1.0', '2.2.0', '2.3.0'].forEach(version => {
+  ['2.0.0', '2.1.0', '2.2.0', '2.3.0', '2.4.0'].forEach(version => {
     mimeTypes.push(
       `application/vnd.aai.asyncapi;version=${version}`,
       `application/vnd.aai.asyncapi+json;version=${version}`,


### PR DESCRIPTION
- [x] Update the list of AsyncAPI schema MIME types with the new version

Part of https://github.com/asyncapi/spec/issues/735