### PR TITLE
refactor: add Parser class

### DIFF
--- a/src/custom-operations/index.ts
+++ b/src/custom-operations/index.ts
@@ -1,26 +1,27 @@
 import { applyTraitsV2, applyTraitsV3 } from './apply-traits';
 import { parseSchemasV2 } from './parse-schema';
 
+import type { Parser } from '../parser';
 import type { ParseOptions } from "../parse";
 import type { DetailedAsyncAPI } from "../types";
 
-export async function customOperations(detailed: DetailedAsyncAPI, options: ParseOptions): Promise<void> {
+export async function customOperations(parser: Parser, detailed: DetailedAsyncAPI, options: ParseOptions): Promise<void> {
   switch (detailed.semver.major) {
-    case 2: return operationsV2(detailed, options);
-    case 3: return operationsV3(detailed, options);
+    case 2: return operationsV2(parser, detailed, options);
+    case 3: return operationsV3(parser, detailed, options);
   }
 }
 
-async function operationsV2(detailed: DetailedAsyncAPI, options: ParseOptions): Promise<void> {
+async function operationsV2(parser: Parser, detailed: DetailedAsyncAPI, options: ParseOptions): Promise<void> {
   if (options.applyTraits) {
     applyTraitsV2(detailed.parsed);
   }
   if (options.parseSchemas) {
-    await parseSchemasV2(detailed);
+    await parseSchemasV2(parser, detailed);
   }
 }
 
-async function operationsV3(detailed: DetailedAsyncAPI, options: ParseOptions): Promise<void> {
+async function operationsV3(parser: Parser, detailed: DetailedAsyncAPI, options: ParseOptions): Promise<void> {
   if (options.applyTraits) {
     applyTraitsV3(detailed.parsed);
   }

--- a/src/custom-operations/parse-schema.ts
+++ b/src/custom-operations/parse-schema.ts
@@ -4,6 +4,7 @@ import { toPath } from 'lodash';
 import { parseSchema, getDefaultSchemaFormat } from '../schema-parser';
 import { xParserOriginalSchemaFormat } from '../constants';
 
+import type { Parser } from '../parser';
 import type { ParseSchemaInput } from "../schema-parser";
 import type { DetailedAsyncAPI } from "../types";
 
@@ -20,7 +21,7 @@ const customSchemasPathsV2 = [
   '$.components.messages.*',
 ];
 
-export async function parseSchemasV2(detailed: DetailedAsyncAPI) {
+export async function parseSchemasV2(parser: Parser, detailed: DetailedAsyncAPI) {
   const defaultSchemaFormat = getDefaultSchemaFormat(detailed.parsed.asyncapi as string);
   const parseItems: Array<ToParseItem> = [];
 
@@ -57,10 +58,10 @@ export async function parseSchemasV2(detailed: DetailedAsyncAPI) {
     });
   });
 
-  return Promise.all(parseItems.map(parseSchemaV2));
+  return Promise.all(parseItems.map(item => parseSchemaV2(parser, item)));
 }
 
-async function parseSchemaV2(item: ToParseItem) {
+async function parseSchemaV2(parser: Parser, item: ToParseItem) {
   item.value[xParserOriginalSchemaFormat] = item.input.schemaFormat;
-  item.value.payload = await parseSchema(item.input);
+  item.value.payload = await parseSchema(parser, item.input);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,11 @@
 export * from './models';
 
-export { lint, validate } from './lint';
-export { parse } from './parse';
+export { Parser } from './parser';
 export { stringify, unstringify } from './stringify';
-
-export { registerSchemaParser } from './schema-parser';
 export { AsyncAPISchemaParser } from './schema-parser/asyncapi-schema-parser';
 
+export type { AsyncAPISemver, Diagnostic, SchemaValidateResult } from './types';
 export type { LintOptions, ValidateOptions, ValidateOutput } from './lint';
+export type { ParseInput, ParseOptions, ParseOutput } from './parse';
 export type { StringifyOptions } from './stringify';
-export type { ParseOptions } from './parse';
-export type { AsyncAPISemver, ParserInput, ParserOutput, Diagnostic, SchemaValidateResult } from './types';
-
 export type { ValidateSchemaInput, ParseSchemaInput, SchemaParser } from './schema-parser'

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,0 +1,48 @@
+import { Spectral } from "@stoplight/spectral-core";
+import { asyncapi as aasRuleset } from "@stoplight/spectral-rulesets";
+
+import { parse } from "./parse";
+import { lint, validate } from "./lint";
+import { registerSchemaParser } from './schema-parser';
+
+import type { IConstructorOpts } from "@stoplight/spectral-core";
+import type { ParseInput, ParseOptions } from "./parse";
+import type { LintOptions, ValidateOptions } from "./lint";
+import type { SchemaParser } from './schema-parser';
+
+export interface ParserOptions {
+  spectral?: Spectral | IConstructorOpts;
+}
+
+export class Parser {
+  public readonly parserRegistry = new Map<string, SchemaParser>();
+  public readonly spectral: Spectral;
+
+  constructor(options?: ParserOptions) {
+    const { spectral } = options || {};
+    if (spectral instanceof Spectral) {
+      this.spectral = spectral;
+    } else {
+      this.spectral = new Spectral(spectral);
+    }
+
+    // TODO: fix type
+    this.spectral.setRuleset(aasRuleset as any);
+  }
+
+  parse(asyncapi: ParseInput, options?: ParseOptions) {
+    return parse(this, asyncapi, options);
+  }
+
+  lint(asyncapi: ParseInput, options?: LintOptions) {
+    return lint(this, asyncapi, options);
+  }
+
+  validate(asyncapi: ParseInput, options?: ValidateOptions) {
+    return validate(this, asyncapi, options);
+  }
+
+  registerSchemaParser(parser: SchemaParser) {
+    return registerSchemaParser(this, parser);
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,4 @@
 import type { ISpectralDiagnostic, IFunctionResult } from '@stoplight/spectral-core';
-import type { AsyncAPIDocumentInterface } from './models/asyncapi';
 
 export type MaybeAsyncAPI = { asyncapi: string } & Record<string, unknown>;
 export interface AsyncAPISemver {
@@ -16,17 +15,5 @@ export interface DetailedAsyncAPI {
   semver: AsyncAPISemver;
 }
 
-export type ParserInput = string | MaybeAsyncAPI | AsyncAPIDocumentInterface;
-
 export type Diagnostic = ISpectralDiagnostic;
 export type SchemaValidateResult = IFunctionResult;
-
-export interface ParserOutput {
-  source: ParserInput;
-  parsed: AsyncAPIDocumentInterface | undefined;
-  diagnostics: Diagnostic[]; 
-}
-
-export interface Constructor<T> {
-  new (...args: any[]): T
-}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -62,6 +62,9 @@ export function getSemver(version: string): AsyncAPISemver {
 }
 
 export function normalizeInput(asyncapi: string | MaybeAsyncAPI): string {
+  if (typeof asyncapi === 'string') {
+    return asyncapi;
+  }
   return JSON.stringify(asyncapi, undefined, 2);
 };
 

--- a/test/lint.spec.ts
+++ b/test/lint.spec.ts
@@ -1,7 +1,10 @@
 import { lint, validate } from '../src/lint';
+import { Parser } from '../src/parser';
 import { hasErrorDiagnostic, hasWarningDiagnostic } from '../src/utils';
 
 describe('lint() & validate()', function() {
+  const parser = new Parser();
+
   describe('lint()', function() {
     it('should lint invalid document', async function() {
       const document = {
@@ -12,7 +15,7 @@ describe('lint() & validate()', function() {
         },
       }
 
-      const diagnostics = await lint(document);
+      const diagnostics = await lint(parser, document);
       if (!diagnostics) {
         return;
       }
@@ -32,7 +35,7 @@ describe('lint() & validate()', function() {
         channels: {}
       }
 
-      const diagnostics = await lint(document);
+      const diagnostics = await lint(parser, document);
       if (!diagnostics) {
         return;
       }
@@ -52,7 +55,7 @@ describe('lint() & validate()', function() {
           version: '1.0',
         },
       }, undefined, 2);
-      const { validated, diagnostics } = await validate(document);
+      const { validated, diagnostics } = await validate(parser, document);
 
       expect(validated).toBeUndefined();
       expect(diagnostics.length > 0).toEqual(true);
@@ -67,7 +70,7 @@ describe('lint() & validate()', function() {
         },
         channels: {}
       }, undefined, 2);
-      const { validated, diagnostics } = await validate(document);
+      const { validated, diagnostics } = await validate(parser, document);
       
       expect(validated).not.toBeUndefined();
       expect(diagnostics.length > 0).toEqual(true);
@@ -82,7 +85,7 @@ describe('lint() & validate()', function() {
         },
         channels: {}
       }, undefined, 2);
-      const { validated, diagnostics } = await validate(document, { allowedSeverity: { warning: false } });
+      const { validated, diagnostics } = await validate(parser, document, { allowedSeverity: { warning: false } });
       
       expect(validated).toBeUndefined();
       expect(diagnostics.length > 0).toEqual(true);

--- a/test/parse.spec.ts
+++ b/test/parse.spec.ts
@@ -1,7 +1,10 @@
 import { AsyncAPIDocumentV2 } from '../src/models';
+import { Parser } from '../src/parser';
 import { parse } from '../src/parse';
 
 describe('parse()', function() {
+  const parser = new Parser();
+
   it('should parse valid document', async function() {
     const document = {
       asyncapi: '2.0.0',
@@ -11,7 +14,7 @@ describe('parse()', function() {
       },
       channels: {}
     }
-    const { parsed, diagnostics } = await parse(document);
+    const { parsed, diagnostics } = await parse(parser, document);
     
     expect(parsed).toBeInstanceOf(AsyncAPIDocumentV2);
     expect(diagnostics.length > 0).toEqual(true);
@@ -25,7 +28,7 @@ describe('parse()', function() {
         version: '1.0',
       },
     }
-    const { parsed, diagnostics } = await parse(document);
+    const { parsed, diagnostics } = await parse(parser, document);
     
     expect(parsed).toEqual(undefined);
     expect(diagnostics.length > 0).toEqual(true);

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -1,0 +1,29 @@
+import { Spectral } from "@stoplight/spectral-core";
+import { Parser } from '../src/parser';
+import { AsyncAPISchemaParser } from '../src/schema-parser/asyncapi-schema-parser';
+
+describe('Parser class', function() {
+  it('should create Parser instance', async function() {
+    const parser = new Parser();
+    expect(parser).toBeInstanceOf(Parser);
+  });
+
+  it('should have default Spectral instance if no instance is specified in the constructor', async function() {
+    const parser = new Parser();
+    expect(parser.spectral).toBeInstanceOf(Spectral);
+  });
+
+  it('should have Spectral instance given in constructor', async function() {
+    const spectral = new Spectral();
+    const parser = new Parser({ spectral });
+    expect(parser.spectral).toBeInstanceOf(Spectral);
+    expect(parser.spectral).toEqual(spectral);
+  });
+
+  it('should register schema parser', async function() {
+    const parser = new Parser();
+    const schemaParser = AsyncAPISchemaParser();
+    parser.registerSchemaParser(schemaParser);
+    expect(parser.parserRegistry.size).toBeGreaterThan(1);
+  });
+});


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Add `Parser` class. Having a different instance (of Parser) for validation/parsing is important from the point of view of tools for which the rules for Spectral will often change, e.g. `server-api`. Once the 2.0.0 version of the parser is released, people should be able to upload their own rules. This will also allow us to optimize the validation on the side of e.g. the Studio. 

**Related issue(s)**
Part of #481 
Part of #482 