### PR TITLE
refactor: add filters to some collections

### DIFF
--- a/src/models/channels.ts
+++ b/src/models/channels.ts
@@ -1,4 +1,7 @@
 import type { Collection } from "./collection";
 import type { ChannelInterface } from "./channel";
 
-export interface ChannelsInterface extends Collection<ChannelInterface> {}
+export interface ChannelsInterface extends Collection<ChannelInterface> {
+    filterBySend(): ChannelInterface[]
+    filterByReceive(): ChannelInterface[]
+}

--- a/src/models/channels.ts
+++ b/src/models/channels.ts
@@ -2,6 +2,6 @@ import type { Collection } from "./collection";
 import type { ChannelInterface } from "./channel";
 
 export interface ChannelsInterface extends Collection<ChannelInterface> {
-    filterBySend(): ChannelInterface[]
-    filterByReceive(): ChannelInterface[]
+  filterBySend(): ChannelInterface[];
+  filterByReceive(): ChannelInterface[];
 }

--- a/src/models/collection.ts
+++ b/src/models/collection.ts
@@ -17,4 +17,8 @@ export abstract class Collection<T extends BaseModel | Collection<any>> extends 
   isEmpty(): boolean {
     return this.collections.length === 0;
   }
+
+  filterBy(filter: (item: T) => boolean): T[] {
+    return this.collections.filter(filter);
+  }
 }

--- a/src/models/messages.ts
+++ b/src/models/messages.ts
@@ -1,4 +1,7 @@
 import type { Collection } from "./collection";
 import type { MessageInterface } from "./message";
 
-export interface MessagesInterface extends Collection<MessageInterface> {}
+export interface MessagesInterface extends Collection<MessageInterface> {
+    filterBySend(): MessageInterface[]
+    filterByReceive(): MessageInterface[]
+}

--- a/src/models/messages.ts
+++ b/src/models/messages.ts
@@ -2,6 +2,6 @@ import type { Collection } from "./collection";
 import type { MessageInterface } from "./message";
 
 export interface MessagesInterface extends Collection<MessageInterface> {
-    filterBySend(): MessageInterface[]
-    filterByReceive(): MessageInterface[]
+  filterBySend(): MessageInterface[];
+  filterByReceive(): MessageInterface[];
 }

--- a/src/models/operations.ts
+++ b/src/models/operations.ts
@@ -2,6 +2,6 @@ import type { Collection } from "./collection";
 import type { OperationInterface } from "./operation";
 
 export interface OperationsInterface extends Collection<OperationInterface> {
-    filterBySend(): OperationInterface[]
-    filterByReceive(): OperationInterface[]
+  filterBySend(): OperationInterface[];
+  filterByReceive(): OperationInterface[];
 }

--- a/src/models/operations.ts
+++ b/src/models/operations.ts
@@ -1,4 +1,7 @@
 import type { Collection } from "./collection";
 import type { OperationInterface } from "./operation";
 
-export interface OperationsInterface extends Collection<OperationInterface> {}
+export interface OperationsInterface extends Collection<OperationInterface> {
+    filterBySend(): OperationInterface[]
+    filterByReceive(): OperationInterface[]
+}

--- a/src/models/servers.ts
+++ b/src/models/servers.ts
@@ -1,4 +1,7 @@
 import type { Collection } from "./collection";
 import type { ServerInterface } from "./server";
 
-export interface ServersInterface extends Collection<ServerInterface> {}
+export interface ServersInterface extends Collection<ServerInterface> {
+    filterBySend(): ServerInterface[]
+    filterByReceive(): ServerInterface[]
+}

--- a/src/models/servers.ts
+++ b/src/models/servers.ts
@@ -2,6 +2,6 @@ import type { Collection } from "./collection";
 import type { ServerInterface } from "./server";
 
 export interface ServersInterface extends Collection<ServerInterface> {
-    filterBySend(): ServerInterface[]
-    filterByReceive(): ServerInterface[]
+  filterBySend(): ServerInterface[];
+  filterByReceive(): ServerInterface[];
 }

