### PR TITLE
refactor: add schemaFormat method to the Message model

### DIFF
--- a/src/models/message-trait.ts
+++ b/src/models/message-trait.ts
@@ -6,6 +6,7 @@ import type { SchemaInterface } from "./schema";
 
 export interface MessageTraitInterface extends BaseModel, BindingsMixinInterface, DescriptionMixinInterface, ExtensionsMixinInterface, ExternalDocumentationMixinInterface, TagsMixinInterface {
   id(): string;
+  schemaFormat(): string;
   hasMessageId(): boolean;
   messageId(): string | undefined;
   hasCorrelationId(): boolean;

--- a/src/models/v2/message-trait.ts
+++ b/src/models/v2/message-trait.ts
@@ -4,7 +4,7 @@ import { MessageExamples } from './message-examples';
 import { MessageExample } from './message-example';
 import { Schema } from './schema';
 
-import { getDefaultSchemaFormat } from '../../schema-parser/index';
+import { getDefaultSchemaFormat } from '../../schema-parser';
 
 import { Mixin } from '../utils';
 import { BindingsMixin } from './mixins/bindings';

--- a/src/models/v2/message-trait.ts
+++ b/src/models/v2/message-trait.ts
@@ -4,6 +4,8 @@ import { MessageExamples } from './message-examples';
 import { MessageExample } from './message-example';
 import { Schema } from './schema';
 
+import { getDefaultSchemaFormat } from '../../schema-parser/index';
+
 import { Mixin } from '../utils';
 import { BindingsMixin } from './mixins/bindings';
 import { DescriptionMixin } from './mixins/description';
@@ -27,6 +29,10 @@ export class MessageTrait extends Mixin(BaseModel, BindingsMixin, DescriptionMix
 
   id(): string {
     return this.messageId() || this._meta.id;
+  }
+
+  schemaFormat(): string {
+    return this._json.schemaFormat || getDefaultSchemaFormat(this._meta.asyncapi.semver.version);
   }
 
   hasMessageId(): boolean {

--- a/test/models/v2/message-trait.spec.ts
+++ b/test/models/v2/message-trait.spec.ts
@@ -27,6 +27,20 @@ describe('MessageTrait model', function() {
     });
   });
 
+  describe('.schemaFormat()', function() {
+    it('should return defined schemaFormat', function() {
+      const doc = { schemaFormat: 'customSchemaFormat' };
+      const d = new MessageTrait(doc, { asyncapi: {} as any, pointer: '', id: 'message' });
+      expect(d.schemaFormat()).toEqual('customSchemaFormat');
+    });
+
+    it('should return default schemaFormat if schemaFormat field is absent', function() {
+      const doc = {};
+      const d = new MessageTrait(doc, { asyncapi: { semver: { version: '2.0.0' } } as any, pointer: '', id: 'message' });
+      expect(d.schemaFormat()).toEqual('application/vnd.aai.asyncapi;version=2.0.0');
+    });
+  });
+
   describe('.hasMessageId()', function() {
     it('should return true when there is a value', function() {
       const doc = { messageId: '...' };

--- a/test/models/v2/message.spec.ts
+++ b/test/models/v2/message.spec.ts
@@ -32,6 +32,20 @@ describe('Message model', function() {
     });
   });
 
+  describe('.schemaFormat()', function() {
+    it('should return defined schemaFormat', function() {
+      const doc = { schemaFormat: 'customSchemaFormat' };
+      const d = new Message(doc, { asyncapi: {} as any, pointer: '', id: 'message' });
+      expect(d.schemaFormat()).toEqual('customSchemaFormat');
+    });
+
+    it('should return default schemaFormat if schemaFormat field is absent', function() {
+      const doc = {};
+      const d = new Message(doc, { asyncapi: { semver: { version: '2.0.0' } } as any, pointer: '', id: 'message' });
+      expect(d.schemaFormat()).toEqual('application/vnd.aai.asyncapi;version=2.0.0');
+    });
+  });
+
   describe('.hasPayload()', function() {
     it('should return true when there is a value', function() {
       const doc = { payload: {} };


### PR DESCRIPTION
Add `schemaFormat` method to the `Message model` and `MessageTrait model`. Atm we don't have clarification if we wanna go forward with proposal https://github.com/asyncapi/spec/pull/797 so will add `schemaFormat` to mentioned models and (maybe) in the future deprecate that method.

cc @smoya 

Part of:
#482 
#481 