### PR TITLE
fix: case when message is oneOf for one element

### DIFF
--- a/lib/models/operation.js
+++ b/lib/models/operation.js
@@ -50,6 +50,7 @@ class Operation extends OperationTraitable {
    */
   message(index) {
     if (!this._json.message) return null;
+    if (this._json.message.oneOf && this._json.message.oneOf.length === 1) return new Message(this._json.message.oneOf[0]);
     if (!this._json.message.oneOf) return new Message(this._json.message);
     if (typeof index !== 'number') return null;
     if (index > this._json.message.oneOf.length - 1) return null;

--- a/test/models/operation_test.js
+++ b/test/models/operation_test.js
@@ -93,6 +93,12 @@ describe('Operation', function() {
       expect(d.message(0).json()).to.be.deep.equal(doc.message.oneOf[0]);
       expect(d.message(1).json()).to.be.deep.equal(doc.message.oneOf[1]);
     });
+
+    it('should return a Message object if no index is provided and message is oneOf from one element', function() {
+      const doc = { message: { oneOf: [{ test: true }] } };
+      const d = new Operation(doc);
+      expect(d.message().json()).to.be.deep.equal(doc.message.oneOf[0]);
+    });
     
     it('should return null when index is out of bounds', function() {
       const doc = { message: { oneOf: [{ test: true }, { test: false }] } };


### PR DESCRIPTION

**Description**

If message object is
```
      message:
        oneOf:
          - $ref: '#/components/messages/ixOtaResponse'
```
Then parser will return
```
channel.subscribe().hasMultipleMessages() => false
channel.subscribe().messages() => [ Message{ ... } ]
channel.subscribe().message() => Message{ ... }
```

**Related issue(s)**
Fixes #475 