### PR TITLE
fix: broken package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@asyncapi/parser",
-      "version": "1.15.0-2022-04-release.1",
+      "version": "1.15.0-2022-04-release.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
@@ -60,7 +60,7 @@
     "node_modules/@asyncapi/specs": {
       "version": "2.14.0-2022-04-release.2",
       "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.14.0-2022-04-release.2.tgz",
-      "integrity": "sha512-yl1MYTQNyku9IPWg4vLokRSzn+/6iJrOdmwBckK32eQTCN5jUwvU2zN4aPv5GZuzngxrcoSTYHCtV7jnB8cDow=
+      "integrity": "sha512-yl1MYTQNyku9IPWg4vLokRSzn+/6iJrOdmwBckK32eQTCN5jUwvU2zN4aPv5GZuzngxrcoSTYHCtV7jnB8cDow=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.8.3",
@@ -3076,18 +3076,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/dmd/node_modules/marked": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
-      "dev": true,
-      "bin": {
-        "marked": "bin/marked"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/dmd/node_modules/reduce-flatten": {
@@ -6205,15 +6193,15 @@
       }
     },
     "node_modules/marked": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
-      "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
+      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
       "dev": true,
       "bin": {
         "marked": "bin/marked"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/marked-terminal": {
@@ -9298,7 +9286,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -9314,19 +9302,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9341,7 +9329,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -9359,7 +9347,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -13242,6 +13230,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/semantic-release/node_modules/marked": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.3.tgz",
+      "integrity": "sha512-5otztIIcJfPc2qGTN8cVtOJEjNJZ0jwa46INMagrYfk0EvqtRuEHLsEe0LrFS0/q+ZRKT0+kXK7P2T1AN5lWRA==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked"
+      },
+      "engines": {
+        "node": ">= 8.16.2"
       }
     },
     "node_modules/semantic-release/node_modules/p-limit": {
@@ -17862,12 +17862,6 @@
         "walk-back": "^4.0.0"
       },
       "dependencies": {
-        "marked": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-          "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
-          "dev": true
-        },
         "reduce-flatten": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-3.0.0.tgz",
@@ -20346,9 +20340,9 @@
       }
     },
     "marked": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
-      "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
+      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
       "dev": true
     },
     "marked-terminal": {
@@ -22683,7 +22677,7 @@
         "lodash._baseindexof": {
           "version": "3.1.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
@@ -22697,17 +22691,17 @@
         "lodash._bindcallback": {
           "version": "3.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
@@ -22720,7 +22714,7 @@
         "lodash._getnative": {
           "version": "3.9.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true
         },
         "lodash._root": {
           "version": "3.0.1",
@@ -22735,7 +22729,7 @@
         "lodash.restparam": {
           "version": "3.6.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true
         },
         "lodash.union": {
           "version": "4.6.0",
@@ -25761,6 +25755,12 @@
           "requires": {
             "p-locate": "^4.1.0"
           }
+        },
+        "marked": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.3.tgz",
+          "integrity": "sha512-5otztIIcJfPc2qGTN8cVtOJEjNJZ0jwa46INMagrYfk0EvqtRuEHLsEe0LrFS0/q+ZRKT0+kXK7P2T1AN5lWRA==",
+          "dev": true
         },
         "p-limit": {
           "version": "2.3.0",


### PR DESCRIPTION
**Description**

A malformed `package-lock.json` file has been merged on https://github.com/asyncapi/parser-js/pull/476/files#diff-053150b640a7ce75eff69d1a22cae7f0f94ad64ce9a855db544dda0929316519R63.

We didn't realize it until it was merged. See https://github.com/asyncapi/parser-js/runs/6110565450?check_suite_focus=true
I think the whole set of github actions didn't run on the PR, maybe due to the fact it was the first time the author made a PR (and owner had to approve, but didn't happen).

Anyway, this PR is fixing it.