### PR TITLE
chore: add next-major-spec prerelease

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,10 @@
       {
         "name": "next-major",
         "prerelease": true
+      },
+      {
+        "name": "next-major-spec",
+        "prerelease": true
       }
     ],
     "plugins": [


### PR DESCRIPTION
**Description**
This PR adds the [agreed-upon branch for next major spec version](https://github.com/asyncapi/spec/issues/734#issuecomment-1077455953) going forward.

**Related issue(s)**
Related to https://github.com/asyncapi/spec/issues/691