--- a/src/models/v2/channels.ts
+++ b/src/models/v2/channels.ts
@@ -11,4 +11,16 @@ export class Channels extends Collection<ChannelInterface> implements ChannelsIn
   override has(id: string): boolean {
     return this.collections.some(channel => channel.id() === id);
   }
+
+  filterBySend(): ChannelInterface[] {
+      return this.filterBy(function (channel: ChannelInterface): boolean {
+        return channel.operations().filterBySend().length > 0;
+      })
+  }
+
+  filterByReceive(): ChannelInterface[] {
+    return this.filterBy(function (channel: ChannelInterface): boolean {
+      return channel.operations().filterByReceive().length > 0;
+    });
+  }
 }

--- a/src/models/v2/channels.ts
+++ b/src/models/v2/channels.ts
@@ -13,14 +13,10 @@ export class Channels extends Collection<ChannelInterface> implements ChannelsIn
   }
 
   filterBySend(): ChannelInterface[] {
-      return this.filterBy(function (channel: ChannelInterface): boolean {
-        return channel.operations().filterBySend().length > 0;
-      })
+    return this.filterBy(channel => channel.operations().filterBySend().length > 0);
   }
 
   filterByReceive(): ChannelInterface[] {
-    return this.filterBy(function (channel: ChannelInterface): boolean {
-      return channel.operations().filterByReceive().length > 0;
-    });
+    return this.filterBy(channel => channel.operations().filterByReceive().length > 0);
   }
 }

--- a/src/models/v2/messages.ts
+++ b/src/models/v2/messages.ts
@@ -11,4 +11,16 @@ export class Messages extends Collection<MessageInterface> implements MessagesIn
   override has(id: string): boolean {
     return this.collections.some(message => message.id() === id);
   }
+
+  filterBySend(): MessageInterface[] {
+      return this.filterBy(function (messages: MessageInterface): boolean {
+        return messages.operations().filterBySend().length > 0;
+      })
+  }
+
+  filterByReceive(): MessageInterface[] {
+    return this.filterBy(function (messages: MessageInterface): boolean {
+      return messages.operations().filterByReceive().length > 0;
+    });
+  }
 }

--- a/src/models/v2/messages.ts
+++ b/src/models/v2/messages.ts
@@ -13,14 +13,10 @@ export class Messages extends Collection<MessageInterface> implements MessagesIn
   }
 
   filterBySend(): MessageInterface[] {
-      return this.filterBy(function (messages: MessageInterface): boolean {
-        return messages.operations().filterBySend().length > 0;
-      })
+    return this.filterBy(message => message.operations().filterBySend().length > 0);
   }
 
   filterByReceive(): MessageInterface[] {
-    return this.filterBy(function (messages: MessageInterface): boolean {
-      return messages.operations().filterByReceive().length > 0;
-    });
+    return this.filterBy(message => message.operations().filterByReceive().length > 0);
   }
 }

--- a/src/models/v2/operations.ts
+++ b/src/models/v2/operations.ts
@@ -13,14 +13,10 @@ export class Operations extends Collection<OperationInterface> implements Operat
   }
 
   filterBySend(): OperationInterface[] {
-    return this.filterBy(function (operation: OperationInterface): boolean {
-      return operation.isSend();
-    })
+    return this.filterBy(operation => operation.isSend());
   }
 
   filterByReceive(): OperationInterface[] {
-    return this.filterBy(function (operation: OperationInterface): boolean {
-      return operation.isReceive();
-    });
+    return this.filterBy(operation => operation.isReceive());
   }
 }

--- a/src/models/v2/operations.ts
+++ b/src/models/v2/operations.ts
@@ -11,4 +11,16 @@ export class Operations extends Collection<OperationInterface> implements Operat
   override has(id: string): boolean {
     return this.collections.some(operation => operation.id() === id);
   }
