### PR TITLE
refactor: add RAML Schema Parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,11 @@
         "@stoplight/spectral-parsers": "^1.0.1",
         "@stoplight/spectral-rulesets": "^1.4.3",
         "ajv": "^8.11.0",
+        "js-yaml": "^3.14.1",
         "jsonpath-plus": "^6.0.1",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.21",
+        "ramldt2jsonschema": "^1.2.3",
+        "webapi-parser": "^0.5.0"
       },
       "devDependencies": {
         "@jest/types": "^27.5.1",
@@ -2723,7 +2726,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
@@ -3195,7 +3197,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true,
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
@@ -3255,6 +3256,14 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/compare-func": {
@@ -4356,7 +4365,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -4575,8 +4583,7 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -7221,10 +7228,9 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-      "dev": true,
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -7351,11 +7357,39 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
+    "node_modules/json-schema-migrate": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/json-schema-migrate/-/json-schema-migrate-0.2.0.tgz",
+      "integrity": "sha512-dq4/oHWmtw/+0ytnXsDqVn+VsVweTEmzm5jLgguPn9BjSzn6/q58ZiZx3BHiQyJs612f0T5Z+MrUEUUY5DHsRg==",
+      "dependencies": {
+        "ajv": "^5.0.0"
+      }
+    },
+    "node_modules/json-schema-migrate/node_modules/ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha512-Ajr4IcMXq/2QmMkEmSvxqfLN5zGmJ92gHXAeOXq1OekoH2rfDNsgdDoL2f7QaRCy7G/E6TpxBVdRuNraMztGHw==",
+      "dependencies": {
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
+      }
+    },
+    "node_modules/json-schema-migrate/node_modules/fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha512-fueX787WZKCV0Is4/T2cyAdM4+x1S3MXXOAhavE1ys/W42SHAPacLTQhucja22QBYrfGw50M2sRiXPtTGv9Ymw=="
+    },
+    "node_modules/json-schema-migrate/node_modules/json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha512-4JD/Ivzg7PoW8NzdrBSr3UFwC9mHgvI7Z6z3QGBsSHgKaRTUDmyZAAKJo2UbG1kUVfS9WS8bi36N49U1xw43DA=="
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -13315,6 +13349,21 @@
       "integrity": "sha512-pVzZdDpWwWqEVVLshWUHjNwuVP7SfcmPraYuqocJp1yo2U1R7P+5QAfDhdItkuoGqIBnBYrtPp7rEPqDn9HlZA==",
       "dev": true
     },
+    "node_modules/ramldt2jsonschema": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/ramldt2jsonschema/-/ramldt2jsonschema-1.2.3.tgz",
+      "integrity": "sha512-+wLDAV2NNv9NkfEUOYStaDu/6RYgYXeC1zLtXE+dMU/jDfjpN4iJnBGycDwFTFaIQGosOQhxph7fEX6Mpwxdug==",
+      "dependencies": {
+        "commander": "^5.0.0",
+        "js-yaml": "^3.14.0",
+        "json-schema-migrate": "^0.2.0",
+        "webapi-parser": "^0.5.0"
+      },
+      "bin": {
+        "dt2js": "bin/dt2js.js",
+        "js2dt": "bin/js2dt.js"
+      }
+    },
     "node_modules/randomatic": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
