### PR TITLE
refactor: simplify operation traits based on parser-api

### DIFF
--- a/src/models/operation-trait.ts
+++ b/src/models/operation-trait.ts
@@ -1,12 +1,9 @@
 import type { BaseModel } from "./base";
 import type { BindingsMixinInterface, DescriptionMixinInterface, ExtensionsMixinInterface, ExternalDocumentationMixinInterface, TagsMixinInterface } from './mixins';
-import type { OperationAction } from "./operation";
-import type { SecuritySchemeInterface } from "./security-scheme";
 import { SecurityRequirements } from "./v2/security-requirements";
 
 export interface OperationTraitInterface extends BaseModel, BindingsMixinInterface, DescriptionMixinInterface, ExtensionsMixinInterface, ExternalDocumentationMixinInterface, TagsMixinInterface {
   id(): string;
-  action(): OperationAction;
   hasOperationId(): boolean;
   operationId(): string | undefined;
   hasSummary(): boolean;

--- a/src/models/operation.ts
+++ b/src/models/operation.ts
@@ -8,6 +8,9 @@ import type { ServersInterface } from "./servers";
 export type OperationAction = 'send' | 'receive' | 'publish' | 'subscribe';
 
 export interface OperationInterface extends BaseModel, OperationTraitInterface {
+  action(): OperationAction;
+  isSend(): boolean;
+  isReceive(): boolean;
   servers(): ServersInterface;
   channels(): ChannelsInterface;
   messages(): MessagesInterface;

--- a/src/models/v2/operation-trait.ts
+++ b/src/models/v2/operation-trait.ts
@@ -52,6 +52,14 @@ export class OperationTrait<J extends v2.OperationTraitObject = v2.OperationTrai
     return hasExternalDocs(this);
   }
 
+  isSend(): boolean {
+    return this.action() === 'subscribe';
+  }
+
+  isReceive(): boolean {
+    return this.action() === 'publish';
+  }
+
   externalDocs(): ExternalDocumentationInterface | undefined {
     return externalDocs(this);
   }

--- a/test/models/v2/operation-trait.spec.ts
+++ b/test/models/v2/operation-trait.spec.ts
@@ -20,14 +20,6 @@ describe('OperationTrait model', function() {
     });
   });
 
-  describe('.action()', function() {
-    it('should return kind/action of operation', function() {
-      const doc = {};
-      const d = new OperationTrait(doc, { asyncapi: {} as any, pointer: '', id: 'trait', action: 'publish' });
-      expect(d.action()).toEqual('publish');
-    });
-  });
-
   describe('.hasOperationId()', function() {
     it('should return true when there is a value', function() {
       const doc = { operationId: '...' };

--- a/test/models/v2/operation.spec.ts
+++ b/test/models/v2/operation.spec.ts
@@ -89,6 +89,42 @@ describe('Operation model', function() {
     });
   });
 
+  describe('.action()', function() {
+    it('should return kind/action of operation', function() {
+      const doc = {};
+      const d = new OperationTrait(doc, { asyncapi: {} as any, pointer: '', id: 'trait', action: 'publish' });
+      expect(d.action()).toEqual('publish');
+    });
+  });
+
+  describe('.isSend()', function() {
+    it('should return true when operation is subscribe', function() {
+      const doc = {};
+      const d = new OperationTrait(doc, { asyncapi: {} as any, pointer: '', id: 'trait', action: 'subscribe' });
+      expect(d.isSend()).toBeTruthy();
+    });
+
+    it('should return false when operation is publish', function() {
+      const doc = {};
+      const d = new OperationTrait(doc, { asyncapi: {} as any, pointer: '', id: 'trait', action: 'publish' });
+      expect(d.isSend()).toBeFalsy();
+    });
+  });
+
+  describe('.isReceive()', function() {
+    it('should return true when operation is publish', function() {
+      const doc = {};
+      const d = new OperationTrait(doc, { asyncapi: {} as any, pointer: '', id: 'trait', action: 'publish' });
+      expect(d.isReceive()).toBeTruthy();
+    });
+
+    it('should return false when operation is subscribe', function() {
+      const doc = {};
+      const d = new OperationTrait(doc, { asyncapi: {} as any, pointer: '', id: 'trait', action: 'subscribe' });
+      expect(d.isReceive()).toBeFalsy();
+    });
+  });
+
   describe('.messages()', function() {
     it('should return collection of messages - single message', function() {
       const doc = { message: { messageId: '...' } };


### PR DESCRIPTION
**Description**

This PR simplifies `OperationTrait` based on last changes found in https://github.com/asyncapi/parser-api/pull/71#issuecomment-1235603136.
Also added `isSend` and `isReceive` methods to `Operation`.

**Related issue(s)**
https://github.com/asyncapi/parser-js/issues/401