+
+  filterBySend(): OperationInterface[] {
+    return this.filterBy(function (operation: OperationInterface): boolean {
+      return operation.isSend();
+    })
+  }
+
+  filterByReceive(): OperationInterface[] {
+    return this.filterBy(function (operation: OperationInterface): boolean {
+      return operation.isReceive();
+    });
+  }
 }

--- a/src/models/v2/servers.ts
+++ b/src/models/v2/servers.ts
@@ -10,4 +10,16 @@ export class Servers extends Collection<ServerInterface> implements ServersInter
   override has(id: string): boolean {
     return this.collections.some(server => server.id() === id);
   }
+
+  filterBySend(): ServerInterface[] {
+    return this.filterBy(function (server: ServerInterface): boolean {
+      return server.operations().filterBySend().length > 0;
+    })
+  }
+
+  filterByReceive(): ServerInterface[] {
+    return this.filterBy(function (server: ServerInterface): boolean {
+      return server.operations().filterByReceive().length > 0;
+    });
+  }
 }

--- a/src/models/v2/servers.ts
+++ b/src/models/v2/servers.ts
@@ -12,14 +12,10 @@ export class Servers extends Collection<ServerInterface> implements ServersInter
   }
 
   filterBySend(): ServerInterface[] {
-    return this.filterBy(function (server: ServerInterface): boolean {
-      return server.operations().filterBySend().length > 0;
-    })
+    return this.filterBy(server => server.operations().filterBySend().length > 0);
   }
 
   filterByReceive(): ServerInterface[] {
-    return this.filterBy(function (server: ServerInterface): boolean {
-      return server.operations().filterByReceive().length > 0;
-    });
+    return this.filterBy(server => server.operations().filterByReceive().length > 0);
   }
 }

--- a/test/models/collection.spec.ts
+++ b/test/models/collection.spec.ts
@@ -76,4 +76,28 @@ describe('Collection model', function() {
       expect(d.get('name1')).toEqual(undefined);
     });
   });
+
+  describe('.filterBy()', function() {
+    it('should return array of ItemModel if filter function matches', function() {
+      const doc = { name: 'name' };
+      const item = new ItemModel(doc);
+      const d = new Model([item]);
+
+      const filter = function (_: ItemModel): boolean {
+        return true;
+      }
+      expect(d.filterBy(filter)).toEqual([item]);
+    });
+
+    it('should return empty array of ItemModel if filter function does not match', function() {
+      const doc = { name: 'name' };
+      const item = new ItemModel(doc);
+      const d = new Model([item]);
+
+      const filter = function (_: ItemModel): boolean {
+        return false;
+      }
+      expect(d.filterBy(filter)).toEqual([]);
+    });
+  });
 });

--- a/test/models/v2/channels.spec.ts
+++ b/test/models/v2/channels.spec.ts
@@ -5,6 +5,12 @@ const channel = {
   publish: {},
 };
 const channelItem = new Channel(channel, { asyncapi: {} as any, pointer: '', id: 'channel', address: '' });