@@ -14151,8 +14200,7 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "node_modules/stack-utils": {
       "version": "2.0.5",
@@ -14891,6 +14939,30 @@
       "dependencies": {
         "makeerror": "1.0.12"
       }
+    },
+    "node_modules/webapi-parser": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/webapi-parser/-/webapi-parser-0.5.0.tgz",
+      "integrity": "sha512-fPt6XuMqLSvBz8exwX4QE1UT+pROLHa00EMDCdO0ybICduwQ1V4f7AWX4pNOpCp+x+0FjczEsOxtQU0d8L3QKw==",
+      "dependencies": {
+        "ajv": "6.5.2"
+      }
+    },
+    "node_modules/webapi-parser/node_modules/ajv": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
+      "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
+      "dependencies": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.1"
+      }
+    },
+    "node_modules/webapi-parser/node_modules/fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w=="
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -17229,7 +17301,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -17598,8 +17669,7 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "coffee-script": {
       "version": "1.12.7",
@@ -17642,6 +17712,11 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
     },
     "compare-func": {
       "version": "1.3.2",
@@ -18488,8 +18563,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
       "version": "1.4.0",
@@ -18651,8 +18725,7 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -20646,10 +20719,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-      "dev": true,
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -20746,11 +20818,41 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
+    "json-schema-migrate": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/json-schema-migrate/-/json-schema-migrate-0.2.0.tgz",
+      "integrity": "sha512-dq4/oHWmtw/+0ytnXsDqVn+VsVweTEmzm5jLgguPn9BjSzn6/q58ZiZx3BHiQyJs612f0T5Z+MrUEUUY5DHsRg==",
+      "requires": {
+        "ajv": "^5.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha512-Ajr4IcMXq/2QmMkEmSvxqfLN5zGmJ92gHXAeOXq1OekoH2rfDNsgdDoL2f7QaRCy7G/E6TpxBVdRuNraMztGHw==",
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha512-fueX787WZKCV0Is4/T2cyAdM4+x1S3MXXOAhavE1ys/W42SHAPacLTQhucja22QBYrfGw50M2sRiXPtTGv9Ymw=="
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha512-4JD/Ivzg7PoW8NzdrBSr3UFwC9mHgvI7Z6z3QGBsSHgKaRTUDmyZAAKJo2UbG1kUVfS9WS8bi36N49U1xw43DA=="
+        }
+      }
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -25318,6 +25420,17 @@
       "integrity": "sha512-pVzZdDpWwWqEVVLshWUHjNwuVP7SfcmPraYuqocJp1yo2U1R7P+5QAfDhdItkuoGqIBnBYrtPp7rEPqDn9HlZA==",
       "dev": true
     },
+    "ramldt2jsonschema": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/ramldt2jsonschema/-/ramldt2jsonschema-1.2.3.tgz",
+      "integrity": "sha512-+wLDAV2NNv9NkfEUOYStaDu/6RYgYXeC1zLtXE+dMU/jDfjpN4iJnBGycDwFTFaIQGosOQhxph7fEX6Mpwxdug==",
+      "requires": {
+        "commander": "^5.0.0",
+        "js-yaml": "^3.14.0",
+        "json-schema-migrate": "^0.2.0",
+        "webapi-parser": "^0.5.0"
+      }
+    },
     "randomatic": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
@@ -25952,8 +26065,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "stack-utils": {
       "version": "2.0.5",
@@ -26504,6 +26616,32 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.12"
+      }
+    },
+    "webapi-parser": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/webapi-parser/-/webapi-parser-0.5.0.tgz",
+      "integrity": "sha512-fPt6XuMqLSvBz8exwX4QE1UT+pROLHa00EMDCdO0ybICduwQ1V4f7AWX4pNOpCp+x+0FjczEsOxtQU0d8L3QKw==",
+      "requires": {
+        "ajv": "6.5.2"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
+          "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.1"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w=="
+        }
       }
     },
     "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -55,8 +55,11 @@
     "@stoplight/spectral-parsers": "^1.0.1",
     "@stoplight/spectral-rulesets": "^1.4.3",
     "ajv": "^8.11.0",
+    "js-yaml": "^3.14.1",
     "jsonpath-plus": "^6.0.1",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "ramldt2jsonschema": "^1.2.3",
