### PR TITLE
feat: add support for tags field on Server model

### DIFF
--- a/lib/models/server.js
+++ b/lib/models/server.js
@@ -7,6 +7,7 @@ const ServerSecurityRequirement = require('./server-security-requirement');
 const MixinDescription = require('../mixins/description');
 const MixinBindings = require('../mixins/bindings');
 const MixinSpecificationExtensions = require('../mixins/specification-extensions');
+const MixinTags = require('../mixins/tags');
 
 /**
  * Implements functions to deal with a Server object.
@@ -16,6 +17,7 @@ const MixinSpecificationExtensions = require('../mixins/specification-extensions
  * @mixes MixinDescription
  * @mixes MixinBindings
  * @mixes MixinSpecificationExtensions
+ * @mixes MixinTags
  * @returns {Server}
  */
 class Server extends Base {
@@ -71,4 +73,4 @@ class Server extends Base {
   }
 }
 
-module.exports = mix(Server, MixinDescription, MixinBindings, MixinSpecificationExtensions);
+module.exports = mix(Server, MixinDescription, MixinBindings, MixinSpecificationExtensions, MixinTags);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
-        "@asyncapi/specs": "^3.0.0",
+        "@asyncapi/specs": "2.15.0-next-spec.2",
         "@fmvilas/pseudo-yaml-ast": "^0.3.1",
         "ajv": "^6.10.1",
         "js-yaml": "^3.13.1",
@@ -59,9 +59,9 @@
       }
     },
     "node_modules/@asyncapi/specs": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-3.1.0.tgz",
-      "integrity": "sha512-6xFvzDd54+M9g6EM259Y4a4iiFb2VzPr6eoxA/ttwTu7NRxaGScocXskXtuz53ZWx9BWZWuzwDYKfM3KBkDfiQ=="
+      "version": "2.15.0-next-spec.2",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.15.0-next-spec.2.tgz",
+      "integrity": "sha512-yjuNJOUh1XZBuP+cwhJSCjpnx6D5kb0VpcLTP1vi1RmQYUiF52KdjfbJYaFBW05+WZ/1sV92NkvmQfXAIlbaQw=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.8.3",
@@ -16112,9 +16112,9 @@
       }
     },
     "@asyncapi/specs": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-3.1.0.tgz",
-      "integrity": "sha512-6xFvzDd54+M9g6EM259Y4a4iiFb2VzPr6eoxA/ttwTu7NRxaGScocXskXtuz53ZWx9BWZWuzwDYKfM3KBkDfiQ=="
+      "version": "2.15.0-next-spec.2",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.15.0-next-spec.2.tgz",
+      "integrity": "sha512-yjuNJOUh1XZBuP+cwhJSCjpnx6D5kb0VpcLTP1vi1RmQYUiF52KdjfbJYaFBW05+WZ/1sV92NkvmQfXAIlbaQw=="
     },
     "@babel/code-frame": {
       "version": "7.8.3",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.0.6",
-    "@asyncapi/specs": "^3.0.0",
+    "@asyncapi/specs": "2.15.0-next-spec.2",
     "@fmvilas/pseudo-yaml-ast": "^0.3.1",
     "ajv": "^6.10.1",
     "js-yaml": "^3.13.1",

--- a/test/models/server_test.js
+++ b/test/models/server_test.js
@@ -1,11 +1,12 @@
 const { expect } = require('chai');
-const js = { url: 'test.com', protocol: 'amqp', protocolVersion: '0-9-1', description: 'test', variables: { test1: { enum: ['value1', 'value2'], default: 'value1', description: 'test1', examples: ['value2'] } }, security: [{ oauth2: ['user:read'] }], bindings: { amqp: 'test' }, 'x-test': 'testing' };
+const js = { url: 'test.com', protocol: 'amqp', protocolVersion: '0-9-1', description: 'test', variables: { test1: { enum: ['value1', 'value2'], default: 'value1', description: 'test1', examples: ['value2'] } }, security: [{ oauth2: ['user:read'] }], bindings: { amqp: 'test' }, 'x-test': 'testing', tags: [{ name: 'env:development' }] };
 
 const Server = require('../../lib/models/server');
 
 const { assertMixinDescriptionInheritance } = require('../mixins/description_test');
 const { assertMixinBindingsInheritance } = require('../mixins/bindings_test');
 const { assertMixinSpecificationExtensionsInheritance } = require('../mixins/specification-extensions_test');
+const { assertMixinTagsInheritance } = require('../mixins/tags_test');
 
 describe('Server', function() {
   describe('#url()', function() {
@@ -73,6 +74,7 @@ describe('Server', function() {
       assertMixinDescriptionInheritance(Server);
       assertMixinBindingsInheritance(Server);
       assertMixinSpecificationExtensionsInheritance(Server);
+      assertMixinTagsInheritance(Server);
     });
   });
 });


### PR DESCRIPTION
**Description**

This PR adds support for Tags on Server model. They can be used for providing metadata, including the environment such as `production`, `development`, etc.

**Related issue(s)**
https://github.com/asyncapi/spec/issues/654