+const channelItems = [
+  new Channel({ publish: {operationId: 'test1'} }, { asyncapi: {} as any, pointer: '', id: 'channel1', address: '' }),
+  new Channel({ publish: {operationId: 'test2'} }, { asyncapi: {} as any, pointer: '', id: 'channel2', address: '' }),
+  new Channel({ subscribe: {operationId: 'test3'} }, { asyncapi: {} as any, pointer: '', id: 'channel3', address: '' }),
+  new Channel({ subscribe: {operationId: 'test4'} }, { asyncapi: {} as any, pointer: '', id: 'channel4', address: '' }),
+];
 
 describe('Channels model', function () {
   describe('.isEmpty()', function () {
@@ -40,6 +46,30 @@ describe('Channels model', function () {
     it('should return false if the Channel name is missing', function () {
       const servers = new Channels([channelItem]);
       expect(servers.has('anotherName')).toEqual(false);
+    })
+  })
+
+  describe('.filterBySend()', function () {
+    it('should return all channels with subscribe operation', function () {
+      const operations = new Channels(channelItems);
+      expect(operations.filterBySend()).toEqual([channelItems[2], channelItems[3]]);
+    })
+
+    it('should return empty if there are no channels with operations with subscribe action', function () {
+      const operations = new Channels([channelItems[0], channelItems[1]]);
+      expect(operations.filterBySend()).toEqual([]);
+    })
+  })
+
+  describe('.filterByReceive()', function () {
+    it('should return all channels with publish operation', function () {
+      const operations = new Channels(channelItems);
+      expect(operations.filterByReceive()).toEqual([channelItems[0], channelItems[1]]);
+    })
+
+    it('should return empty if there are no channels with operations with publish action', function () {
+      const operations = new Channels([channelItems[2], channelItems[3]]);
+      expect(operations.filterByReceive()).toEqual([]);
     })
   })
 })

--- a/test/models/v2/messages.spec.ts
+++ b/test/models/v2/messages.spec.ts
@@ -5,41 +5,71 @@ const message = {
   messageId: 'test',
 };
 const messageItem = new Message(message, { asyncapi: {} as any, pointer: '', id: 'test' });
+const messageItems = [
+  new Message({ messageId: "test1" }, { asyncapi: { parsed: { channels: { test1: { publish: { operationId: "test1", message: { messageId: "test1" } } } } } } as any, pointer: '', id: 'test1' }),
+  new Message({ messageId: "test2" }, { asyncapi: { parsed: { channels: { test2: { publish: { operationId: "test2", message: { messageId: "test2" } } } } } } as any, pointer: '', id: 'test2' }),
+  new Message({ messageId: "test3" }, { asyncapi: { parsed: { channels: { test3: { subscribe: { operationId: "test3", message: { messageId: "test3" } } } } } } as any, pointer: '', id: 'test3' }),
+  new Message({ messageId: "test4" }, { asyncapi: { parsed: { channels: { test4: { subscribe: { operationId: "test4", message: { messageId: "test4" } } } } } } as any, pointer: '', id: 'test4' }),
+];
 
 describe('Messages model', function () {
   describe('.isEmpty()', function () {
     it('should return true if collection is empty', function () {
-      const servers = new Messages([]);
-      expect(servers.isEmpty()).toEqual(true);
+      const messages = new Messages([]);
+      expect(messages.isEmpty()).toEqual(true);
     });
 
     it('should return false if collection is not empty', function () {
-      const servers = new Messages([messageItem]);
-      expect(servers.isEmpty()).toEqual(false);
+      const messages = new Messages([messageItem]);
+      expect(messages.isEmpty()).toEqual(false);
     });
   });
 
   describe('.get(id)', function () {
     it('should return a specific Message if it is present', function () {
-      const servers = new Messages([messageItem]);
-      expect(servers.get('test')).toBeTruthy();
+      const messages = new Messages([messageItem]);
+      expect(messages.get('test')).toBeTruthy();
     });
 
     it('should return undefined if specific Message is missing', function () {
-      const servers = new Messages([]);
-      expect(servers.get('test')).toBeUndefined();
+      const messages = new Messages([]);
+      expect(messages.get('test')).toBeUndefined();
     });
   });
 
   describe('.has(id)', function () {
     it('should return true if the said id is available', function () {
-      const servers = new Messages([messageItem]);
-      expect(servers.has('test')).toEqual(true);
+      const messages = new Messages([messageItem]);
+      expect(messages.has('test')).toEqual(true);
     })
 
     it('should return false if the Message id is missing', function () {
-      const servers = new Messages([messageItem]);
-      expect(servers.has('anotherId')).toEqual(false);
+      const messages = new Messages([messageItem]);
+      expect(messages.has('anotherId')).toEqual(false);
+    })
+  })
+
+  describe('.filterBySend()', function () {
+    it('should return all messages in channels with subscribe operation', function () {
+      const messages = new Messages(messageItems);
+      expect(messages.filterBySend()).toEqual([messageItems[2], messageItems[3]]);
+    })
+
+    it('should return empty if there are no messages in channels with operations with subscribe action', function () {
+      const messages = new Messages([messageItems[0], messageItems[1]]);
+      expect(messages.filterBySend()).toEqual([]);
+    })
+  })
+
+  describe('.filterByReceive()', function () {
+    it('should return all messages in channels with publish operation', function () {
+      const messages = new Messages(messageItems);
+      expect(messages.filterByReceive()).toEqual([messageItems[0], messageItems[1]]);
+    })
+
+    it('should return empty if there are no messages in channels with operations with publish action', function () {
+      const messages = new Messages([messageItems[2], messageItems[3]]);
+      expect(messages.filterByReceive()).toEqual([]);
     })
   })
 })

--- a/test/models/v2/messages.spec.ts
+++ b/test/models/v2/messages.spec.ts
@@ -1,15 +1,18 @@
 import { Messages } from '../../../src/models/v2/messages';
 import { Message } from '../../../src/models/v2/message';
 
-const message = {
-  messageId: 'test',
-};
-const messageItem = new Message(message, { asyncapi: {} as any, pointer: '', id: 'test' });
+const messages = {
+  test1: { messageId: 'test1' },
+  test2: { messageId: 'test2' },
+  test3: { messageId: 'test3' },
+  test4: { messageId: 'test4' },
+}
+
 const messageItems = [
-  new Message({ messageId: "test1" }, { asyncapi: { parsed: { channels: { test1: { publish: { operationId: "test1", message: { messageId: "test1" } } } } } } as any, pointer: '', id: 'test1' }),
-  new Message({ messageId: "test2" }, { asyncapi: { parsed: { channels: { test2: { publish: { operationId: "test2", message: { messageId: "test2" } } } } } } as any, pointer: '', id: 'test2' }),
-  new Message({ messageId: "test3" }, { asyncapi: { parsed: { channels: { test3: { subscribe: { operationId: "test3", message: { messageId: "test3" } } } } } } as any, pointer: '', id: 'test3' }),
-  new Message({ messageId: "test4" }, { asyncapi: { parsed: { channels: { test4: { subscribe: { operationId: "test4", message: { messageId: "test4" } } } } } } as any, pointer: '', id: 'test4' }),
+  new Message(messages.test1, { asyncapi: { parsed: { channels: { test1: { publish: { operationId: "test1", message: messages.test1 } } } } } as any, pointer: '', id: 'test1' }),
+  new Message(messages.test2, { asyncapi: { parsed: { channels: { test2: { publish: { operationId: "test2", message: messages.test2 } } } } } as any, pointer: '', id: 'test2' }),
+  new Message(messages.test3, { asyncapi: { parsed: { channels: { test3: { subscribe: { operationId: "test3", message: messages.test3 } } } } } as any, pointer: '', id: 'test3' }),
+  new Message(messages.test4, { asyncapi: { parsed: { channels: { test4: { subscribe: { operationId: "test4", message: messages.test4 } } } } } as any, pointer: '', id: 'test4' }),
 ];
 
 describe('Messages model', function () {
@@ -20,31 +23,31 @@ describe('Messages model', function () {
     });
 
     it('should return false if collection is not empty', function () {
-      const messages = new Messages([messageItem]);
+      const messages = new Messages([messageItems[0]]);
       expect(messages.isEmpty()).toEqual(false);
     });
   });
 
   describe('.get(id)', function () {
     it('should return a specific Message if it is present', function () {
-      const messages = new Messages([messageItem]);
-      expect(messages.get('test')).toBeTruthy();
+      const messages = new Messages([messageItems[0]]);
+      expect(messages.get('test1')).toBeTruthy();
     });
 
     it('should return undefined if specific Message is missing', function () {
       const messages = new Messages([]);
-      expect(messages.get('test')).toBeUndefined();
+      expect(messages.get('test1')).toBeUndefined();
     });
   });
 
   describe('.has(id)', function () {
     it('should return true if the said id is available', function () {
-      const messages = new Messages([messageItem]);
-      expect(messages.has('test')).toEqual(true);
+      const messages = new Messages([messageItems[0]]);
+      expect(messages.has('test1')).toEqual(true);
     })
 
     it('should return false if the Message id is missing', function () {
-      const messages = new Messages([messageItem]);
+      const messages = new Messages([messageItems[0]]);
       expect(messages.has('anotherId')).toEqual(false);
     })
   })

--- a/test/models/v2/operations.spec.ts
+++ b/test/models/v2/operations.spec.ts
@@ -5,41 +5,71 @@ const operation = {
   operationId: 'test',
 };
 const operationItem = new Operation(operation, { asyncapi: {} as any, pointer: '', id: 'test', action: 'publish' });
+const operationItems = [
+  new Operation({operationId: 'test1'}, { asyncapi: {} as any, pointer: '', id: 'test1', action: 'publish' }),
+  new Operation({operationId: 'test2'}, { asyncapi: {} as any, pointer: '', id: 'test2', action: 'publish' }),
+  new Operation({operationId: 'test3'}, { asyncapi: {} as any, pointer: '', id: 'test3', action: 'subscribe' }),
+  new Operation({operationId: 'test4'}, { asyncapi: {} as any, pointer: '', id: 'test4', action: 'subscribe' }),
+];
 
 describe('Operations model', function () {
   describe('.isEmpty()', function () {
     it('should return true if collection is empty', function () {
-      const servers = new Operations([]);
-      expect(servers.isEmpty()).toEqual(true);
+      const operations = new Operations([]);
+      expect(operations.isEmpty()).toEqual(true);
     });
 
     it('should return false if collection is not empty', function () {
-      const servers = new Operations([operationItem]);
-      expect(servers.isEmpty()).toEqual(false);
+      const operations = new Operations([operationItem]);
+      expect(operations.isEmpty()).toEqual(false);
     });
   });
 
   describe('.get(id)', function () {
     it('should return a specific Operation if it is present', function () {
-      const servers = new Operations([operationItem]);
-      expect(servers.get('test')).toBeTruthy();
+      const operations = new Operations([operationItem]);
+      expect(operations.get('test')).toBeTruthy();
     });
 
     it('should return undefined if specific Operation is missing', function () {
-      const servers = new Operations([]);
-      expect(servers.get('test')).toBeUndefined();
+      const operations = new Operations([]);
+      expect(operations.get('test')).toBeUndefined();
     });
   });
 
   describe('.has(id)', function () {
     it('should return true if the said id is available', function () {
-      const servers = new Operations([operationItem]);
-      expect(servers.has('test')).toEqual(true);
+      const operations = new Operations([operationItem]);
+      expect(operations.has('test')).toEqual(true);
     })
 
     it('should return false if the Operation id is missing', function () {
-      const servers = new Operations([operationItem]);
-      expect(servers.has('anotherId')).toEqual(false);
+      const operations = new Operations([operationItem]);
+      expect(operations.has('anotherId')).toEqual(false);
+    })
+  })
+
+  describe('.filterBySend()', function () {
+    it('should return all operations with subscribe action', function () {
+      const operations = new Operations(operationItems);
+      expect(operations.filterBySend()).toEqual([operationItems[2], operationItems[3]]);
+    })
+
+    it('should return empty if there are no operations with subscribe action', function () {
+      const operations = new Operations([operationItems[0], operationItems[1]]);
+      expect(operations.filterBySend()).toEqual([]);
+    })
+  })
+
+  describe('.filterByReceive()', function () {
+    it('should return all operations with publish action', function () {
+      const operations = new Operations(operationItems);
+      expect(operations.filterByReceive()).toEqual([operationItems[0], operationItems[1]]);
+    })
+
+    it('should return empty if there are no operations with publish action', function () {
+      const operations = new Operations([operationItems[2], operationItems[3]]);
+      expect(operations.filterByReceive()).toEqual([]);
     })
   })
 })

--- a/test/models/v2/servers.spec.ts
+++ b/test/models/v2/servers.spec.ts
@@ -6,9 +6,31 @@ const doc = {
     protocol: 'mqtt',
     protocolVersion: '1.0.0',
     url: 'development.gigantic-server.com'
+  },
+  'development2': {
+    protocol: 'mqtt',
+    protocolVersion: '1.0.0',
+    url: 'development2.gigantic-server.com'
+  },
+  'production': {
+    protocol: 'mqtt',
+    protocolVersion: '1.0.0',
+    url: 'production.gigantic-server.com'
+  },
+  'production2': {
+    protocol: 'mqtt',
+    protocolVersion: '1.0.0',
+    url: 'production2.gigantic-server.com'
   }
 };
+
 const docItem = new Server(doc.development, { asyncapi: {} as any, pointer: '', id: 'development' });
+const serverItems = [
+  new Server(doc.development, { asyncapi: { parsed: { channels: { test1: { publish: { operationId: "test1" } } } } } as any, pointer: '', id: 'development' }),
+  new Server(doc.development2, { asyncapi: { parsed: { channels: { test2: { publish: { operationId: "test2" } } } } } as any, pointer: '', id: 'development2' }),
+  new Server(doc.production, { asyncapi: { parsed: { channels: { test3: { subscribe: { operationId: "test3" } } } } } as any, pointer: '', id: 'production' }),
+  new Server(doc.production2, { asyncapi: { parsed: { channels: { test4: { subscribe: { operationId: "test4" } } } } } as any, pointer: '', id: 'production2' }),
+];
 
 describe('Servers model', function () {
   describe('.isEmpty()', function () {
@@ -44,6 +66,30 @@ describe('Servers model', function () {
     it('should return false if the server name is missing', function () {
       const servers = new Servers([docItem]);
       expect(servers.has('production')).toEqual(false);
+    })
+  })
+
+  describe('.filterBySend()', function () {
+    it('should return all servers with channels with subscribe operation', function () {
+      const servers = new Servers(serverItems);
+      expect(servers.filterBySend()).toEqual([serverItems[2], serverItems[3]]);
+    })
+
+    it('should return empty if there are no servers with channels with operations with subscribe action', function () {
+      const servers = new Servers([serverItems[0], serverItems[1]]);
+      expect(servers.filterBySend()).toEqual([]);
+    })
+  })
+
+  describe('.filterByReceive()', function () {
+    it('should return all servers with channels with publish operation', function () {
+      const servers = new Servers(serverItems);
+      expect(servers.filterByReceive()).toEqual([serverItems[0], serverItems[1]]);
+    })
+
+    it('should return empty if there are no servers with channels with operations with publish action', function () {
+      const servers = new Servers([serverItems[2], serverItems[3]]);
+      expect(servers.filterByReceive()).toEqual([]);
     })
   })
 })


### PR DESCRIPTION
**Description**

This PR adds:
- `FilterBySend()` method to `Messages`, `Servers`, `Operations`, `Channels` models.
- `FilterByReceive()` method to `Messages`, `Servers`, `Operations`, `Channels` models.

All changes are done based on the Parser-API; last development in particular can be found in https://github.com/asyncapi/parser-api/pull/71.

**Related issue(s)**
https://github.com/asyncapi/parser-js/issues/401