+    "webapi-parser": "^0.5.0"
   },
   "release": {
     "branches": [

--- a/src/schema-parser/raml-schema-parser.ts
+++ b/src/schema-parser/raml-schema-parser.ts
@@ -1,0 +1,69 @@
+import { SchemaParser, ParseSchemaInput, ValidateSchemaInput } from "../schema-parser";
+import type { AsyncAPISchema, SchemaValidateResult } from '../types';
+import yaml from 'js-yaml';
+import * as lib from "webapi-parser";
+const wap = lib.WebApiParser;
+const r2j = require('ramldt2jsonschema');
+
+export function RamlSchemaParser(): SchemaParser {
+    return {
+      validate,
+      parse,
+      getMimeTypes,
+    }
+  }
+
+async function parse(input: ParseSchemaInput<unknown, unknown>): Promise<AsyncAPISchema> {
+    const message = (input.meta as any).message
+    try {
+        const payload = formatPayload(input.data);
+
+        // Draft 6 is compatible with 7.
+        const jsonModel = await r2j.dt2js(payload, 'tmpType', { draft: '06' });
+        const convertedType = jsonModel.definitions.tmpType;
+
+        message['x-parser-original-schema-format'] = input.schemaFormat || input.defaultSchemaFormat;
+        message['x-parser-original-payload'] = payload;
+        message.payload = convertedType;
+        delete message.schemaFormat;
+    } catch (e) {
+        console.error(e);
+    }
+
+    return message.payload;
+}
+
+function getMimeTypes() {
+  return [
+    'application/raml+yaml;version=1.0',
+  ];
+}
+
+async function validate(input: ValidateSchemaInput<unknown, unknown>): Promise<SchemaValidateResult[]> {
+  const payload = formatPayload(input.data);
+  const parsed = await wap.raml10.parse(payload);
+  const report = await wap.raml10.validate(parsed);
+  if (report.conforms) {
+    // No errors found.
+    return [];
+  }
+  
+  let validateResult: SchemaValidateResult[] = [];
+  report.results.forEach(result => {
+    validateResult.push({
+      message: result.message,
+      path: input.path, // Info provided by the RAML parser doesn't provide a real path to the error.
+    } as SchemaValidateResult);
+  });
+
+  return validateResult;
+}
+
+function formatPayload(payload: any): string {
+  if (typeof payload === 'object') {
+      payload = `#%RAML 1.0 Library\n${ 
+      yaml.dump({ types: { tmpType: payload } })}`;
+  }
+
+  return payload as string;
+}

--- a/src/schema-parser/raml-schema-parser.ts
+++ b/src/schema-parser/raml-schema-parser.ts
@@ -14,22 +14,18 @@ export function RamlSchemaParser(): SchemaParser {
   }
 
 async function parse(input: ParseSchemaInput<unknown, unknown>): Promise<AsyncAPISchema> {
-    const message = (input.meta as any).message
-    try {
-        const payload = formatPayload(input.data);
+    const message = (input.meta as any).message;
+    const payload = formatPayload(input.data);
 
-        // Draft 6 is compatible with 7.
-        const jsonModel = await r2j.dt2js(payload, 'tmpType', { draft: '06' });
-        const convertedType = jsonModel.definitions.tmpType;
+    // Draft 6 is compatible with 7.
+    const jsonModel = await r2j.dt2js(payload, 'tmpType', { draft: '06' });
+    const convertedType = jsonModel.definitions.tmpType;
 
-        message['x-parser-original-schema-format'] = input.schemaFormat || input.defaultSchemaFormat;
-        message['x-parser-original-payload'] = payload;
-        message.payload = convertedType;
-        delete message.schemaFormat;
-    } catch (e) {
-        console.error(e);
-    }
-
+    message['x-parser-original-schema-format'] = input.schemaFormat || input.defaultSchemaFormat;
+    message['x-parser-original-payload'] = payload;
+    message.payload = convertedType;
+    delete message.schemaFormat;
+  
     return message.payload;
 }
 

--- a/src/schema-parser/raml-schema-parser.ts
+++ b/src/schema-parser/raml-schema-parser.ts
@@ -52,7 +52,7 @@ async function validate(input: ValidateSchemaInput<unknown, unknown>): Promise<S
   report.results.forEach(result => {
     validateResult.push({
       message: result.message,
-      path: input.path, // Info provided by the RAML parser doesn't provide a real path to the error.
+      path: [], // RAML parser doesn't provide a path to the error.
     } as SchemaValidateResult);
   });
 

--- a/test/schema-parser/raml/complex.json
+++ b/test/schema-parser/raml/complex.json
@@ -1,0 +1,90 @@
+{
+    "schemaFormat": "application/raml+yaml;version=1.0",
+    "payload":
+    {
+        "type":
+        [
+            "CatWithAddress",
+            "CatWithCity"
+        ],
+        "minProperties": 1,
+        "maxProperties": 50,
+        "additionalProperties": false,
+        "discriminator": "breed",
+        "discriminatorValue": "CatOne",
+        "properties":
+        {
+            "proscons":
+            {
+                "type": "CatPros | CatCons",
+                "required": true
+            },
+            "name":
+            {
+                "type": "CatName",
+                "amazing": true
+            },
+            "breed":
+            {
+                "type": "CatBreed"
+            },
+            "age": "CatAge",
+            "rating":
+            {
+                "type": "integer",
+                "multipleOf": 5,
+                "example":
+                {
+                    "displayName": "Cat's rating",
+                    "description": "Rating of cat's awesomeness",
+                    "strict": false,
+                    "value": 50
+                }
+            },
+            "year_of_birth": "date-only",
+            "time_of_birth": "time-only",
+            "dt_of_birth":
+            {
+                "type": "datetime-only",
+                "required": false
+            },
+            "addition_date":
+            {
+                "type": "datetime",
+                "format": "rfc2616"
+            },
+            "removal_date":
+            {
+                "type": "datetime"
+            },
+            "photo":
+            {
+                "type": "file",
+                "fileTypes":
+                [
+                    "image/jpeg",
+                    "image/png"
+                ],
+                "minLength": 1,
+                "maxLength": 307200
+            },
+            "description": "nil",
+            "habits?": "string",
+            "character": "nil | string",
+            "siblings": "string[]",
+            "parents": "CatName[]",
+            "ratingHistory": "(integer | number)[]",
+            "additionalData":
+            {
+                "type":
+                {
+                    "type": "object",
+                    "properties":
+                    {
+                        "weight": "number"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/schema-parser/raml/invalid.json
+++ b/test/schema-parser/raml/invalid.json
@@ -1,0 +1,13 @@
+{
+  "schemaFormat": "application/raml+yaml;version=1.0",
+  "payload": {
+    "type": "object",
+    "properties": {
+      "title": "string",
+      "author": {
+        "type": "string",
+        "examples": "test"
+      }
+    }
+  }
+}

--- a/test/schema-parser/raml/raml-schema-parser.spec.ts
+++ b/test/schema-parser/raml/raml-schema-parser.spec.ts
@@ -49,7 +49,7 @@ describe('validate()', function() {
     
     const result = (results as SchemaValidateResult[])[0];
     expect(result.message).toEqual("Property 'examples' should be a map");
-    expect(result.path).toEqual(inputWithInvalidRAML.path);
+    expect(result.path).toEqual([]); // Validator doesn't provide info about the error path
   });
 });
 

--- a/test/schema-parser/raml/raml-schema-parser.spec.ts
+++ b/test/schema-parser/raml/raml-schema-parser.spec.ts
@@ -1,0 +1,79 @@
+import { ParseSchemaInput, ValidateSchemaInput } from '../../../src/schema-parser/index';
+import { RamlSchemaParser } from '../../../src/schema-parser/raml-schema-parser';
+import { SchemaValidateResult } from '../../../src/types';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const inputWithSimpleRAML = toInput(fs.readFileSync(path.resolve(__dirname, './simple.json'), 'utf8'));
+const outputWithSimpleRAML = '{"payload":{"type":"object","examples":[{"title":"A book","author":"An author"}],"additionalProperties":true,"required":["title","author"],"properties":{"title":{"type":"string"},"author":{"type":"string","examples":["Eva"]}}},"x-parser-original-schema-format":"application/raml+yaml;version=1.0","x-parser-original-payload":"#%RAML 1.0 Library\\ntypes:\\n  tmpType:\\n    type: object\\n    properties:\\n      title: string\\n      author:\\n        type: string\\n        examples:\\n          anExample: Eva\\n    examples:\\n      exampleOne:\\n        title: A book\\n        author: An author\\n"}';
+
+const inputWithComplexRAML = toInput(fs.readFileSync(path.resolve(__dirname, './complex.json'), 'utf8'));
+const outputWithComplexRAML = `{"payload":{"minProperties":1,"maxProperties":50,"additionalProperties":false,"discriminator":"breed","discriminatorValue":"CatOne","type":"object","required":["proscons","name","breed","age","rating","year_of_birth","time_of_birth","addition_date","removal_date","photo","description","character","siblings","parents","ratingHistory","additionalData"],"properties":{"proscons":{"anyOf":[true,true]},"name":true,"breed":true,"age":true,"rating":{"type":"integer","multipleOf":5,"example":{"displayName":"Cat's rating","description":"Rating of cat's awesomeness","strict":false,"value":50}},"year_of_birth":{"type":"string","format":"date"},"time_of_birth":{"type":"string","format":"time"},"dt_of_birth":{"type":"string","format":"date-time-only"},"addition_date":{"type":"string","format":"rfc2616"},"removal_date":{"type":"string","format":"date-time"},"photo":{"type":"string","minLength":1,"maxLength":307200},"description":{"type":"null"},"habits":{"type":"string"},"character":{"anyOf":[{"type":"null"},{"type":"string"}]},"siblings":{"type":"array","items":{"type":"string"}},"parents":{"type":"array","items":true},"ratingHistory":{"type":"array","items":{"anyOf":[{"type":"integer"},{"type":"number"}]}},"additionalData":{"type":"object","additionalProperties":true,"required":["weight"],"properties":{"weight":{"type":"number"}}}}},"x-parser-original-schema-format":"application/raml+yaml;version=1.0","x-parser-original-payload":"#%RAML 1.0 Library\\ntypes:\\n  tmpType:\\n    type:\\n      - CatWithAddress\\n      - CatWithCity\\n    minProperties: 1\\n    maxProperties: 50\\n    additionalProperties: false\\n    discriminator: breed\\n    discriminatorValue: CatOne\\n    properties:\\n      proscons:\\n        type: CatPros | CatCons\\n        required: true\\n      name:\\n        type: CatName\\n        amazing: true\\n      breed:\\n        type: CatBreed\\n      age: CatAge\\n      rating:\\n        type: integer\\n        multipleOf: 5\\n        example:\\n          displayName: Cat's rating\\n          description: Rating of cat's awesomeness\\n          strict: false\\n          value: 50\\n      year_of_birth: date-only\\n      time_of_birth: time-only\\n      dt_of_birth:\\n        type: datetime-only\\n        required: false\\n      addition_date:\\n        type: datetime\\n        format: rfc2616\\n      removal_date:\\n        type: datetime\\n      photo:\\n        type: file\\n        fileTypes:\\n          - image/jpeg\\n          - image/png\\n        minLength: 1\\n        maxLength: 307200\\n      description: nil\\n      habits?: string\\n      character: nil | string\\n      siblings: 'string[]'\\n      parents: 'CatName[]'\\n      ratingHistory: '(integer | number)[]'\\n      additionalData:\\n        type:\\n          type: object\\n          properties:\\n            weight: number\\n"}`;
+
+const inputWithInvalidRAML = toInput(fs.readFileSync(path.resolve(__dirname, './invalid.json'), 'utf8'));
+
+describe('parse()', function() {
+  const parser = RamlSchemaParser();
+
+  it('should parse simple RAML data types', async function() {
+    await doTest(inputWithSimpleRAML, outputWithSimpleRAML);
+  });
+
+  it('should parse complex RAML data types', async function() {
+    await doTest(inputWithComplexRAML, outputWithComplexRAML);
+  });
+
+  async function doTest(originalInput: ParseSchemaInput, expectedOutput: string) {
+    const input = {...originalInput};
+    const result = await parser.parse(input);
+
+    // Check that the return value of parse() is the expected JSON Schema.
+    expect(result).toEqual(JSON.parse(expectedOutput).payload);
+
+    // Check that the message got modified, i.e. adding extensions, setting the payload, etc.
+    const message = (input.meta as any).message; 
+    expect(JSON.stringify(message)).toEqual(expectedOutput);
+  }
+});
+
+describe('validate()', function() {
+  const parser = RamlSchemaParser();
+
+  it('should validate valid RAML', async function() {
+    const result = await parser.validate(inputWithSimpleRAML);
+    expect(result).toHaveLength(0);
+  });
+  it('should validate invalid RAML', async function() {
+    const results = await parser.validate(inputWithInvalidRAML);
+    expect(results).toHaveLength(1);
+    
+    const result = (results as SchemaValidateResult[])[0];
+    expect(result.message).toEqual("Property 'examples' should be a map");
+    expect(result.path).toEqual(inputWithInvalidRAML.path);
+  });
+});
+
+function toInput(raw: string): ParseSchemaInput | ValidateSchemaInput {
+  const message = JSON.parse(raw);
+  const schemaInput = {
+    asyncapi: {
+      semver: {
+        version: "2.4.0",
+        major: 2,
+        minor: 4,
+        patch: 0
+      }, 
+      source: "",
+      parsed: {},
+    },
+    path: ["otherchannel", "subscribe", "message", "payload"],
+    data: message.payload,
+    meta: {
+      message: message,
+    },
+    schemaFormat: message.schemaFormat,
+    defaultSchemaFormat: "application/vnd.aai.asyncapi;version=2.4.0",
+  };
+
+  return schemaInput;
+}

--- a/test/schema-parser/raml/simple.json
+++ b/test/schema-parser/raml/simple.json
@@ -1,0 +1,21 @@
+{
+    "schemaFormat": "application/raml+yaml;version=1.0",
+    "payload": {
+      "type": "object",
+      "properties": {
+        "title": "string",
+        "author": {
+          "type": "string",
+          "examples": {
+            "anExample": "Eva"
+          }
+        }
+      },
+      "examples": {
+        "exampleOne": {
+          "title": "A book",
+          "author": "An author"
+        }
+      }
+    }
+}


### PR DESCRIPTION
**Description**

This PR does the following:

- Ports https://github.com/asyncapi/raml-dt-schema-parser to TypeScript.
- Makes it compliant with the [new interface](https://github.com/asyncapi/parser-js/issues/480) for Schema Parsers (new `validate()` method).

> **Note**
> Schema validation is done through https://github.com/raml-org/webapi-parser. It does not provide a real JSON Path value for validation errors or something that can be really transformed in all cases. By now, path will point to the message payload but we can keep investigating other solutions.

**Related issue(s)**
https://github.com/asyncapi/parser-js/issues/480