### PR TITLE
docs: fix links in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Head over to [asyncapi/raml-dt-schema-parser](https://www.github.com/asyncapi/ra
 
 The parser API is generally structured the same way as the AsyncAPI specification, with additional support functions such as `has<Something>()`. The parser uses wrapped functions to get the properties stored in JSON. This means in order to get the info object you would use the function `doc.info()` and to get the title inside the info object you call `doc.info().title()`.
 
-See [API documentation](/API.md) for more example and full API reference information.
+See [API documentation](./API.md) for more example and full API reference information.
 
 ## Using in the browser
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -48,7 +48,7 @@ module.exports = {
  * Parses and validate an AsyncAPI document from YAML or JSON.
  * 
  * @param {(String | Object)} asyncapiYAMLorJSON An AsyncAPI document in JSON or YAML format.
- * @param {ParserOptions=} options Configuration options object {@link ParserOptions}
+ * @param {ParserOptions=} options Configuration options object {@link #asyncapiparserparseroptions--object|ParserOptions}
  * @returns {Promise<AsyncAPIDocument>} The parsed AsyncAPI document.
  */
 async function parse(asyncapiYAMLorJSON, options = {}) {
@@ -124,7 +124,7 @@ async function parse(asyncapiYAMLorJSON, options = {}) {
  * 
  * @param {String} url URL where the AsyncAPI document is located.
  * @param {Object=} [fetchOptions] Configuration to pass to the {@link https://developer.mozilla.org/en-US/docs/Web/API/Request|fetch} call.
- * @param {ParserOptions=} [options] Configuration to pass to the {@link ParserOptions} method.
+ * @param {ParserOptions=} [options] Configuration to pass to the {@link #asyncapiparserparseroptions--object|ParserOptions} method.
  * @returns {Promise<AsyncAPIDocument>} The parsed AsyncAPI document.
  */
 function parseFromUrl(url, fetchOptions, options) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -39,8 +39,8 @@ module.exports = {
  * The complete list of parse configuration options used to parse the given data.
  * @typedef {Object} ParserOptions
  * @property {String=} path - Path to the AsyncAPI document. It will be used to resolve relative references. Defaults to current working dir.
- * @property {Object=} parse - Options object to pass to {@link https://apidevtools.org/json-schema-ref-parser/docs/options.html|json-schema-ref-parser}.
- * @property {Object=} resolve - Options object to pass to {@link https://apidevtools.org/json-schema-ref-parser/docs/options.html|json-schema-ref-parser}.
+ * @property {Object=} parse - Options object to pass to {@link https://apitools.dev/json-schema-ref-parser/docs/options.html|json-schema-ref-parser}.
+ * @property {Object=} resolve - Options object to pass to {@link https://apitools.dev/json-schema-ref-parser/docs/options.html|json-schema-ref-parser}.
  * @property {Boolean=} applyTraits - Whether to resolve and apply traits or not. Defaults to true.
  */
 


### PR DESCRIPTION
### Description
this PR is supposed to fix all the [dead links](https://github.com/asyncapi/parser-js/runs/6143265431?check_suite_focus=true) in markdown files across the repo.