### PR TITLE
refactor: add missed methods to models

### DIFF
--- a/src/models/asyncapi.ts
+++ b/src/models/asyncapi.ts
@@ -1,15 +1,29 @@
 import { AsyncAPIDocumentV2 } from "./v2";
 
-import type { InfoInterface } from "./info";
 import type { BaseModel } from "./base";
+import type { InfoInterface } from "./info";
+import type { ChannelsInterface } from "./channels";
+import type { ComponentsInterface } from "./components";
+import type { MessagesInterface } from "./messages";
 import type { ExtensionsMixinInterface } from "./mixins";
+import type { OperationsInterface } from "./operations";
+import type { SchemasInterface } from "./schemas";
+import type { SecuritySchemesInterface } from "./security-schemes";
 import type { ServersInterface } from "./servers";
 import type { DetailedAsyncAPI } from "../types";
 
 export interface AsyncAPIDocumentInterface extends BaseModel, ExtensionsMixinInterface {
   version(): string;
+  defaultContentType(): string | undefined;
+  hasDefaultContentType(): boolean;
   info(): InfoInterface;
   servers(): ServersInterface;
+  channels(): ChannelsInterface;
+  operations(): OperationsInterface;
+  messages(): MessagesInterface;
+  schemas(): SchemasInterface;
+  securitySchemes(): SecuritySchemesInterface;
+  components(): ComponentsInterface;
 }
 
 export function newAsyncAPIDocument(asyncapi: DetailedAsyncAPI): AsyncAPIDocumentInterface {
@@ -17,7 +31,7 @@ export function newAsyncAPIDocument(asyncapi: DetailedAsyncAPI): AsyncAPIDocumen
     case 2:
       return new AsyncAPIDocumentV2(asyncapi.parsed, { asyncapi, pointer: '/' });
     // case 3:
-    //   return new AsyncAPIDocumentV3(asyncapi.parsed, { asyncapi, pointer: '/' }) as any;
+    //   return new AsyncAPIDocumentV3(asyncapi.parsed, { asyncapi, pointer: '/' });
     default:
       throw new Error(`Unsupported AsyncAPI version: ${asyncapi.semver.version}`);
   }

--- a/src/models/channel.ts
+++ b/src/models/channel.ts
@@ -1,5 +1,6 @@
 import type { BaseModel } from "./base";
 import type { ChannelParametersInterface } from "./channel-parameters";
+import type { MessagesInterface } from "./messages";
 import type { BindingsMixinInterface, DescriptionMixinInterface, ExtensionsMixinInterface } from "./mixins";
 import type { OperationsInterface } from "./operations";
 import type { ServersInterface } from "./servers";
@@ -9,5 +10,6 @@ export interface ChannelInterface extends BaseModel, BindingsMixinInterface, Des
   address(): string;
   servers(): ServersInterface;
   operations(): OperationsInterface;
+  messages(): MessagesInterface;
   parameters(): ChannelParametersInterface;
 }

--- a/src/models/message.ts
+++ b/src/models/message.ts
@@ -1,10 +1,16 @@
 import type { BaseModel } from "./base";
+import type { ChannelsInterface } from "./channels";
 import type { MessageTraitsInterface } from "./message-traits";
 import type { MessageTraitInterface } from "./message-trait";
+import type { OperationsInterface } from "./operations";
 import type { SchemaInterface } from "./schema";
+import type { ServersInterface } from "./servers";
 
 export interface MessageInterface extends BaseModel, MessageTraitInterface {
   hasPayload(): boolean;
   payload(): SchemaInterface | undefined;
+  servers(): ServersInterface;
+  channels(): ChannelsInterface;
+  operations(): OperationsInterface;
   traits(): MessageTraitsInterface;
 }

--- a/src/models/operation.ts
+++ b/src/models/operation.ts
@@ -1,11 +1,15 @@
 import type { BaseModel } from "./base";
+import type { ChannelsInterface } from "./channels";
 import type { MessagesInterface } from "./messages";
 import type { OperationTraitsInterface } from "./operation-traits";
 import type { OperationTraitInterface } from "./operation-trait";
+import type { ServersInterface } from "./servers";
 
 export type OperationAction = 'send' | 'receive' | 'publish' | 'subscribe';
 
 export interface OperationInterface extends BaseModel, OperationTraitInterface {
+  servers(): ServersInterface;
+  channels(): ChannelsInterface;
   messages(): MessagesInterface;
   traits(): OperationTraitsInterface;
 }

--- a/src/models/server.ts
+++ b/src/models/server.ts
@@ -1,5 +1,8 @@
 import type { BaseModel } from "./base";
+import type { ChannelsInterface } from './channels'
+import type { MessagesInterface } from './messages'
 import type { BindingsMixinInterface, DescriptionMixinInterface, ExtensionsMixinInterface } from './mixins';
+import type { OperationsInterface } from './operations'
 import type { ServerVariablesInterface } from "./server-variables";
 import type { SecuritySchemeInterface } from "./security-scheme";
 
@@ -9,6 +12,9 @@ export interface ServerInterface extends BaseModel, DescriptionMixinInterface, B
   protocol(): string;
   protocolVersion(): string;
   hasProtocolVersion(): boolean;
+  channels(): ChannelsInterface;
+  operations(): OperationsInterface;
+  messages(): MessagesInterface;
   variables(): ServerVariablesInterface;
   security(): Array<Record<string, { schema: SecuritySchemeInterface; scopes: string[]; }>>;
 }

