### PR TITLE
feat: add security field at the operation level

### DIFF
--- a/API.md
+++ b/API.md
@@ -233,6 +233,7 @@
             * [.extension(key)](#module_@asyncapi/parser+OAuthFlow+extension) ⇒ <code>any</code>
             * [.hasExt(key)](#module_@asyncapi/parser+OAuthFlow+hasExt) ⇒ <code>boolean</code>
             * [.ext(key)](#module_@asyncapi/parser+OAuthFlow+ext) ⇒ <code>any</code>
+        * [.OperationSecurityRequirement](#module_@asyncapi/parser+OperationSecurityRequirement) ⇐ <code>Base</code>
         * [.OperationTrait](#module_@asyncapi/parser+OperationTrait) ⇐ <code>OperationTraitable</code>
         * [.OperationTraitable](#module_@asyncapi/parser+OperationTraitable) ⇐ <code>Base</code>
             * [.id()](#module_@asyncapi/parser+OperationTraitable+id) ⇒ <code>string</code>
@@ -265,7 +266,7 @@
             * [.hasTraits()](#module_@asyncapi/parser+Operation+hasTraits) ⇒ <code>boolean</code>
             * [.messages()](#module_@asyncapi/parser+Operation+messages) ⇒ <code>Array.&lt;Message&gt;</code>
             * [.message()](#module_@asyncapi/parser+Operation+message) ⇒ <code>Message</code>
-            * [.OperationSecurityRequirement](#module_@asyncapi/parser+OperationSecurityRequirement) ⇐ <code>Base</code>
+            * [.security()](#module_@asyncapi/parser+Operation+security) ⇒ <code>Array.&lt;OperationSecurityRequirement&gt;</code>
         * [.PublishOperation](#module_@asyncapi/parser+PublishOperation) ⇐ <code>Operation</code>
             * [.isPublish()](#module_@asyncapi/parser+PublishOperation+isPublish) ⇒ <code>boolean</code>
             * [.isSubscribe()](#module_@asyncapi/parser+PublishOperation+isSubscribe) ⇒ <code>boolean</code>
@@ -1913,6 +1914,13 @@ Implements functions to deal with a OAuthFlow object.
 | --- | --- | --- |
 | key | <code>string</code> | Extension key. |
 
+<a name="module_@asyncapi/parser+OperationSecurityRequirement"></a>
+
+### @asyncapi/parser.OperationSecurityRequirement ⇐ <code>Base</code>
+Implements functions to deal with a OperationSecurityRequirement object.
+
+**Kind**: instance class of [<code>@asyncapi/parser</code>](#module_@asyncapi/parser)  
+**Extends**: <code>Base</code>  
 <a name="module_@asyncapi/parser+OperationTrait"></a>
 
 ### @asyncapi/parser.OperationTrait ⇐ <code>OperationTraitable</code>
@@ -2152,7 +2160,7 @@ Implements functions to deal with an Operation object.
 <a name="module_@asyncapi/parser+Operation+security"></a>
 
 #### operation.security() ⇒ <code>Array.&lt;OperationSecurityRequirement&gt;</code>
-**Kind**: instance method of [<code>Operation</code>](#module_@asyncapi/parser+Operation)
+**Kind**: instance method of [<code>Operation</code>](#module_@asyncapi/parser+Operation)  
 <a name="module_@asyncapi/parser+PublishOperation"></a>
 
 ### @asyncapi/parser.PublishOperation ⇐ <code>Operation</code>

--- a/API.md
+++ b/API.md
@@ -265,6 +265,7 @@
             * [.hasTraits()](#module_@asyncapi/parser+Operation+hasTraits) ⇒ <code>boolean</code>
             * [.messages()](#module_@asyncapi/parser+Operation+messages) ⇒ <code>Array.&lt;Message&gt;</code>
             * [.message()](#module_@asyncapi/parser+Operation+message) ⇒ <code>Message</code>
+            * [.OperationSecurityRequirement](#module_@asyncapi/parser+OperationSecurityRequirement) ⇐ <code>Base</code>
         * [.PublishOperation](#module_@asyncapi/parser+PublishOperation) ⇐ <code>Operation</code>
             * [.isPublish()](#module_@asyncapi/parser+PublishOperation+isPublish) ⇒ <code>boolean</code>
             * [.isSubscribe()](#module_@asyncapi/parser+PublishOperation+isSubscribe) ⇒ <code>boolean</code>
@@ -2126,6 +2127,7 @@ Implements functions to deal with an Operation object.
     * [.hasTraits()](#module_@asyncapi/parser+Operation+hasTraits) ⇒ <code>boolean</code>
     * [.messages()](#module_@asyncapi/parser+Operation+messages) ⇒ <code>Array.&lt;Message&gt;</code>
     * [.message()](#module_@asyncapi/parser+Operation+message) ⇒ <code>Message</code>
+    * [.security()](#module_@asyncapi/parser+Operation+security) ⇒ <code>Array.&lt;OperationSecurityRequirement&gt;</code>
 
 <a name="module_@asyncapi/parser+Operation+hasMultipleMessages"></a>
 
@@ -2147,6 +2149,10 @@ Implements functions to deal with an Operation object.
 
 #### operation.message() ⇒ <code>Message</code>
 **Kind**: instance method of [<code>Operation</code>](#module_@asyncapi/parser+Operation)  
+<a name="module_@asyncapi/parser+Operation+security"></a>
+
+#### operation.security() ⇒ <code>Array.&lt;OperationSecurityRequirement&gt;</code>
+**Kind**: instance method of [<code>Operation</code>](#module_@asyncapi/parser+Operation)
 <a name="module_@asyncapi/parser+PublishOperation"></a>
 
 ### @asyncapi/parser.PublishOperation ⇐ <code>Operation</code>

--- a/lib/models/operation-security-requirement.js
+++ b/lib/models/operation-security-requirement.js
@@ -1,0 +1,13 @@
+const Base = require('./base');
+
+/**
+ * Implements functions to deal with a OperationSecurityRequirement object.
+ * @class
+ * @alias module:@asyncapi/parser#OperationSecurityRequirement
+ * @extends Base
+ * @returns {OperationSecurityRequirement}
+ */
+class OperationSecurityRequirement extends Base {
+}
+
+module.exports = OperationSecurityRequirement;

--- a/lib/models/operation.js
+++ b/lib/models/operation.js
@@ -1,6 +1,7 @@
 const OperationTraitable = require('./operation-traitable');
 const Message = require('./message');
 const OperationTrait = require('./operation-trait');
+const OperationSecurityRequirement = require('./operation-security-requirement');
 
 /**
  * Implements functions to deal with an Operation object.
@@ -53,6 +54,14 @@ class Operation extends OperationTraitable {
     if (typeof index !== 'number') return null;
     if (index > this._json.message.oneOf.length - 1) return null;
     return new Message(this._json.message.oneOf[+index]);
+  }
+
+  /**
+   * @returns {OperationSecurityRequirement[]}
+  */
+  security() {
+    if (!this._json.security) return null;
+    return this._json.security.map(sec => new OperationSecurityRequirement(sec));
   }
 }
 

--- a/test/models/operation_test.js
+++ b/test/models/operation_test.js
@@ -127,7 +127,7 @@ describe('Operation', function() {
     it('should return an array of security requirements objects', function() {
       const d = new Operation(js);
       expect(Array.isArray(d.security())).to.equal(true);
-      expect(d.security().length > 0).to.equal(true);
+      expect(d.security()).to.have.lengthOf(1);
       d.security().forEach((s, i) => {
         expect(s.constructor.name).to.equal('OperationSecurityRequirement');
         expect(s.json()).to.equal(js.security[i]);

--- a/test/models/operation_test.js
+++ b/test/models/operation_test.js
@@ -127,6 +127,7 @@ describe('Operation', function() {
     it('should return an array of security requirements objects', function() {
       const d = new Operation(js);
       expect(Array.isArray(d.security())).to.equal(true);
+      expect(d.security().length > 0).to.equal(true);
       d.security().forEach((s, i) => {
         expect(s.constructor.name).to.equal('OperationSecurityRequirement');
         expect(s.json()).to.equal(js.security[i]);

--- a/test/models/operation_test.js
+++ b/test/models/operation_test.js
@@ -1,5 +1,5 @@
 const { expect } = require('chai');
-const js = { summary: 't', description: 'test', traits: [{bindings: {kafka: {clientId: 'my-app-id'}}}], operationId: 'test', tags: [{name: 'tag1'}], externalDocs: { url: 'somewhere' }, bindings: { amqp: { test: true } }, message: { test: true }, 'x-test': 'testing' };
+const js = { summary: 't', description: 'test', traits: [{bindings: {kafka: {clientId: 'my-app-id'}}}], operationId: 'test', tags: [{name: 'tag1'}], externalDocs: { url: 'somewhere' }, bindings: { amqp: { test: true } }, message: { test: true }, 'x-test': 'testing', security: [{ oauth2: ['user:read'] }]};
 
 const Operation = require('../../lib/models/operation');
 
@@ -120,6 +120,17 @@ describe('Operation', function() {
       assertMixinTagsInheritance(Operation);
       assertMixinBindingsInheritance(Operation);
       assertMixinSpecificationExtensionsInheritance(Operation);
+    });
+  });
+
+  describe('#security()', function() {
+    it('should return an array of security requirements objects', function() {
+      const d = new Operation(js);
+      expect(Array.isArray(d.security())).to.equal(true);
+      d.security().forEach((s, i) => {
+        expect(s.constructor.name).to.equal('OperationSecurityRequirement');
+        expect(s.json()).to.equal(js.security[i]);
+      });
     });
   });
 });

--- a/types.d.ts
+++ b/types.d.ts
@@ -839,6 +839,12 @@ declare module "@asyncapi/parser" {
         hasTraits(): boolean;
         messages(): Message[];
         message(): Message;
+        security(): OperationSecurityRequirement[];
+    }
+    /**
+     * Implements functions to deal with a OperationSecurityRequirement object.
+    */
+    class OperationSecurityRequirement extends Base {
     }
     /**
      * Implements functions to deal with a PublishOperation object.


### PR DESCRIPTION
File                                | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
------------------------------------|---------|----------|---------|---------|-------------------
All files                           |   95.87 |    88.33 |   97.32 |   98.21 |                   
 lib                                |   96.29 |    88.79 |   99.24 |   98.85 |                   
  anonymousNaming.js                |     100 |    95.45 |     100 |     100 | 28                
  asyncapiSchemaFormatParser.js     |     100 |      100 |     100 |     100 |                   
  constants.js                      |     100 |      100 |     100 |     100 |                   
  customValidators.js               |   99.02 |    96.97 |     100 |     100 | 45,513,541-545    
  index.js                          |     100 |      100 |     100 |     100 |                   
  iterators.js                      |   94.64 |     88.1 |   95.65 |   99.04 | 243               
  json-parse.js                     |   95.45 |    66.67 |     100 |   95.45 | 41                
  parser.js                         |   97.35 |    91.07 |     100 |   99.02 | 112               
  utils.js                          |    91.1 |    79.38 |     100 |   96.75 | 83-85,94-96       
 lib/errors                         |      95 |    91.67 |   66.67 |   93.33 |                   
  parser-error.js                   |      95 |    91.67 |   66.67 |   93.33 | 60                
 lib/mixins                         |     100 |      100 |     100 |     100 |                   
  bindings.js                       |     100 |      100 |     100 |     100 |                   
  description.js                    |     100 |      100 |     100 |     100 |                   
  external-docs.js                  |     100 |      100 |     100 |     100 |                   
  specification-extensions.js       |     100 |      100 |     100 |     100 |                   
  tags.js                           |     100 |      100 |     100 |     100 |                   
 lib/models                         |   95.05 |    85.78 |   96.21 |   97.41 |                   
  asyncapi.js                       |   95.83 |     87.1 |   96.77 |   96.58 | 54,274,319,354    
  base.js                           |      80 |       75 |     100 |     100 | 11,21             
  channel-parameter.js              |      90 |       50 |     100 |     100 | 30                
  channel.js                        |   93.55 |    83.33 |     100 |     100 | 75-83             
  components.js                     |     100 |      100 |     100 |     100 |                   
  contact.js                        |     100 |      100 |     100 |     100 |                   
  correlation-id.js                 |     100 |      100 |     100 |     100 |                   
  external-docs.js                  |     100 |      100 |     100 |     100 |                   
  info.js                           |     100 |      100 |     100 |     100 |                   
  license.js                        |     100 |      100 |     100 |     100 |                   
  message-trait.js                  |     100 |      100 |     100 |     100 |                   
  message-traitable.js              |      92 |    66.67 |     100 |     100 | 39-47             
  message.js                        |   93.75 |       80 |     100 |     100 | 33,48-55          
  oauth-flow.js                     |     100 |      100 |     100 |     100 |                   
  operation-security-requirement.js |     100 |      100 |     100 |     100 |                   
  operation-trait.js                |     100 |      100 |     100 |     100 |                   
  operation-traitable.js            |     100 |      100 |     100 |     100 |                   
  operation.js                      |      80 |    66.67 |   88.89 |   86.36 | 18-20             
  publish-operation.js              |      40 |      100 |       0 |      40 | 15-29             
  schema.js                         |     100 |    96.77 |     100 |     100 | 421,437           
  security-scheme.js                |     100 |      100 |     100 |     100 |                   
  server-security-requirement.js    |     100 |      100 |     100 |     100 |                   
  server-variable.js                |   92.31 |       50 |     100 |     100 | 30                
  server.js                         |   94.44 |       50 |     100 |     100 | 69                
  subscribe-operation.js            |      40 |      100 |       0 |      40 | 15-29             
  tag.js                            |     100 |      100 |     100 |     100 |                   
  utils.js                          |     100 |      100 |     100 |     100 |                   


**Description**
We are using AsyncAPI specifications for publishing the subscriber specific details of our topics and associated payloads for our HTTP push use cases.

Our subscribable channels(or topics) are protected by a set of OAuth scopes (authorization code or client credentials) - that a potential subscriber needs to be aware of.

Here is a sample contract.

We are able to accommodate almost every detail of interest to an integrator/subscriber (THANK YOU) - with the exception of being able to call out the oauth scopes necessary for the subscription to the topic - i.e. the security aspect at the channel or rather channel/operation level.

The current specification is perhaps more aligned with a broker based topology - but ours is a pure push use case (to registered webhooks) and we need an ability to call out any security aspects at the channel operation level.

**Related issue(s)**
https://github.com/asyncapi/parser-js/issues/434
https://github.com/asyncapi/spec-json-schemas/pull/189