### PR TITLE
chore: point @asyncapi/specs package to 2.14.0-2022-04-release.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,11 +6,11 @@
   "packages": {
     "": {
       "name": "@asyncapi/parser",
-      "version": "1.14.1",
+      "version": "1.15.0-2022-04-release.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
-        "@asyncapi/specs": "^2.13.0",
+        "@asyncapi/specs": "v2.14.0-2022-04-release.1",
         "@fmvilas/pseudo-yaml-ast": "^0.3.1",
         "ajv": "^6.10.1",
         "js-yaml": "^3.13.1",
@@ -58,9 +58,9 @@
       }
     },
     "node_modules/@asyncapi/specs": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.13.0.tgz",
-      "integrity": "sha512-X0OrxJtzwRH8iLILO/gUTDqjGVPmagmdlgdyuBggYAoGXzF6ZuAws3XCLxtPNve5eA/0V/1puwpUYEGekI22og=="
+      "version": "2.14.0-2022-04-release.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.14.0-2022-04-release.1.tgz",
+      "integrity": "sha512-Xq9RVO91lLb7A5O4rN76lvNtoLxsWUnEGRwx5T+LXEfT/USkcDGLOCWK2T2PAUF8vtrJYVm31hB3xXm+sjVALQ=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.8.3",
@@ -15320,9 +15320,9 @@
       }
     },
     "@asyncapi/specs": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.13.0.tgz",
-      "integrity": "sha512-X0OrxJtzwRH8iLILO/gUTDqjGVPmagmdlgdyuBggYAoGXzF6ZuAws3XCLxtPNve5eA/0V/1puwpUYEGekI22og=="
+      "version": "2.14.0-2022-04-release.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.14.0-2022-04-release.1.tgz",
+      "integrity": "sha512-Xq9RVO91lLb7A5O4rN76lvNtoLxsWUnEGRwx5T+LXEfT/USkcDGLOCWK2T2PAUF8vtrJYVm31hB3xXm+sjVALQ=="
     },
     "@babel/code-frame": {
       "version": "7.8.3",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.0.6",
-    "@asyncapi/specs": "^2.13.0",
+    "@asyncapi/specs": "v2.14.0-2022-04-release.1",
     "@fmvilas/pseudo-yaml-ast": "^0.3.1",
     "ajv": "^6.10.1",
     "js-yaml": "^3.13.1",


### PR DESCRIPTION
Wondering if I could use some wildcard to not having to do this change every time we wanna merge a change.