### PR TITLE
refactor: fix AsyncAPI Schema Parser error path

### DIFF
--- a/src/schema-parser/asyncapi-schema-parser.ts
+++ b/src/schema-parser/asyncapi-schema-parser.ts
@@ -28,7 +28,7 @@ async function validate(input: ValidateSchemaInput<unknown, unknown>): Promise<S
   let result: SchemaValidateResult[] = []
   const valid = validator(input.data);
   if (!valid && validator.errors) {
-    result = ajvToSpectralResult([...validator.errors], input.path);
+    result = ajvToSpectralResult([...validator.errors]);
   }
 
   return result;
@@ -55,17 +55,11 @@ function getMimeTypes() {
   return mimeTypes;
 }
 
-function ajvToSpectralResult(errors: ErrorObject[], parentPath: Array<string | number>): SchemaValidateResult[] {
-  if (parentPath === undefined) {
-    parentPath = [];
-  }
-
+function ajvToSpectralResult(errors: ErrorObject[]): SchemaValidateResult[] {
   return errors.map(error => {
-    const errorPath = error.instancePath.replace(/^\//, '').split('/');
-
     return {
       message: error.message,
-      path: parentPath.concat(errorPath),
+      path: error.instancePath.replace(/^\//, '').split('/'),
     } as SchemaValidateResult;
   });
 }

--- a/test/schema-parser/asyncapi-schema-parser.spec.ts
+++ b/test/schema-parser/asyncapi-schema-parser.spec.ts
@@ -67,19 +67,19 @@ describe('AsyncAPISchemaParser', function () {
     const expectedResult: SchemaValidateResult[] = [
       {
         message: 'must be object,boolean',
-        path: ['components', 'schemas', 'schema1', 'payload', 'properties', 'name', 'if']
+        path: ['properties', 'name', 'if']
       },
       {
         message: 'must be array',
-        path: ['components', 'schemas', 'schema1', 'payload', 'oneOf']
+        path: ['oneOf']
       },
       {
         message: 'must be array',
-        path: ['components', 'schemas', 'schema1', 'payload', 'oneOf']
+        path: ['oneOf']
       },
       {
         message: 'must be object,boolean',
-        path: ['components', 'schemas', 'schema1', 'payload', 'properties', 'name', 'if']
+        path: ['properties', 'name', 'if']
       }
     ];
 


### PR DESCRIPTION
**Description**

As mentioned in https://github.com/asyncapi/parser-js/pull/577#discussion_r952480918, the returned path should be relative to the payload and should not include the path to the payload itself. 

**Related issue(s)**
https://github.com/asyncapi/parser-js/issues/480