--- a/src/models/v2/channel.ts
+++ b/src/models/v2/channel.ts
@@ -15,6 +15,8 @@ import { ExtensionsMixin } from './mixins/extensions';
 import type { ModelMetadata } from "../base";
 import type { ChannelInterface } from "../channel";
 import type { ChannelParametersInterface } from "../channel-parameters";
+import type { MessagesInterface } from "../messages";
+import type { MessageInterface } from "../message";
 import type { OperationsInterface } from "../operations";
 import type { OperationInterface } from "../operation";
 import type { ServersInterface } from "../servers";
@@ -48,18 +50,19 @@ export class Channel extends Mixin(BaseModel, BindingsMixin, DescriptionMixin, E
   }
 
   operations(): OperationsInterface {
-    const operations: OperationInterface[] = []
-    if (this._json.publish) {
-      operations.push(
-        this.createModel(Operation, this._json.publish, { id: 'publish', action: 'publish', pointer: `${this._meta.pointer}/publish` }),
+    const operations: OperationInterface[] = [];
+    ['publish', 'subscribe'].forEach(operationKind => {
+      this._json[operationKind] && operations.push(
+        this.createModel(Operation, this._json[operationKind], { id: operationKind, action: operationKind, pointer: `${this._meta.pointer}/${operationKind}` }),
       );
-    }
-    if (this._json.subscribe) {
-      operations.push(
-        this.createModel(Operation, this._json.subscribe, { id: 'subscribe', action: 'subscribe', pointer: `${this._meta.pointer}/subscribe` }),
-      );
-    }
+    });
     return new Operations(operations);
+  }
+
+  messages(): MessagesInterface {
+    const messages: MessageInterface[] = [];
+    this.operations().forEach(operation => messages.push(...operation.messages().all()));
+    return new Messages(messages);
   }
 
   parameters(): ChannelParametersInterface {

--- a/src/models/v2/channel.ts
+++ b/src/models/v2/channel.ts
@@ -51,9 +51,9 @@ export class Channel extends Mixin(BaseModel, BindingsMixin, DescriptionMixin, E
 
   operations(): OperationsInterface {
     const operations: OperationInterface[] = [];
-    ['publish', 'subscribe'].forEach(operationKind => {
-      this._json[operationKind] && operations.push(
-        this.createModel(Operation, this._json[operationKind], { id: operationKind, action: operationKind, pointer: `${this._meta.pointer}/${operationKind}` }),
+    ['publish', 'subscribe'].forEach(operationAction => {
+      this._json[operationAction] && operations.push(
+        this.createModel(Operation, this._json[operationAction], { id: operationAction, action: operationAction, pointer: `${this._meta.pointer}/${operationAction}` }),
       );
     });
     return new Operations(operations);

--- a/src/models/v2/message.ts
+++ b/src/models/v2/message.ts
@@ -59,14 +59,14 @@ export class Message extends MessageTrait implements MessageInterface {
   operations(): OperationsInterface {
     const operations: OperationInterface[] = [];
     Object.entries(this._meta.asyncapi?.parsed.channels || {}).forEach(([channelAddress, channel]: [string, any]) => {
-      ['subscribe', 'publish'].forEach(operationKind => {
-        const operation = channel[operationKind];
+      ['subscribe', 'publish'].forEach(operationAction => {
+        const operation = channel[operationAction];
         if (operation && (
           operation.message === this._json ||
           (operation.message.oneOf || []).includes(this._json)
         )) {
           operations.push(
-            this.createModel(Operation, operation, { pointer: `/channels/${tilde(channelAddress)}/${operationKind}` })
+            this.createModel(Operation, operation, { pointer: `/channels/${tilde(channelAddress)}/${operationAction}`, action: operationAction })
           );
         }
       });

--- a/src/models/v2/operation.ts
+++ b/src/models/v2/operation.ts
@@ -1,13 +1,48 @@
-import { Message } from "./message";
+import { Channels } from "./channels";
+import { Channel } from "./channel";
 import { Messages } from "./messages";
+import { Message } from "./message";
 import { OperationTraits } from "./operation-traits";
 import { OperationTrait } from "./operation-trait";
+import { Servers } from "./servers";
 
+import { tilde } from "../../utils";
+
+import type { ChannelsInterface } from "../channels";
+import type { ChannelInterface } from "../channel";
 import type { MessagesInterface } from "../messages";
 import type { OperationInterface } from "../operation";
 import type { OperationTraitsInterface } from "../operation-traits";
+import type { ServersInterface } from "../servers";
+import type { ServerInterface } from "../server";
 
 export class Operation extends OperationTrait implements OperationInterface {
+  servers(): ServersInterface {
+    const servers: ServerInterface[] = [];
+    const serversData: any[] = [];
+    this.channels().forEach(channel => {
+      channel.servers().forEach(server => {
+        if (!serversData.includes(server.json())) {
+          serversData.push(server.json());
+          servers.push(server);
+        }
+      })
+    });
+    return new Servers(servers);
+  }
+
+  channels(): ChannelsInterface {
+    const channels: ChannelInterface[] = [];
+    Object.entries(this._meta.asyncapi.parsed.channels || {}).forEach(([channelAddress, channel]: [string, any]) => {
+      if (channel.subscribe === this._json || channel.publish === this._json) {
+        channels.push(
+          this.createModel(Channel, channel, { id: channelAddress, pointer: `/channels/${tilde(channelAddress)}` })
+        );
+      }
+    });
+    return new Channels(channels);
+  }
+
   messages(): MessagesInterface {
     let isOneOf = false;
     let messages = this._json.message || [];

--- a/src/models/v2/operation.ts
+++ b/src/models/v2/operation.ts
@@ -36,7 +36,7 @@ export class Operation extends OperationTrait implements OperationInterface {
     Object.entries(this._meta.asyncapi.parsed.channels || {}).forEach(([channelAddress, channel]: [string, any]) => {
       if (channel.subscribe === this._json || channel.publish === this._json) {
         channels.push(
-          this.createModel(Channel, channel, { id: channelAddress, pointer: `/channels/${tilde(channelAddress)}` })
+          this.createModel(Channel, channel, { id: channelAddress, address: channelAddress, pointer: `/channels/${tilde(channelAddress)}` })
         );
       }
     });

--- a/src/models/v2/server.ts
+++ b/src/models/v2/server.ts
@@ -66,7 +66,9 @@ export class Server extends Mixin(BaseModel, BindingsMixin, DescriptionMixin, Ex
 
   operations(): OperationsInterface {
     const operations: OperationInterface[] = [];
-    this.channels().forEach(channel => operations.push(...channel.operations().all()));
+    this.channels().forEach(channel => {
+      operations.push(...channel.operations().all())
+    });
     return new Operations(operations);
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -100,3 +100,24 @@ export function mergePatch(origin: unknown, patch: unknown) {
 export function isObject(value: unknown): value is Record<string, any> {
   return Boolean(value) && typeof value === 'object' && Array.isArray(value) === false;
 }
+
+export function tilde(str: string) {
+  return str.replace(/[~\/]{1}/g, (sub) => {
+    switch (sub) {
+      case '/': return '~1';
+      case '~': return '~0';
+    }
+    return sub;
+  });
+};
+
+export function untilde(str: string) {
+  if (!str.includes('~')) return str;
+  return str.replace(/~[01]/g, (sub) => {
+    switch (sub) {
+      case '~1': return '/';
+      case '~0': return '~';
+    }
+    return sub;
+  });
+};

--- a/test/models/asyncapi.spec.ts
+++ b/test/models/asyncapi.spec.ts
@@ -1,0 +1,19 @@
+import { AsyncAPIDocumentV2, newAsyncAPIDocument } from '../../src/models';
+
+import { createDetailedAsyncAPI } from '../../src/utils';
+
+describe('AsyncAPIDocument factory', function() {
+  it('should create a valid document from v2.0.0', function() {
+    const doc = { asyncapi: "2.0.0" };
+    const detailed = createDetailedAsyncAPI(doc, doc);
+    const d = newAsyncAPIDocument(detailed)
+    expect(d.version()).toEqual(doc.asyncapi);
+    expect(d).toBeInstanceOf(AsyncAPIDocumentV2);
+  });
+
+  it('should fail trying to create a document from a non supported spec version', function() {
+    const doc = { asyncapi: "99.99.99" };
+    const detailed = createDetailedAsyncAPI(doc, doc);
+    expect(() => newAsyncAPIDocument(detailed)).toThrow("Unsupported AsyncAPI version: 99.99.99");
+  });
+});

--- a/test/models/v2/asyncapi.spec.ts
+++ b/test/models/v2/asyncapi.spec.ts
@@ -1,10 +1,12 @@
-import { 
-  newAsyncAPIDocument, 
-  AsyncAPIDocumentV2, 
-  InfoV2, 
-  ServersV2, 
-} from '../../../src/models';
-import { createDetailedAsyncAPI } from '../../../src/utils';
+import { AsyncAPIDocument } from '../../../src/models/v2/asyncapi';
+import { Channels } from '../../../src/models/v2/channels';
+import { Components } from '../../../src/models/v2/components';
+import { Info } from '../../../src/models/v2/info';
+import { Messages } from '../../../src/models/v2/messages';
+import { Operations } from '../../../src/models/v2/operations';
+import { Schemas } from '../../../src/models/v2/schemas';
+import { SecuritySchemes } from '../../../src/models/v2/security-schemes';
+import { Servers } from '../../../src/models/v2/servers';
 
 import { 
   assertExtensionsMixinInheritance,
@@ -14,50 +16,149 @@ describe('AsyncAPIDocument model', function() {
   describe('.version()', function() {
     it('should return the value', function() {
       const doc = { asyncapi: "2.0.0" };
-      const d = new AsyncAPIDocumentV2(doc);
+      const d = new AsyncAPIDocument(doc);
       expect(d.version()).toEqual(doc.asyncapi);
     });
     
     it('should return undefined when there is no value', function() {
       const doc = { };
-      const d = new AsyncAPIDocumentV2(doc);
+      const d = new AsyncAPIDocument(doc);
       expect(d.version()).toBeUndefined();
+    });
+  });
+
+  describe('.hasDefaultContentType()', function() {
+    it('should return true when there is a value', function() {
+      const doc = { defaultContentType: "..." };
+      const d = new AsyncAPIDocument(doc);
+      expect(d.hasDefaultContentType()).toEqual(true);
+    });
+    
+    it('should return false when there is no value', function() {
+      const doc = {};
+      const d = new AsyncAPIDocument(doc);
+      expect(d.hasDefaultContentType()).toEqual(false);
+    });
+  });
+
+  describe('.defaultContentType()', function() {
+    it('should return the value', function() {
+      const doc = { defaultContentType: "..." };
+      const d = new AsyncAPIDocument(doc);
+      expect(d.defaultContentType()).toEqual(doc.defaultContentType);
+    });
+    
+    it('should return undefined when there is no value', function() {
+      const doc = {};
+      const d = new AsyncAPIDocument(doc);
+      expect(d.defaultContentType()).toBeUndefined();
     });
   });
 
   describe('.info()', function() {
     it('should return an Info object', function() {
       const doc = { info: { name: "LeChuck" } };
-      const d = new AsyncAPIDocumentV2(doc);
-      expect(d.info()).toBeInstanceOf(InfoV2);
+      const d = new AsyncAPIDocument(doc);
+      expect(d.info()).toBeInstanceOf(Info);
     });
   });
 
-  describe('.servers()', function(){
-    it('should return an servers object', function(){
+  describe('.servers()', function() {
+    it('should return a collection of servers', function() {
       const doc = { servers: { development: {} } };
-      const d = new AsyncAPIDocumentV2(doc);
-      expect(d.servers()).toBeInstanceOf(ServersV2);
+      const d = new AsyncAPIDocument(doc);
+      expect(d.servers()).toBeInstanceOf(Servers);
+      expect(d.servers()).toHaveLength(1);
+      expect(d.servers().all()[0].id()).toEqual('development');
+    })
+
+    it('should return a collection of servers even if servers are not defined', function() {
+      const doc = {};
+      const d = new AsyncAPIDocument(doc);
+      expect(d.servers()).toBeInstanceOf(Servers);
+    })
+  })
+
+  describe('.channels()', function() {
+    it('should return a collection of channels', function() {
+      const doc = { channels: { 'user/signup': {} } };
+      const d = new AsyncAPIDocument(doc);
+      expect(d.channels()).toBeInstanceOf(Channels);
+      expect(d.channels()).toHaveLength(1);
+      expect(d.channels().all()[0].address()).toEqual('user/signup');
+    })
+
+    it('should return a collection of channels even if channels are not defined', function() {
+      const doc = {};
+      const d = new AsyncAPIDocument(doc);
+      expect(d.channels()).toBeInstanceOf(Channels);
+    })
+  })
+
+  describe('.operations()', function() {
+    it('should return a collection of operations', function() {
+      const doc = { channels: { 'user/signup': { publish: {}, subscribe: {} }, 'user/logout': { publish: {} } } };
+      const d = new AsyncAPIDocument(doc);
+      expect(d.operations()).toBeInstanceOf(Operations);
+      expect(d.operations()).toHaveLength(3);
+    })
+
+    it('should return a collection of operations even if operations are not defined', function() {
+      const doc = {};
+      const d = new AsyncAPIDocument(doc);
+      expect(d.operations()).toBeInstanceOf(Operations);
+    })
+  })
+
+  describe('.messages()', function() {
+    it('should return a collection of messages', function() {
+      const doc = { channels: { 'user/signup': { publish: { message: {} }, subscribe: { message: { oneOf: [{}, {}] } } }, 'user/logout': { publish: { message: {} } } } };
+      const d = new AsyncAPIDocument(doc);
+      expect(d.messages()).toBeInstanceOf(Messages);
+      expect(d.messages()).toHaveLength(4);
+    })
+
+    it('should return a collection of messages even if messages are not defined', function() {
+      const doc = {};
+      const d = new AsyncAPIDocument(doc);
+      expect(d.messages()).toBeInstanceOf(Messages);
+    })
+  })
+
+  describe('.schemas()', function() {
+    it.todo('should return a collection of schemas')
+  })
+
+  describe('.securitySchemes()', function() {
+    it('should return a collection of securitySchemes', function() {
+      const doc = { components: { securitySchemes: { security1: {}, security2: {} } } };
+      const d = new AsyncAPIDocument(doc);
+      expect(d.securitySchemes()).toBeInstanceOf(SecuritySchemes);
+      expect(d.securitySchemes()).toHaveLength(2);
+    })
+
+    it('should return a collection of securitySchemes even if securitySchemes are not defined', function() {
+      const doc = {};
+      const d = new AsyncAPIDocument(doc);
+      expect(d.securitySchemes()).toBeInstanceOf(SecuritySchemes);
+    })
+  })
+
+  describe('.components()', function() {
+    it('should return a components model', function() {
+      const doc = { components: {} };
+      const d = new AsyncAPIDocument(doc);
+      expect(d.components()).toBeInstanceOf(Components);
+    })
+
+    it('should return a components model even if components are not defined', function() {
+      const doc = {};
+      const d = new AsyncAPIDocument(doc);
+      expect(d.components()).toBeInstanceOf(Components);
     })
   })
 
   describe('mixins inheritance', function() {
-    assertExtensionsMixinInheritance(AsyncAPIDocumentV2);
-  });
-});
-
-describe('AsyncAPIDocument factory', function() {
-  it('should create a valid document from v2.0.0', function() {
-    const doc = { asyncapi: "2.0.0" };
-    const detailed = createDetailedAsyncAPI(doc, doc);
-    const d = newAsyncAPIDocument(detailed)
-    expect(d.version()).toEqual(doc.asyncapi);
-    expect(d).toBeInstanceOf(AsyncAPIDocumentV2);
-  });
-
-  it('should fail trying to create a document from a non supported spec version', function() {
-    const doc = { asyncapi: "99.99.99" };
-    const detailed = createDetailedAsyncAPI(doc, doc);
-    expect(() => newAsyncAPIDocument(detailed)).toThrow("Unsupported AsyncAPI version: 99.99.99");
+    assertExtensionsMixinInheritance(AsyncAPIDocument);
   });
 });

--- a/test/models/v2/channel.spec.ts
+++ b/test/models/v2/channel.spec.ts
@@ -3,6 +3,8 @@ import { ChannelParameters } from '../../../src/models/v2/channel-parameters';
 import { ChannelParameter } from '../../../src/models/v2/channel-parameter';
 import { Operations } from '../../../src/models/v2/operations';
 import { Operation } from '../../../src/models/v2/operation';
+import { Messages } from '../../../src/models/v2/messages';
+import { Message } from '../../../src/models/v2/message';
 import { Servers } from '../../../src/models/v2/servers';
 import { Server } from '../../../src/models/v2/server';
 
@@ -90,6 +92,35 @@ describe('Channel model', function() {
       expect(d.operations().all()[0].action()).toEqual('publish');
       expect(d.operations().all()[1]).toBeInstanceOf(Operation);
       expect(d.operations().all()[1].action()).toEqual('subscribe');
+    });
+  });
+
+  describe('.messages()', function() {
+    it('should return collection of messages - single message', function() {
+      const doc = { publish: { message: { messageId: '...' } } };
+      const d = new Channel(doc);
+      expect(d.messages()).toBeInstanceOf(Messages);
+      expect(d.messages().all()).toHaveLength(1);
+      expect(d.messages().all()[0]).toBeInstanceOf(Message);
+      expect(d.messages().all()[0].messageId()).toEqual(doc.publish.message.messageId);
+    });
+    
+    it('should return collection of messages - oneOf message', function() {
+      const doc = { subscribe: { message: { oneOf: [{ messageId: '1' }, { messageId: '2' }] } } };
+      const d = new Channel(doc);
+      expect(d.messages()).toBeInstanceOf(Messages);
+      expect(d.messages().all()).toHaveLength(2);
+      expect(d.messages().all()[0]).toBeInstanceOf(Message);
+      expect(d.messages().all()[0].messageId()).toEqual(doc.subscribe.message.oneOf[0].messageId);
+      expect(d.messages().all()[1]).toBeInstanceOf(Message);
+      expect(d.messages().all()[1].messageId()).toEqual(doc.subscribe.message.oneOf[1].messageId);
+    });
+
+    it('should return collection of messages - single message and oneOf', function() {
+      const doc = { publish: { message: {} }, subscribe: { message: { oneOf: [{ messageId: '1' }, { messageId: '2' }] } } };
+      const d = new Channel(doc);
+      expect(d.messages()).toBeInstanceOf(Messages);
+      expect(d.messages().all()).toHaveLength(3);
     });
   });
 

--- a/test/models/v2/message.spec.ts
+++ b/test/models/v2/message.spec.ts
@@ -1,7 +1,13 @@
+import { Channels } from '../../../src/models/v2/channels';
+import { Channel } from '../../../src/models/v2/channel';
 import { Message } from '../../../src/models/v2/message';
 import { MessageTraits } from '../../../src/models/v2/message-traits';
 import { MessageTrait } from '../../../src/models/v2/message-trait';
+import { Operations } from '../../../src/models/v2/operations';
+import { Operation } from '../../../src/models/v2/operation';
 import { Schema } from '../../../src/models/v2/schema';
+import { Servers } from '../../../src/models/v2/servers';
+import { Server } from '../../../src/models/v2/server';
 
 import { 
   assertBindingsMixinInheritance,
@@ -51,6 +57,101 @@ describe('Message model', function() {
       const doc = {};
       const d = new Message(doc);
       expect(d.payload()).toBeUndefined();
+    });
+  });
+
+  describe('.servers()', function() {
+    it('should return collection of servers - available on all servers', function() {
+      const doc = {};
+      const d = new Message(doc, { asyncapi: { parsed: { servers: { production: {}, development: {} }, channels: { 'user/signup': { publish: { message: doc } } } } } as any, pointer: '', id: 'message' });
+      expect(d.servers()).toBeInstanceOf(Servers);
+      expect(d.servers().all()).toHaveLength(2);
+      expect(d.servers().all()[0]).toBeInstanceOf(Server);
+      expect(d.servers().all()[0].id()).toEqual('production');
+      expect(d.servers().all()[1]).toBeInstanceOf(Server);
+      expect(d.servers().all()[1].id()).toEqual('development');
+    });
+
+    it('should return collection of servers - available on selected servers', function() {
+      const doc = {};
+      const d = new Message(doc, { asyncapi: { parsed: { servers: { production: {}, development: {} }, channels: { 'user/signup': { publish: { message: doc }, servers: ['production'] } } } } as any, pointer: '', id: 'message' });
+      expect(d.servers()).toBeInstanceOf(Servers);
+      expect(d.servers().all()).toHaveLength(1);
+      expect(d.servers().all()[0]).toBeInstanceOf(Server);
+      expect(d.servers().all()[0].id()).toEqual('production');
+    });
+
+    it('should return collection of servers - do not duplicate servers', function() {
+      const doc = {};
+      const d = new Message(doc, { asyncapi: { parsed: { servers: { production: {}, development: {} }, channels: { 'user/signup': { publish: { message: doc }, subscribe: { message: doc }, servers: ['production'] } } } } as any, pointer: '', id: 'message' });
+      expect(d.servers()).toBeInstanceOf(Servers);
+      expect(d.servers().all()).toHaveLength(1);
+      expect(d.servers().all()[0]).toBeInstanceOf(Server);
+      expect(d.servers().all()[0].id()).toEqual('production');
+    });
+  });
+
+  describe('.channels()', function() {
+    it('should return collection of channels - single channel', function() {
+      const doc = {};
+      const d = new Message(doc, { asyncapi: { parsed: { channels: { 'user/signup': { publish: { message: doc } } } } } as any, pointer: '', id: 'message' });
+      expect(d.channels()).toBeInstanceOf(Channels);
+      expect(d.channels().all()).toHaveLength(1);
+      expect(d.channels().all()[0]).toBeInstanceOf(Channel);
+      expect(d.channels().all()[0].address()).toEqual('user/signup');
+    });
+
+    it('should return collection of channels - multiple channels', function() {
+      const doc = {};
+      const d = new Message(doc, { asyncapi: { parsed: { channels: { 'user/signup': { publish: { message: doc } }, 'user/logout': { subscribe: { message: doc } } } } } as any, pointer: '', id: 'message' });
+      expect(d.channels()).toBeInstanceOf(Channels);
+      expect(d.channels().all()).toHaveLength(2);
+      expect(d.channels().all()[0]).toBeInstanceOf(Channel);
+      expect(d.channels().all()[0].address()).toEqual('user/signup');
+      expect(d.channels().all()[1]).toBeInstanceOf(Channel);
+      expect(d.channels().all()[1].address()).toEqual('user/logout');
+    });
+
+    it('should return collection of channels - do not duplicate channels', function() {
+      const doc = {};
+      const d = new Message(doc, { asyncapi: { parsed: { channels: { 'user/signup': { publish: { message: doc }, subscribe: { message: doc } } } } } as any, pointer: '', id: 'message' });
+      expect(d.channels()).toBeInstanceOf(Channels);
+      expect(d.channels().all()).toHaveLength(1);
+      expect(d.channels().all()[0]).toBeInstanceOf(Channel);
+      expect(d.channels().all()[0].address()).toEqual('user/signup');
+    });
+  });
+
+  describe('.operations()', function() {
+    it('should return collection of operations - single operation', function() {
+      const doc = {};
+      const d = new Message(doc, { asyncapi: { parsed: { channels: { 'user/signup': { publish: { message: doc } } } } } as any, pointer: '', id: 'message' });
+      expect(d.operations()).toBeInstanceOf(Operations);
+      expect(d.operations().all()).toHaveLength(1);
+      expect(d.operations().all()[0]).toBeInstanceOf(Operation);
+      expect(d.operations().all()[0].action()).toEqual('publish');
+    });
+
+    it('should return collection of operations - multiple operations', function() {
+      const doc = {};
+      const d = new Message(doc, { asyncapi: { parsed: { channels: { 'user/signup': { publish: { message: doc }, subscribe: { message: doc } } } } } as any, pointer: '', id: 'message' });
+      expect(d.operations()).toBeInstanceOf(Operations);
+      expect(d.operations().all()).toHaveLength(2);
+      expect(d.operations().all()[0]).toBeInstanceOf(Operation);
+      expect(d.operations().all()[0].action()).toEqual('subscribe');
+      expect(d.operations().all()[1]).toBeInstanceOf(Operation);
+      expect(d.operations().all()[1].action()).toEqual('publish');
+    });
+
+    it('should return collection of operations - multiple operations on different channels', function() {
+      const doc = {};
+      const d = new Message(doc, { asyncapi: { parsed: { channels: { 'user/signup': { publish: { message: doc } }, 'user/logout': { subscribe: { message: doc } } } } } as any, pointer: '', id: 'message' });
+      expect(d.operations()).toBeInstanceOf(Operations);
+      expect(d.operations().all()).toHaveLength(2);
+      expect(d.operations().all()[0]).toBeInstanceOf(Operation);
+      expect(d.operations().all()[0].action()).toEqual('publish');
+      expect(d.operations().all()[1]).toBeInstanceOf(Operation);
+      expect(d.operations().all()[1].action()).toEqual('subscribe');
     });
   });
 

--- a/test/models/v2/operation.spec.ts
+++ b/test/models/v2/operation.spec.ts
@@ -1,8 +1,12 @@
+import { Channels } from '../../../src/models/v2/channels';
+import { Channel } from '../../../src/models/v2/channel';
 import { Operation } from '../../../src/models/v2/operation';
 import { OperationTraits } from '../../../src/models/v2/operation-traits';
 import { OperationTrait } from '../../../src/models/v2/operation-trait';
 import { Messages } from '../../../src/models/v2/messages';
 import { Message } from '../../../src/models/v2/message';
+import { Servers } from '../../../src/models/v2/servers';
+import { Server } from '../../../src/models/v2/server';
 
 import { 
   assertBindingsMixinInheritance,
@@ -24,6 +28,70 @@ describe('Operation model', function() {
       const doc = { operationId: '...' };
       const d = new Operation(doc);
       expect(d.id()).toEqual(doc.operationId);
+    });
+  });
+
+  describe('.servers()', function() {
+    it('should return collection of servers - channel available on all servers', function() {
+      const doc = {};
+      const d = new Operation(doc, { asyncapi: { parsed: { servers: { production: {}, development: {} }, channels: { 'user/signup': { publish: doc } } } } as any, pointer: '', id: 'operation', action: 'publish' });
+      expect(d.servers()).toBeInstanceOf(Servers);
+      expect(d.servers().all()).toHaveLength(2);
+      expect(d.servers().all()[0]).toBeInstanceOf(Server);
+      expect(d.servers().all()[0].id()).toEqual('production');
+      expect(d.servers().all()[1]).toBeInstanceOf(Server);
+      expect(d.servers().all()[1].id()).toEqual('development');
+    });
+
+    it('should return collection of servers - channel available on selected servers', function() {
+      const doc = {};
+      const d = new Operation(doc, { asyncapi: { parsed: { servers: { production: {}, development: {} }, channels: { 'user/signup': { publish: doc, servers: ['production'] } } } } as any, pointer: '', id: 'operation', action: 'publish' });
+      expect(d.servers()).toBeInstanceOf(Servers);
+      expect(d.servers().all()).toHaveLength(1);
+      expect(d.servers().all()[0]).toBeInstanceOf(Server);
+      expect(d.servers().all()[0].id()).toEqual('production');
+    });
+
+    it('should return collection of servers - do not duplicate servers', function() {
+      const doc = {};
+      const d = new Operation(doc, { asyncapi: { parsed: { servers: { production: {}, development: {} }, channels: { 'user/signup': { publish: doc, servers: ['production'] }, 'user/logout': { subscribe: doc } } } } as any, pointer: '', id: 'operation', action: 'publish' });
+      expect(d.servers()).toBeInstanceOf(Servers);
+      expect(d.servers().all()).toHaveLength(2);
+      expect(d.servers().all()[0]).toBeInstanceOf(Server);
+      expect(d.servers().all()[0].id()).toEqual('production');
+      expect(d.servers().all()[1]).toBeInstanceOf(Server);
+      expect(d.servers().all()[1].id()).toEqual('development');
+    });
+  });
+
+  describe('.channels()', function() {
+    it('should return collection of channels - single channel', function() {
+      const doc = {};
+      const d = new Operation(doc, { asyncapi: { parsed: { channels: { 'user/signup': { publish: doc } } } } as any, pointer: '', id: 'operation', action: 'publish' });
+      expect(d.channels()).toBeInstanceOf(Channels);
+      expect(d.channels().all()).toHaveLength(1);
+      expect(d.channels().all()[0]).toBeInstanceOf(Channel);
+      expect(d.channels().all()[0].address()).toEqual('user/signup');
+    });
+
+    it('should return collection of channels - multiple channels', function() {
+      const doc = {};
+      const d = new Operation(doc, { asyncapi: { parsed: { channels: { 'user/signup': { publish: doc }, 'user/logout': { subscribe: doc } } } } as any, pointer: '', id: 'operation', action: 'publish' });
+      expect(d.channels()).toBeInstanceOf(Channels);
+      expect(d.channels().all()).toHaveLength(2);
+      expect(d.channels().all()[0]).toBeInstanceOf(Channel);
+      expect(d.channels().all()[0].address()).toEqual('user/signup');
+      expect(d.channels().all()[1]).toBeInstanceOf(Channel);
+      expect(d.channels().all()[1].address()).toEqual('user/logout');
+    });
+
+    it('should return collection of channels - do not duplicate channels', function() {
+      const doc = {};
+      const d = new Operation(doc, { asyncapi: { parsed: { channels: { 'user/signup': { publish: doc, subscribe: doc } } } } as any, pointer: '', id: 'operation', action: 'publish' });
+      expect(d.channels()).toBeInstanceOf(Channels);
+      expect(d.channels().all()).toHaveLength(1);
+      expect(d.channels().all()[0]).toBeInstanceOf(Channel);
+      expect(d.channels().all()[0].address()).toEqual('user/signup');
     });
   });
 

--- a/test/models/v2/server.spec.ts
+++ b/test/models/v2/server.spec.ts
@@ -1,3 +1,9 @@
+import { Channels } from '../../../src/models/v2/channels';
+import { Channel } from '../../../src/models/v2/channel';
+import { Messages } from '../../../src/models/v2/messages';
+import { Message } from '../../../src/models/v2/message';
+import { Operations } from '../../../src/models/v2/operations';
+import { Operation } from '../../../src/models/v2/operation';
 import { Server } from '../../../src/models/v2/server';
 import { ServerVariables } from '../../../src/models/v2/server-variables';
 import { SecurityScheme } from '../../../src/models/v2/security-scheme';
@@ -60,6 +66,111 @@ describe('Server Model', function () {
   describe('.url()', function () {
     it('should return value', function () {
       expect(docItem.url()).toMatch(doc.development.url);
+    });
+  });
+
+  describe('.channels()', function() {
+    it('should return collection of channels - single channel', function() {
+      const doc = {};
+      const d = new Server(doc, { asyncapi: { parsed: { channels: { 'user/signup': {} } } } as any, pointer: '', id: 'production' });
+      expect(d.channels()).toBeInstanceOf(Channels);
+      expect(d.channels().all()).toHaveLength(1);
+      expect(d.channels().all()[0]).toBeInstanceOf(Channel);
+      expect(d.channels().all()[0].address()).toEqual('user/signup');
+    });
+
+    it('should return collection of channels - multiple channels', function() {
+      const doc = {};
+      const d = new Server(doc, { asyncapi: { parsed: { channels: { 'user/signup': {}, 'user/logout': {} } } } as any, pointer: '', id: 'production' });
+      expect(d.channels()).toBeInstanceOf(Channels);
+      expect(d.channels().all()).toHaveLength(2);
+      expect(d.channels().all()[0]).toBeInstanceOf(Channel);
+      expect(d.channels().all()[0].address()).toEqual('user/signup');
+      expect(d.channels().all()[1]).toBeInstanceOf(Channel);
+      expect(d.channels().all()[1].address()).toEqual('user/logout');
+    });
+
+    it('should return collection of channels - server available only in particular channel', function() {
+      const doc = {};
+      const d = new Server(doc, { asyncapi: { parsed: { channels: { 'user/signup': { servers: ['production'] }, 'user/logout': { servers: ['development'] }, 'user/create': {} } } } as any, pointer: '', id: 'production', });
+      expect(d.channels()).toBeInstanceOf(Channels);
+      expect(d.channels().all()).toHaveLength(2);
+      expect(d.channels().all()[0]).toBeInstanceOf(Channel);
+      expect(d.channels().all()[0].address()).toEqual('user/signup');
+      expect(d.channels().all()[1]).toBeInstanceOf(Channel);
+      expect(d.channels().all()[1].address()).toEqual('user/create');
+    });
+  });
+
+  describe('.operations()', function() {
+    it('should return collection of operations - single channel', function() {
+      const doc = {};
+      const d = new Server(doc, { asyncapi: { parsed: { channels: { 'user/signup': { publish: { operationId: '1' } } } } } as any, pointer: '', id: 'production' });
+      expect(d.operations()).toBeInstanceOf(Operations);
+      expect(d.operations().all()).toHaveLength(1);
+      expect(d.operations().all()[0]).toBeInstanceOf(Operation);
+      expect(d.operations().all()[0].operationId()).toEqual('1');
+    });
+
+    it('should return collection of channels - multiple channels', function() {
+      const doc = {};
+      const d = new Server(doc, { asyncapi: { parsed: { channels: { 'user/signup': { publish: { operationId: '1' } }, 'user/logout': { subscribe: { operationId: '2' } } } } } as any, pointer: '', id: 'production' });
+      expect(d.operations()).toBeInstanceOf(Operations);
+      expect(d.operations().all()).toHaveLength(2);
+      expect(d.operations().all()[0]).toBeInstanceOf(Operation);
+      expect(d.operations().all()[0].operationId()).toEqual('1');
+      expect(d.operations().all()[1]).toBeInstanceOf(Operation);
+      expect(d.operations().all()[1].operationId()).toEqual('2');
+    });
+
+    it('should return collection of channels - server available only in particular channel', function() {
+      const doc = {};
+      const d = new Server(doc, { asyncapi: { parsed: { channels: { 'user/signup': { servers: ['production'], publish: { operationId: '1' } }, 'user/logout': { servers: ['development'] }, 'user/create': { subscribe: { operationId: '3' }, publish: { operationId: '2' } } } } } as any, pointer: '', id: 'production', });
+      expect(d.operations()).toBeInstanceOf(Operations);
+      expect(d.operations().all()).toHaveLength(3);
+      expect(d.operations().all()[0]).toBeInstanceOf(Operation);
+      expect(d.operations().all()[0].operationId()).toEqual('1');
+      expect(d.operations().all()[1]).toBeInstanceOf(Operation);
+      expect(d.operations().all()[1].operationId()).toEqual('2');
+      expect(d.operations().all()[2]).toBeInstanceOf(Operation);
+      expect(d.operations().all()[2].operationId()).toEqual('3');
+    });
+  });
+
+  describe('.messages()', function() {
+    it('should return collection of messages - single channel', function() {
+      const doc = {};
+      const d = new Server(doc, { asyncapi: { parsed: { channels: { 'user/signup': { publish: { message: { messageId: '1' } } } } } } as any, pointer: '', id: 'production' });
+      expect(d.messages()).toBeInstanceOf(Messages);
+      expect(d.messages().all()).toHaveLength(1);
+      expect(d.messages().all()[0]).toBeInstanceOf(Message);
+      expect(d.messages().all()[0].messageId()).toEqual('1');
+    });
+
+    it('should return collection of messages - multiple channels', function() {
+      const doc = {};
+      const d = new Server(doc, { asyncapi: { parsed: { channels: { 'user/signup': { publish: { message: { messageId: '1' } } }, 'user/logout': { subscribe: { message: { oneOf: [{ messageId: '2' }, { messageId: '3' }] } } } } } } as any, pointer: '', id: 'production' });
+      expect(d.messages()).toBeInstanceOf(Messages);
+      expect(d.messages().all()).toHaveLength(3);
+      expect(d.messages().all()[0]).toBeInstanceOf(Message);
+      expect(d.messages().all()[0].messageId()).toEqual('1');
+      expect(d.messages().all()[1]).toBeInstanceOf(Message);
+      expect(d.messages().all()[1].messageId()).toEqual('2');
+      expect(d.messages().all()[2]).toBeInstanceOf(Message);
+      expect(d.messages().all()[2].messageId()).toEqual('3');
+    });
+
+    it('should return collection of messages - server available only in particular channel', function() {
+      const doc = {};
+      const d = new Server(doc, { asyncapi: { parsed: { channels: { 'user/signup': { servers: ['production'], publish: { message: { messageId: '1' } } }, 'user/logout': { servers: ['development'] }, 'user/create': { subscribe: { message: { messageId: '3' } }, publish: { message: { messageId: '2' } } } } } } as any, pointer: '', id: 'production', });
+      expect(d.messages()).toBeInstanceOf(Messages);
+      expect(d.messages().all()).toHaveLength(3);
+      expect(d.messages().all()[0]).toBeInstanceOf(Message);
+      expect(d.messages().all()[0].messageId()).toEqual('1');
+      expect(d.messages().all()[1]).toBeInstanceOf(Message);
+      expect(d.messages().all()[1].messageId()).toEqual('2');
+      expect(d.messages().all()[2]).toBeInstanceOf(Message);
+      expect(d.messages().all()[2].messageId()).toEqual('3');
     });
   });
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- add missed methods to models: `AsyncAPI`, `Server`, `Channel`, `Operation`, `Message`, mainly `servers()`, `channels()`, `operations()`, `messages()`
- add unit tests

**Related issue(s)**
Part of #481 
Part of #482 