### PR TITLE
refactor: add possibility to pass custom resolvers (unstable)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@types/json-schema": "^7.0.11",
         "@types/lodash": "^4.14.179",
         "@types/node-fetch": "^2.6.2",
+        "@types/urijs": "^1.19.19",
         "@typescript-eslint/eslint-plugin": "^5.36.2",
         "@typescript-eslint/parser": "^5.36.2",
         "conventional-changelog-conventionalcommits": "^4.2.3",
@@ -2891,7 +2892,8 @@
     },
     "node_modules/@types/urijs": {
       "version": "1.19.19",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.19.tgz",
+      "integrity": "sha512-FDJNkyhmKLw7uEvTxx5tSXfPeQpO0iy73Ry+PmYZJvQy0QIWX8a7kJ4kLWRf+EbTPJEPDSgPXHaM7pzr5lmvCg=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.12",
@@ -19594,7 +19596,9 @@
       "dev": true
     },
     "@types/urijs": {
-      "version": "1.19.19"
+      "version": "1.19.19",
+      "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.19.tgz",
+      "integrity": "sha512-FDJNkyhmKLw7uEvTxx5tSXfPeQpO0iy73Ry+PmYZJvQy0QIWX8a7kJ4kLWRf+EbTPJEPDSgPXHaM7pzr5lmvCg=="
     },
     "@types/yargs": {
       "version": "17.0.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@asyncapi/specs": "^3.1.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "^3.2.0",
+        "@stoplight/json-ref-resolver": "^3.1.4",
         "@stoplight/spectral-core": "^1.14.1",
         "@stoplight/spectral-functions": "^1.7.1",
         "@stoplight/spectral-parsers": "^1.0.2",
@@ -2334,20 +2335,20 @@
       "license": "0BSD"
     },
     "node_modules/@stoplight/json-ref-resolver": {
-      "version": "3.1.3",
-      "license": "Apache-2.0",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@stoplight/json-ref-resolver/-/json-ref-resolver-3.1.4.tgz",
+      "integrity": "sha512-842JVmMsi++qpDuIX+JpQvK7YY8FXEZZb+/z4xuRfStOAVEryJT/tbgGOWxniSdxEl9Eni5D/I2afMyy6BuiNw==",
       "dependencies": {
         "@stoplight/json": "^3.17.0",
         "@stoplight/path": "^1.3.2",
-        "@stoplight/types": "^12.3.0",
-        "@types/urijs": "^1.19.16",
+        "@stoplight/types": "^12.3.0 || ^13.0.0",
+        "@types/urijs": "^1.19.19",
         "dependency-graph": "~0.11.0",
         "fast-memoize": "^2.5.2",
         "immer": "^9.0.6",
-        "lodash.get": "^4.4.2",
-        "lodash.set": "^4.3.2",
+        "lodash": "^4.17.21",
         "tslib": "^2.3.1",
-        "urijs": "^1.19.6"
+        "urijs": "^1.19.11"
       },
       "engines": {
         "node": ">=8.3.0"
@@ -2533,6 +2534,27 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@stoplight/spectral-ref-resolver/node_modules/@stoplight/json-ref-resolver": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@stoplight/json-ref-resolver/-/json-ref-resolver-3.1.3.tgz",
+      "integrity": "sha512-SgoKXwVnlpIZUyAFX4W79eeuTWvXmNlMfICZixL16GZXnkjcW+uZnfmAU0ZIjcnaTgaI4mjfxn8LAP2KR6Cr0A==",
+      "dependencies": {
+        "@stoplight/json": "^3.17.0",
+        "@stoplight/path": "^1.3.2",
+        "@stoplight/types": "^12.3.0",
+        "@types/urijs": "^1.19.16",
+        "dependency-graph": "~0.11.0",
+        "fast-memoize": "^2.5.2",
+        "immer": "^9.0.6",
+        "lodash.get": "^4.4.2",
+        "lodash.set": "^4.3.2",
+        "tslib": "^2.3.1",
+        "urijs": "^1.19.6"
+      },
+      "engines": {
+        "node": ">=8.3.0"
       }
     },
     "node_modules/@stoplight/spectral-rulesets": {
@@ -9704,7 +9726,8 @@
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
@@ -9737,7 +9760,8 @@
     },
     "node_modules/lodash.set": {
       "version": "4.3.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
     },
     "node_modules/lodash.snakecase": {
       "version": "4.1.1",
@@ -19194,19 +19218,20 @@
       }
     },
     "@stoplight/json-ref-resolver": {
-      "version": "3.1.3",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@stoplight/json-ref-resolver/-/json-ref-resolver-3.1.4.tgz",
+      "integrity": "sha512-842JVmMsi++qpDuIX+JpQvK7YY8FXEZZb+/z4xuRfStOAVEryJT/tbgGOWxniSdxEl9Eni5D/I2afMyy6BuiNw==",
       "requires": {
         "@stoplight/json": "^3.17.0",
         "@stoplight/path": "^1.3.2",
-        "@stoplight/types": "^12.3.0",
-        "@types/urijs": "^1.19.16",
+        "@stoplight/types": "^12.3.0 || ^13.0.0",
+        "@types/urijs": "^1.19.19",
         "dependency-graph": "~0.11.0",
         "fast-memoize": "^2.5.2",
         "immer": "^9.0.6",
-        "lodash.get": "^4.4.2",
-        "lodash.set": "^4.3.2",
+        "lodash": "^4.17.21",
         "tslib": "^2.3.1",
-        "urijs": "^1.19.6"
+        "urijs": "^1.19.11"
       }
     },
     "@stoplight/lifecycle": {
@@ -19326,6 +19351,26 @@
         "@stoplight/spectral-runtime": "^1.0.0",
         "dependency-graph": "0.11.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@stoplight/json-ref-resolver": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@stoplight/json-ref-resolver/-/json-ref-resolver-3.1.3.tgz",
+          "integrity": "sha512-SgoKXwVnlpIZUyAFX4W79eeuTWvXmNlMfICZixL16GZXnkjcW+uZnfmAU0ZIjcnaTgaI4mjfxn8LAP2KR6Cr0A==",
+          "requires": {
+            "@stoplight/json": "^3.17.0",
+            "@stoplight/path": "^1.3.2",
+            "@stoplight/types": "^12.3.0",
+            "@types/urijs": "^1.19.16",
+            "dependency-graph": "~0.11.0",
+            "fast-memoize": "^2.5.2",
+            "immer": "^9.0.6",
+            "lodash.get": "^4.4.2",
+            "lodash.set": "^4.3.2",
+            "tslib": "^2.3.1",
+            "urijs": "^1.19.6"
+          }
+        }
       }
     },
     "@stoplight/spectral-rulesets": {
@@ -23929,7 +23974,9 @@
       "dev": true
     },
     "lodash.get": {
-      "version": "4.4.2"
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
     },
     "lodash.isequal": {
       "version": "4.5.0"
@@ -23955,7 +24002,9 @@
       "dev": true
     },
     "lodash.set": {
-      "version": "4.3.2"
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
     },
     "lodash.snakecase": {
       "version": "4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,25 +59,6 @@
         "webpack-cli": "^4.10.0"
       }
     },
-    "../asyncapi-node": {
-      "name": "@asyncapi/specs",
-      "version": "3.1.0",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.11"
-      },
-      "devDependencies": {
-        "@semantic-release/commit-analyzer": "^8.0.1",
-        "@semantic-release/github": "7.2.3",
-        "@semantic-release/npm": "^7.0.3",
-        "@semantic-release/release-notes-generator": "^9.0.1",
-        "conventional-changelog-conventionalcommits": "^4.2.3",
-        "mocha": "^8.2.1",
-        "nyc": "^15.1.0",
-        "semantic-release": "19.0.3"
-      }
-    },
     "node_modules/@ampproject/remapping": {
       "version": "2.1.2",
       "license": "Apache-2.0",
@@ -90,8 +71,7 @@
     },
     "node_modules/@asyncapi/specs": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-3.1.0.tgz",
-      "integrity": "sha512-6xFvzDd54+M9g6EM259Y4a4iiFb2VzPr6eoxA/ttwTu7NRxaGScocXskXtuz53ZWx9BWZWuzwDYKfM3KBkDfiQ=="
+      "license": "Apache-2.0"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.16.7",
@@ -593,9 +573,8 @@
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
-      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -1878,9 +1857,8 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.0.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -1899,18 +1877,16 @@
     },
     "node_modules/@jridgewell/set-array": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/source-map": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
-      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -2109,9 +2085,8 @@
     },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.21",
-      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
-      "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@semantic-release/commit-analyzer": {
       "version": "8.0.1",
@@ -2793,9 +2768,8 @@
     },
     "node_modules/@types/eslint": {
       "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.6.tgz",
-      "integrity": "sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -2803,9 +2777,8 @@
     },
     "node_modules/@types/eslint-scope": {
       "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
-      "integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/eslint": "*",
         "@types/estree": "*"
@@ -2813,9 +2786,8 @@
     },
     "node_modules/@types/estree": {
       "version": "0.0.51",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
-      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
@@ -2885,9 +2857,8 @@
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
-      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -2937,9 +2908,8 @@
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@types/node": "*"
@@ -3172,9 +3142,8 @@
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
-      "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.11.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
@@ -3182,27 +3151,23 @@
     },
     "node_modules/@webassemblyjs/floating-point-hex-parser": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
-      "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
-      "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
-      "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
-      "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@webassemblyjs/floating-point-hex-parser": "1.11.1",
         "@webassemblyjs/helper-api-error": "1.11.1",
@@ -3211,15 +3176,13 @@
     },
     "node_modules/@webassemblyjs/helper-wasm-bytecode": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
-      "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
-      "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/helper-buffer": "1.11.1",
@@ -3229,33 +3192,29 @@
     },
     "node_modules/@webassemblyjs/ieee754": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
-      "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
     },
     "node_modules/@webassemblyjs/leb128": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
-      "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
     },
     "node_modules/@webassemblyjs/utf8": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
-      "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
-      "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/helper-buffer": "1.11.1",
@@ -3269,9 +3228,8 @@
     },
     "node_modules/@webassemblyjs/wasm-gen": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
-      "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
@@ -3282,9 +3240,8 @@
     },
     "node_modules/@webassemblyjs/wasm-opt": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
-      "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/helper-buffer": "1.11.1",
@@ -3294,9 +3251,8 @@
     },
     "node_modules/@webassemblyjs/wasm-parser": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
-      "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/helper-api-error": "1.11.1",
@@ -3308,9 +3264,8 @@
     },
     "node_modules/@webassemblyjs/wast-printer": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
-      "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
         "@xtuc/long": "4.2.2"
@@ -3318,9 +3273,8 @@
     },
     "node_modules/@webpack-cli/configtest": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
-      "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "webpack": "4.x.x || 5.x.x",
         "webpack-cli": "4.x.x"
@@ -3328,9 +3282,8 @@
     },
     "node_modules/@webpack-cli/info": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.5.0.tgz",
-      "integrity": "sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "envinfo": "^7.7.3"
       },
@@ -3340,9 +3293,8 @@
     },
     "node_modules/@webpack-cli/serve": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
-      "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "webpack-cli": "4.x.x"
       },
@@ -3354,15 +3306,13 @@
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -3387,9 +3337,8 @@
     },
     "node_modules/acorn-import-assertions": {
       "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "acorn": "^8"
       }
@@ -3644,9 +3593,8 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -3727,8 +3675,6 @@
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true,
       "funding": [
         {
@@ -3743,7 +3689,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/before-after-hook": {
       "version": "2.2.1",
@@ -3752,9 +3699,8 @@
     },
     "node_modules/bl": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -3763,9 +3709,8 @@
     },
     "node_modules/bl/node_modules/readable-stream": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -3839,8 +3784,6 @@
     },
     "node_modules/buffer": {
       "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "dev": true,
       "funding": [
         {
@@ -3856,6 +3799,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -3863,9 +3807,8 @@
     },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -3966,15 +3909,13 @@
     },
     "node_modules/chownr": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/chrome-trace-event": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
-      "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.0"
       }
@@ -4019,9 +3960,8 @@
     },
     "node_modules/clone-deep": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
-      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-plain-object": "^2.0.4",
         "kind-of": "^6.0.2",
@@ -4033,9 +3973,8 @@
     },
     "node_modules/clone-deep/node_modules/is-plain-object": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "isobject": "^3.0.1"
       },
@@ -4045,9 +3984,8 @@
     },
     "node_modules/clone-deep/node_modules/kind-of": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4090,9 +4028,8 @@
     },
     "node_modules/colorette": {
       "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
-      "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/colors": {
       "version": "1.0.3",
@@ -4104,9 +4041,8 @@
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -4252,9 +4188,8 @@
     },
     "node_modules/core-js": {
       "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.1.tgz",
-      "integrity": "sha512-sr0FY4lnO1hkQ4gLDr24K0DGnweGO1QwSj5BpfQjpSJPdqWalja4cTps29Y/PJVG/P7FYlPDkH3hO+Tr0CvDgQ==",
       "hasInstallScript": true,
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -4339,9 +4274,8 @@
     },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "node-fetch": "2.6.7"
       }
@@ -4479,9 +4413,8 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4508,9 +4441,8 @@
     },
     "node_modules/devtools-protocol": {
       "version": "0.0.1036444",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1036444.tgz",
-      "integrity": "sha512-0y4f/T8H9lsESV9kKP1HDUXgHxCdniFeJh6Erq+FbdOEvp/Ydp9t8kcAAM5gOd17pMrTDlFWntoHtzzeTUWKNw==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/diacritics-map": {
       "version": "0.1.0",
@@ -4579,9 +4511,8 @@
     },
     "node_modules/duplexer": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/duplexer2": {
       "version": "0.1.4",
@@ -4621,9 +4552,8 @@
     },
     "node_modules/enhanced-resolve": {
       "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz",
-      "integrity": "sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -4682,9 +4612,8 @@
     },
     "node_modules/envinfo": {
       "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz",
-      "integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "envinfo": "dist/cli.js"
       },
@@ -4756,9 +4685,8 @@
     },
     "node_modules/es-module-lexer": {
       "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-      "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-shim-unscopables": {
       "version": "1.0.0",
@@ -5423,9 +5351,8 @@
     },
     "node_modules/events": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
       }
@@ -5710,9 +5637,8 @@
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
@@ -5730,9 +5656,8 @@
     },
     "node_modules/extract-zip/node_modules/get-stream": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -5782,9 +5707,8 @@
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
-      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4.9.1"
       }
@@ -5807,17 +5731,15 @@
     },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
       }
     },
     "node_modules/fetch-mock": {
       "version": "9.11.0",
-      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.11.0.tgz",
-      "integrity": "sha512-PG1XUv+x7iag5p/iNHD4/jdpxL9FtVSqRMUQhPab4hVDt80T1MH5ehzVrL2IdXO9Q2iBggArFvPqjUbHFuI58Q==",
+      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.0.0",
         "@babel/runtime": "^7.0.0",
@@ -5848,8 +5770,7 @@
     },
     "node_modules/fetch-mock-jest": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/fetch-mock-jest/-/fetch-mock-jest-1.5.1.tgz",
-      "integrity": "sha512-+utwzP8C+Pax1GSka3nFXILWMY3Er2L+s090FOgqVNrNCPp0fDqgXnAHAJf12PLHi0z4PhcTaZNTz8e7K3fjqQ==",
+      "license": "MIT",
       "dependencies": {
         "fetch-mock": "^9.11.0"
       },
@@ -5871,21 +5792,18 @@
     },
     "node_modules/fetch-mock/node_modules/tr46": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
+      "license": "MIT",
       "dependencies": {
         "punycode": "^2.1.0"
       }
     },
     "node_modules/fetch-mock/node_modules/webidl-conversions": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+      "license": "BSD-2-Clause"
     },
     "node_modules/fetch-mock/node_modules/whatwg-url": {
       "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
-      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+      "license": "MIT",
       "dependencies": {
         "lodash.sortby": "^4.7.0",
         "tr46": "^1.0.1",
@@ -5980,9 +5898,8 @@
     },
     "node_modules/form-data": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -6003,9 +5920,8 @@
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "9.0.0",
@@ -6192,8 +6108,7 @@
     },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+      "license": "BSD-2-Clause"
     },
     "node_modules/globals": {
       "version": "13.17.0",
@@ -6310,9 +6225,8 @@
     },
     "node_modules/gzip-size": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
-      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "duplexer": "^0.1.2"
       },
@@ -6441,9 +6355,8 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -6462,8 +6375,6 @@
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "dev": true,
       "funding": [
         {
@@ -6478,7 +6389,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.2.0",
@@ -6594,9 +6506,8 @@
     },
     "node_modules/interpret": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
-      "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }
@@ -6826,8 +6737,7 @@
     },
     "node_modules/is-subset": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-      "integrity": "sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw=="
+      "license": "MIT"
     },
     "node_modules/is-symbol": {
       "version": "1.0.4",
@@ -6875,9 +6785,8 @@
     },
     "node_modules/isobject": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9444,9 +9353,8 @@
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
-      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -9458,18 +9366,16 @@
     },
     "node_modules/jest-worker/node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/jest-worker/node_modules/supports-color": {
       "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -9752,9 +9658,8 @@
     },
     "node_modules/loader-runner": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
-      "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.11.5"
       }
@@ -9801,8 +9706,7 @@
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+      "license": "MIT"
     },
     "node_modules/lodash.ismatch": {
       "version": "4.4.0",
@@ -9840,8 +9744,7 @@
     },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="
+      "license": "MIT"
     },
     "node_modules/lodash.template": {
       "version": "4.5.0",
@@ -10177,18 +10080,16 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -10283,9 +10184,8 @@
     },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/modify-values": {
       "version": "1.0.1",
@@ -10297,9 +10197,8 @@
     },
     "node_modules/mrmime": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
-      "integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
@@ -10315,9 +10214,8 @@
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/nerf-dart": {
       "version": "1.0.0",
@@ -10359,8 +10257,7 @@
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -15139,9 +15036,8 @@
     },
     "node_modules/opener": {
       "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
-      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
       "dev": true,
+      "license": "(WTFPL OR MIT)",
       "bin": {
         "opener": "bin/opener-bin.js"
       }
@@ -15275,9 +15171,8 @@
     },
     "node_modules/path-browserify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "3.0.0",
@@ -15310,14 +15205,12 @@
     },
     "node_modules/path-to-regexp": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
-      "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w=="
+      "license": "MIT"
     },
     "node_modules/pend": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -15508,9 +15401,8 @@
     },
     "node_modules/progress": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -15529,9 +15421,8 @@
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pump": {
       "version": "3.0.0",
@@ -15551,10 +15442,9 @@
     },
     "node_modules/puppeteer": {
       "version": "17.1.2",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-17.1.2.tgz",
-      "integrity": "sha512-xgFOxUl4hRjwQpODZSeJlE/rUzi8OmHtc3T4ir4CRYGzVmaTVHAl8VGpI0ooy752u2DFeMxvQdHmxNnLqPImIg==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
@@ -15583,9 +15473,7 @@
     },
     "node_modules/querystring": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
-      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
-      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.x"
       }
@@ -15673,9 +15561,8 @@
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -15834,9 +15721,8 @@
     },
     "node_modules/rechoir": {
       "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
-      "integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "resolve": "^1.9.0"
       },
@@ -16073,9 +15959,8 @@
     },
     "node_modules/schema-utils": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.8",
         "ajv": "^6.12.5",
@@ -16091,9 +15976,8 @@
     },
     "node_modules/schema-utils/node_modules/ajv": {
       "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -16107,9 +15991,8 @@
     },
     "node_modules/schema-utils/node_modules/ajv-keywords": {
       "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "ajv": "^6.9.1"
       }
@@ -16220,9 +16103,8 @@
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "randombytes": "^2.1.0"
       }
@@ -16240,9 +16122,8 @@
     },
     "node_modules/shallow-clone": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "kind-of": "^6.0.2"
       },
@@ -16252,9 +16133,8 @@
     },
     "node_modules/shallow-clone/node_modules/kind-of": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16331,9 +16211,8 @@
     },
     "node_modules/sirv": {
       "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.19.tgz",
-      "integrity": "sha512-JuLThK3TnZG1TAKDwNIqNq6QA2afLOCcm+iE8D1Kj3GA40pSPsxQjjJl0J8X3tsR7T+CP1GavpzLwYkgVLWrZQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@polka/url": "^1.0.0-next.20",
         "mrmime": "^1.0.0",
@@ -16644,18 +16523,16 @@
     },
     "node_modules/tapable": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/tar-fs": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -16665,9 +16542,8 @@
     },
     "node_modules/tar-stream": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -16681,9 +16557,8 @@
     },
     "node_modules/tar-stream/node_modules/readable-stream": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -16746,9 +16621,8 @@
     },
     "node_modules/terser": {
       "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
-      "integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
@@ -16764,9 +16638,8 @@
     },
     "node_modules/terser-webpack-plugin": {
       "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
-      "integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.14",
         "jest-worker": "^27.4.5",
@@ -16798,15 +16671,13 @@
     },
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/terser/node_modules/source-map-support": {
       "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -16905,17 +16776,15 @@
     },
     "node_modules/totalist": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/totalist/-/totalist-1.1.0.tgz",
-      "integrity": "sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/tr46": {
       "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "license": "MIT"
     },
     "node_modules/traverse": {
       "version": "0.6.6",
@@ -16932,9 +16801,8 @@
     },
     "node_modules/ts-loader": {
       "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.3.1.tgz",
-      "integrity": "sha512-OkyShkcZTsTwyS3Kt7a4rsT/t2qvEVQuKCTg4LJmpj9fhFR7ukGdZwV6Qq3tRUkqcXtfGpPR7+hFKHCG/0d3Lw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",
         "enhanced-resolve": "^5.0.0",
@@ -16951,9 +16819,8 @@
     },
     "node_modules/ts-loader/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -16966,9 +16833,8 @@
     },
     "node_modules/ts-loader/node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -16982,9 +16848,8 @@
     },
     "node_modules/ts-loader/node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -16994,24 +16859,21 @@
     },
     "node_modules/ts-loader/node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ts-loader/node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/ts-loader/node_modules/semver": {
       "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -17024,9 +16886,8 @@
     },
     "node_modules/ts-loader/node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -17192,9 +17053,8 @@
     },
     "node_modules/unbzip2-stream": {
       "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"
@@ -17313,9 +17173,8 @@
     },
     "node_modules/watchpack": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
-      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -17347,14 +17206,12 @@
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "license": "BSD-2-Clause"
     },
     "node_modules/webpack": {
       "version": "5.74.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
-      "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -17399,9 +17256,8 @@
     },
     "node_modules/webpack-bundle-analyzer": {
       "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.6.1.tgz",
-      "integrity": "sha512-oKz9Oz9j3rUciLNfpGFjOb49/jEpXNmWdVH8Ls//zNcnLlQdTGXQQMsBbb/gR7Zl8WNLxVCq+0Hqbx3zv6twBw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "acorn": "^8.0.4",
         "acorn-walk": "^8.0.0",
@@ -17422,9 +17278,8 @@
     },
     "node_modules/webpack-bundle-analyzer/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -17437,9 +17292,8 @@
     },
     "node_modules/webpack-bundle-analyzer/node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -17453,9 +17307,8 @@
     },
     "node_modules/webpack-bundle-analyzer/node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -17465,33 +17318,29 @@
     },
     "node_modules/webpack-bundle-analyzer/node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/webpack-bundle-analyzer/node_modules/commander": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/webpack-bundle-analyzer/node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/webpack-bundle-analyzer/node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -17501,9 +17350,8 @@
     },
     "node_modules/webpack-bundle-analyzer/node_modules/ws": {
       "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -17522,9 +17370,8 @@
     },
     "node_modules/webpack-cli": {
       "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
-      "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^1.2.0",
@@ -17569,18 +17416,16 @@
     },
     "node_modules/webpack-cli/node_modules/commander": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/webpack-merge": {
       "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
-      "integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "clone-deep": "^4.0.1",
         "wildcard": "^2.0.0"
@@ -17591,18 +17436,16 @@
     },
     "node_modules/webpack-sources": {
       "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
-      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
       }
     },
     "node_modules/webpack/node_modules/eslint-scope": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -17613,17 +17456,15 @@
     },
     "node_modules/webpack/node_modules/estraverse": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -17645,9 +17486,8 @@
     },
     "node_modules/wildcard": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
-      "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wolfy87-eventemitter": {
       "version": "5.2.9",
@@ -17719,9 +17559,8 @@
     },
     "node_modules/ws": {
       "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
-      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -17794,9 +17633,8 @@
     },
     "node_modules/yauzl": {
       "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
@@ -17830,9 +17668,7 @@
       }
     },
     "@asyncapi/specs": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-3.1.0.tgz",
-      "integrity": "sha512-6xFvzDd54+M9g6EM259Y4a4iiFb2VzPr6eoxA/ttwTu7NRxaGScocXskXtuz53ZWx9BWZWuzwDYKfM3KBkDfiQ=="
+      "version": "3.1.0"
     },
     "@babel/code-frame": {
       "version": "7.16.7",
@@ -18151,8 +17987,6 @@
     },
     "@discoveryjs/json-ext": {
       "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
-      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
       "dev": true
     },
     "@eslint/eslintrc": {
@@ -19004,8 +18838,6 @@
     },
     "@jridgewell/gen-mapping": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
       "dev": true,
       "requires": {
         "@jridgewell/set-array": "^1.0.1",
@@ -19018,14 +18850,10 @@
     },
     "@jridgewell/set-array": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
       "dev": true
     },
     "@jridgewell/source-map": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
-      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
       "dev": true,
       "requires": {
         "@jridgewell/gen-mapping": "^0.3.0",
@@ -19178,8 +19006,6 @@
     },
     "@polka/url": {
       "version": "1.0.0-next.21",
-      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
-      "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
       "dev": true
     },
     "@semantic-release/commit-analyzer": {
@@ -19666,8 +19492,6 @@
     },
     "@types/eslint": {
       "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.6.tgz",
-      "integrity": "sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==",
       "dev": true,
       "requires": {
         "@types/estree": "*",
@@ -19676,8 +19500,6 @@
     },
     "@types/eslint-scope": {
       "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
-      "integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
       "dev": true,
       "requires": {
         "@types/eslint": "*",
@@ -19686,8 +19508,6 @@
     },
     "@types/estree": {
       "version": "0.0.51",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
-      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
       "dev": true
     },
     "@types/graceful-fs": {
@@ -19747,8 +19567,6 @@
     },
     "@types/node-fetch": {
       "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
-      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -19791,8 +19609,6 @@
     },
     "@types/yauzl": {
       "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -19913,8 +19729,6 @@
     },
     "@webassemblyjs/ast": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
-      "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
       "dev": true,
       "requires": {
         "@webassemblyjs/helper-numbers": "1.11.1",
@@ -19923,26 +19737,18 @@
     },
     "@webassemblyjs/floating-point-hex-parser": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
-      "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
       "dev": true
     },
     "@webassemblyjs/helper-api-error": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
-      "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
       "dev": true
     },
     "@webassemblyjs/helper-buffer": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
-      "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
       "dev": true
     },
     "@webassemblyjs/helper-numbers": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
-      "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
       "dev": true,
       "requires": {
         "@webassemblyjs/floating-point-hex-parser": "1.11.1",
@@ -19952,14 +19758,10 @@
     },
     "@webassemblyjs/helper-wasm-bytecode": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
-      "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
       "dev": true
     },
     "@webassemblyjs/helper-wasm-section": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
-      "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.11.1",
@@ -19970,8 +19772,6 @@
     },
     "@webassemblyjs/ieee754": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
-      "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
       "dev": true,
       "requires": {
         "@xtuc/ieee754": "^1.2.0"
@@ -19979,8 +19779,6 @@
     },
     "@webassemblyjs/leb128": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
-      "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
       "dev": true,
       "requires": {
         "@xtuc/long": "4.2.2"
@@ -19988,14 +19786,10 @@
     },
     "@webassemblyjs/utf8": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
-      "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
       "dev": true
     },
     "@webassemblyjs/wasm-edit": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
-      "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.11.1",
@@ -20010,8 +19804,6 @@
     },
     "@webassemblyjs/wasm-gen": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
-      "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.11.1",
@@ -20023,8 +19815,6 @@
     },
     "@webassemblyjs/wasm-opt": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
-      "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.11.1",
@@ -20035,8 +19825,6 @@
     },
     "@webassemblyjs/wasm-parser": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
-      "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.11.1",
@@ -20049,8 +19837,6 @@
     },
     "@webassemblyjs/wast-printer": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
-      "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.11.1",
@@ -20059,15 +19845,11 @@
     },
     "@webpack-cli/configtest": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
-      "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
       "dev": true,
       "requires": {}
     },
     "@webpack-cli/info": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.5.0.tgz",
-      "integrity": "sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==",
       "dev": true,
       "requires": {
         "envinfo": "^7.7.3"
@@ -20075,21 +19857,15 @@
     },
     "@webpack-cli/serve": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
-      "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
       "dev": true,
       "requires": {}
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
       "dev": true
     },
     "@xtuc/long": {
       "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
     "abort-controller": {
@@ -20104,8 +19880,6 @@
     },
     "acorn-import-assertions": {
       "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
       "dev": true,
       "requires": {}
     },
@@ -20263,8 +20037,6 @@
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
     "at-least-node": {
@@ -20323,8 +20095,6 @@
     },
     "base64-js": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true
     },
     "before-after-hook": {
@@ -20333,8 +20103,6 @@
     },
     "bl": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "dev": true,
       "requires": {
         "buffer": "^5.5.0",
@@ -20344,8 +20112,6 @@
       "dependencies": {
         "readable-stream": {
           "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -20394,8 +20160,6 @@
     },
     "buffer": {
       "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "dev": true,
       "requires": {
         "base64-js": "^1.3.1",
@@ -20404,8 +20168,6 @@
     },
     "buffer-crc32": {
       "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "dev": true
     },
     "buffer-from": {
@@ -20461,14 +20223,10 @@
     },
     "chownr": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "dev": true
     },
     "chrome-trace-event": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
-      "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
       "dev": true
     },
     "ci-info": {
@@ -20501,8 +20259,6 @@
     },
     "clone-deep": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
-      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
       "dev": true,
       "requires": {
         "is-plain-object": "^2.0.4",
@@ -20512,8 +20268,6 @@
       "dependencies": {
         "is-plain-object": {
           "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-          "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
           "dev": true,
           "requires": {
             "isobject": "^3.0.1"
@@ -20521,8 +20275,6 @@
         },
         "kind-of": {
           "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
           "dev": true
         }
       }
@@ -20549,8 +20301,6 @@
     },
     "colorette": {
       "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
-      "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
       "dev": true
     },
     "colors": {
@@ -20559,8 +20309,6 @@
     },
     "combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
@@ -20663,9 +20411,7 @@
       }
     },
     "core-js": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.1.tgz",
-      "integrity": "sha512-sr0FY4lnO1hkQ4gLDr24K0DGnweGO1QwSj5BpfQjpSJPdqWalja4cTps29Y/PJVG/P7FYlPDkH3hO+Tr0CvDgQ=="
+      "version": "3.25.1"
     },
     "core-js-pure": {
       "version": "3.25.0",
@@ -20715,8 +20461,6 @@
     },
     "cross-fetch": {
       "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
       "dev": true,
       "requires": {
         "node-fetch": "2.6.7"
@@ -20801,8 +20545,6 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true
     },
     "dependency-graph": {
@@ -20818,8 +20560,6 @@
     },
     "devtools-protocol": {
       "version": "0.0.1036444",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1036444.tgz",
-      "integrity": "sha512-0y4f/T8H9lsESV9kKP1HDUXgHxCdniFeJh6Erq+FbdOEvp/Ydp9t8kcAAM5gOd17pMrTDlFWntoHtzzeTUWKNw==",
       "dev": true
     },
     "diacritics-map": {
@@ -20863,8 +20603,6 @@
     },
     "duplexer": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true
     },
     "duplexer2": {
@@ -20894,8 +20632,6 @@
     },
     "enhanced-resolve": {
       "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz",
-      "integrity": "sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.2.4",
@@ -20936,8 +20672,6 @@
     },
     "envinfo": {
       "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz",
-      "integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
       "dev": true
     },
     "error-ex": {
@@ -20989,8 +20723,6 @@
     },
     "es-module-lexer": {
       "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-      "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
       "dev": true
     },
     "es-shim-unscopables": {
@@ -21406,8 +21138,6 @@
     },
     "events": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "dev": true
     },
     "execa": {
@@ -21594,8 +21324,6 @@
     },
     "extract-zip": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
       "requires": {
         "@types/yauzl": "^2.9.1",
@@ -21606,8 +21334,6 @@
       "dependencies": {
         "get-stream": {
           "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
           "dev": true,
           "requires": {
             "pump": "^3.0.0"
@@ -21645,8 +21371,6 @@
     },
     "fastest-levenshtein": {
       "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
-      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
       "dev": true
     },
     "fastq": {
@@ -21665,8 +21389,6 @@
     },
     "fd-slicer": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
       "dev": true,
       "requires": {
         "pend": "~1.2.0"
@@ -21674,8 +21396,6 @@
     },
     "fetch-mock": {
       "version": "9.11.0",
-      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.11.0.tgz",
-      "integrity": "sha512-PG1XUv+x7iag5p/iNHD4/jdpxL9FtVSqRMUQhPab4hVDt80T1MH5ehzVrL2IdXO9Q2iBggArFvPqjUbHFuI58Q==",
       "requires": {
         "@babel/core": "^7.0.0",
         "@babel/runtime": "^7.0.0",
@@ -21691,21 +21411,15 @@
       "dependencies": {
         "tr46": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-          "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
           "requires": {
             "punycode": "^2.1.0"
           }
         },
         "webidl-conversions": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+          "version": "4.0.2"
         },
         "whatwg-url": {
           "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
-          "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
           "requires": {
             "lodash.sortby": "^4.7.0",
             "tr46": "^1.0.1",
@@ -21716,8 +21430,6 @@
     },
     "fetch-mock-jest": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/fetch-mock-jest/-/fetch-mock-jest-1.5.1.tgz",
-      "integrity": "sha512-+utwzP8C+Pax1GSka3nFXILWMY3Er2L+s090FOgqVNrNCPp0fDqgXnAHAJf12PLHi0z4PhcTaZNTz8e7K3fjqQ==",
       "requires": {
         "fetch-mock": "^9.11.0"
       }
@@ -21775,8 +21487,6 @@
     },
     "form-data": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
@@ -21794,8 +21504,6 @@
     },
     "fs-constants": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true
     },
     "fs-extra": {
@@ -21915,9 +21623,7 @@
       }
     },
     "glob-to-regexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+      "version": "0.4.1"
     },
     "globals": {
       "version": "13.17.0",
@@ -22000,8 +21706,6 @@
     },
     "gzip-size": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
-      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
       "dev": true,
       "requires": {
         "duplexer": "^0.1.2"
@@ -22072,8 +21776,6 @@
     },
     "https-proxy-agent": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "dev": true,
       "requires": {
         "agent-base": "6",
@@ -22086,8 +21788,6 @@
     },
     "ieee754": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "dev": true
     },
     "ignore": {
@@ -22160,8 +21860,6 @@
     },
     "interpret": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
-      "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
       "dev": true
     },
     "into-stream": {
@@ -22281,9 +21979,7 @@
       }
     },
     "is-subset": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-      "integrity": "sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw=="
+      "version": "0.1.1"
     },
     "is-symbol": {
       "version": "1.0.4",
@@ -22314,8 +22010,6 @@
     },
     "isobject": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true
     },
     "issue-parser": {
@@ -24001,8 +23695,6 @@
     },
     "jest-worker": {
       "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
-      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -24012,14 +23704,10 @@
       "dependencies": {
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "supports-color": {
           "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -24207,8 +23895,6 @@
     },
     "loader-runner": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
-      "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
       "dev": true
     },
     "locate-path": {
@@ -24242,9 +23928,7 @@
       "version": "4.4.2"
     },
     "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+      "version": "4.5.0"
     },
     "lodash.ismatch": {
       "version": "4.4.0",
@@ -24274,9 +23958,7 @@
       "dev": true
     },
     "lodash.sortby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="
+      "version": "4.7.0"
     },
     "lodash.template": {
       "version": "4.5.0",
@@ -24493,14 +24175,10 @@
     },
     "mime-db": {
       "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true
     },
     "mime-types": {
       "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
       "requires": {
         "mime-db": "1.52.0"
@@ -24564,8 +24242,6 @@
     },
     "mkdirp-classic": {
       "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true
     },
     "modify-values": {
@@ -24574,8 +24250,6 @@
     },
     "mrmime": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
-      "integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==",
       "dev": true
     },
     "ms": {
@@ -24587,8 +24261,6 @@
     },
     "neo-async": {
       "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
     "nerf-dart": {
@@ -24621,8 +24293,6 @@
     },
     "node-fetch": {
       "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -28235,8 +27905,6 @@
     },
     "opener": {
       "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
-      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
       "dev": true
     },
     "optionator": {
@@ -28317,8 +27985,6 @@
     },
     "path-browserify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "dev": true
     },
     "path-exists": {
@@ -28338,14 +28004,10 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
-      "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w=="
+      "version": "2.4.0"
     },
     "pend": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true
     },
     "picocolors": {
@@ -28456,8 +28118,6 @@
     },
     "progress": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
     "prompts": {
@@ -28470,8 +28130,6 @@
     },
     "proxy-from-env": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true
     },
     "pump": {
@@ -28487,8 +28145,6 @@
     },
     "puppeteer": {
       "version": "17.1.2",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-17.1.2.tgz",
-      "integrity": "sha512-xgFOxUl4hRjwQpODZSeJlE/rUzi8OmHtc3T4ir4CRYGzVmaTVHAl8VGpI0ooy752u2DFeMxvQdHmxNnLqPImIg==",
       "dev": true,
       "requires": {
         "cross-fetch": "3.1.5",
@@ -28509,9 +28165,7 @@
       "dev": true
     },
     "querystring": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
-      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg=="
+      "version": "0.2.1"
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -28560,8 +28214,6 @@
     },
     "randombytes": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
@@ -28670,8 +28322,6 @@
     },
     "rechoir": {
       "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
-      "integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
       "dev": true,
       "requires": {
         "resolve": "^1.9.0"
@@ -28802,8 +28452,6 @@
     },
     "schema-utils": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.8",
@@ -28813,8 +28461,6 @@
       "dependencies": {
         "ajv": {
           "version": "6.12.6",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -28825,8 +28471,6 @@
         },
         "ajv-keywords": {
           "version": "3.5.2",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
           "dev": true,
           "requires": {}
         }
@@ -28905,8 +28549,6 @@
     },
     "serialize-javascript": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
       "dev": true,
       "requires": {
         "randombytes": "^2.1.0"
@@ -28921,8 +28563,6 @@
     },
     "shallow-clone": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
       "dev": true,
       "requires": {
         "kind-of": "^6.0.2"
@@ -28930,8 +28570,6 @@
       "dependencies": {
         "kind-of": {
           "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
           "dev": true
         }
       }
@@ -28985,8 +28623,6 @@
     },
     "sirv": {
       "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.19.tgz",
-      "integrity": "sha512-JuLThK3TnZG1TAKDwNIqNq6QA2afLOCcm+iE8D1Kj3GA40pSPsxQjjJl0J8X3tsR7T+CP1GavpzLwYkgVLWrZQ==",
       "dev": true,
       "requires": {
         "@polka/url": "^1.0.0-next.20",
@@ -29198,14 +28834,10 @@
     },
     "tapable": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
       "dev": true
     },
     "tar-fs": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
       "dev": true,
       "requires": {
         "chownr": "^1.1.1",
@@ -29216,8 +28848,6 @@
     },
     "tar-stream": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "dev": true,
       "requires": {
         "bl": "^4.0.3",
@@ -29229,8 +28859,6 @@
       "dependencies": {
         "readable-stream": {
           "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -29270,8 +28898,6 @@
     },
     "terser": {
       "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
-      "integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
       "dev": true,
       "requires": {
         "@jridgewell/source-map": "^0.3.2",
@@ -29282,14 +28908,10 @@
       "dependencies": {
         "commander": {
           "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "dev": true
         },
         "source-map-support": {
           "version": "0.5.21",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-          "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
           "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
@@ -29300,8 +28922,6 @@
     },
     "terser-webpack-plugin": {
       "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
-      "integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
       "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.14",
@@ -29377,14 +28997,10 @@
     },
     "totalist": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/totalist/-/totalist-1.1.0.tgz",
-      "integrity": "sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==",
       "dev": true
     },
     "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "version": "0.0.3"
     },
     "traverse": {
       "version": "0.6.6",
@@ -29396,8 +29012,6 @@
     },
     "ts-loader": {
       "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.3.1.tgz",
-      "integrity": "sha512-OkyShkcZTsTwyS3Kt7a4rsT/t2qvEVQuKCTg4LJmpj9fhFR7ukGdZwV6Qq3tRUkqcXtfGpPR7+hFKHCG/0d3Lw==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",
@@ -29408,8 +29022,6 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
@@ -29417,8 +29029,6 @@
         },
         "chalk": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -29427,8 +29037,6 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
             "color-name": "~1.1.4"
@@ -29436,20 +29044,14 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "semver": {
           "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -29457,8 +29059,6 @@
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -29559,8 +29159,6 @@
     },
     "unbzip2-stream": {
       "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
       "dev": true,
       "requires": {
         "buffer": "^5.2.1",
@@ -29639,8 +29237,6 @@
     },
     "watchpack": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
-      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
       "dev": true,
       "requires": {
         "glob-to-regexp": "^0.4.1",
@@ -29668,14 +29264,10 @@
       }
     },
     "webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "version": "3.0.1"
     },
     "webpack": {
       "version": "5.74.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
-      "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",
@@ -29706,8 +29298,6 @@
       "dependencies": {
         "eslint-scope": {
           "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-          "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
           "dev": true,
           "requires": {
             "esrecurse": "^4.3.0",
@@ -29716,16 +29306,12 @@
         },
         "estraverse": {
           "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
           "dev": true
         }
       }
     },
     "webpack-bundle-analyzer": {
       "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.6.1.tgz",
-      "integrity": "sha512-oKz9Oz9j3rUciLNfpGFjOb49/jEpXNmWdVH8Ls//zNcnLlQdTGXQQMsBbb/gR7Zl8WNLxVCq+0Hqbx3zv6twBw==",
       "dev": true,
       "requires": {
         "acorn": "^8.0.4",
@@ -29741,8 +29327,6 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
@@ -29750,8 +29334,6 @@
         },
         "chalk": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -29760,8 +29342,6 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
             "color-name": "~1.1.4"
@@ -29769,26 +29349,18 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "commander": {
           "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
           "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -29796,8 +29368,6 @@
         },
         "ws": {
           "version": "7.5.9",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
           "dev": true,
           "requires": {}
         }
@@ -29805,8 +29375,6 @@
     },
     "webpack-cli": {
       "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
-      "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
       "dev": true,
       "requires": {
         "@discoveryjs/json-ext": "^0.5.0",
@@ -29825,16 +29393,12 @@
       "dependencies": {
         "commander": {
           "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
           "dev": true
         }
       }
     },
     "webpack-merge": {
       "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
-      "integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
       "dev": true,
       "requires": {
         "clone-deep": "^4.0.1",
@@ -29843,14 +29407,10 @@
     },
     "webpack-sources": {
       "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
-      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
       "dev": true
     },
     "whatwg-url": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -29868,8 +29428,6 @@
     },
     "wildcard": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
-      "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
       "dev": true
     },
     "wolfy87-eventemitter": {
@@ -29918,8 +29476,6 @@
     },
     "ws": {
       "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
-      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
       "dev": true,
       "requires": {}
     },
@@ -29958,8 +29514,6 @@
     },
     "yauzl": {
       "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
       "dev": true,
       "requires": {
         "buffer-crc32": "~0.2.3",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "@asyncapi/specs": "^3.1.0",
     "@openapi-contrib/openapi-schema-to-json-schema": "^3.2.0",
+    "@stoplight/json-ref-resolver": "^3.1.4",
     "@stoplight/spectral-core": "^1.14.1",
     "@stoplight/spectral-functions": "^1.7.1",
     "@stoplight/spectral-parsers": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@types/json-schema": "^7.0.11",
     "@types/lodash": "^4.14.179",
     "@types/node-fetch": "^2.6.2",
+    "@types/urijs": "^1.19.19",
     "@typescript-eslint/eslint-plugin": "^5.36.2",
     "@typescript-eslint/parser": "^5.36.2",
     "conventional-changelog-conventionalcommits": "^4.2.3",

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -8,11 +8,13 @@ import { createSpectral } from './spectral';
 import type { Spectral } from '@stoplight/spectral-core';
 import type { ParseOptions, ParseOutput } from './parse';
 import type { ValidateOptions } from './validate';
+import type { ResolverOptions } from './resolver';
 import type { SchemaParser } from './schema-parser';
 import type { Diagnostic, Input } from './types';
 
 export interface ParserOptions {
   schemaParsers?: Array<SchemaParser>;
+  __unstableResolver?: ResolverOptions;
 }
 
 export class Parser {
@@ -22,7 +24,7 @@ export class Parser {
   constructor(
     private readonly options: ParserOptions = {}
   ) {
-    this.spectral = createSpectral(this);
+    this.spectral = createSpectral(this, options);
     this.registerSchemaParser(AsyncAPISchemaParser());
     this.options.schemaParsers?.forEach(parser => this.registerSchemaParser(parser));
   }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -14,7 +14,9 @@ import type { Diagnostic, Input } from './types';
 
 export interface ParserOptions {
   schemaParsers?: Array<SchemaParser>;
-  __unstableResolver?: ResolverOptions;
+  __unstable?: {
+    resolver?: ResolverOptions;
+  };
 }
 
 export class Parser {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,5 +1,3 @@
-import { Spectral } from '@stoplight/spectral-core';
-
 import { toAsyncAPIDocument } from './document';
 import { parse } from './parse';
 import { validate } from './validate';
@@ -7,22 +5,26 @@ import { registerSchemaParser } from './schema-parser';
 import { AsyncAPISchemaParser } from './schema-parser/asyncapi-schema-parser';
 import { createSpectral } from './spectral';
 
+import type { Spectral } from '@stoplight/spectral-core';
 import type { ParseOptions, ParseOutput } from './parse';
 import type { ValidateOptions } from './validate';
 import type { SchemaParser } from './schema-parser';
 import type { Diagnostic, Input } from './types';
 
-export interface ParserOptions {}
+export interface ParserOptions {
+  schemaParsers?: Array<SchemaParser>;
+}
 
 export class Parser {
   public readonly parserRegistry = new Map<string, SchemaParser>();
   protected readonly spectral: Spectral;
 
   constructor(
-    private readonly _: ParserOptions = {}
+    private readonly options: ParserOptions = {}
   ) {
     this.spectral = createSpectral(this);
     this.registerSchemaParser(AsyncAPISchemaParser());
+    this.options.schemaParsers?.forEach(parser => this.registerSchemaParser(parser));
   }
 
   async parse(asyncapi: Input, options?: ParseOptions): Promise<ParseOutput> {

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,35 +1,81 @@
-import { Resolver as SpectralResolver } from '@stoplight/json-ref-resolver';
+import { Resolver as SpectralResolver } from '@stoplight/spectral-ref-resolver';
 import { resolveFile, resolveHttp } from '@stoplight/json-ref-readers';
 
+import type Uri from 'urijs';
+
 export interface Resolver {
+  schema: 'file' | 'http' | 'https' | string;
   order?: number;
-  canRead?: boolean | ((input: ResolverInput) => boolean); 
-  read: (input: ResolverInput) => string | Buffer | Promise<string | Buffer>;
+  canRead?: boolean | ((uri: Uri, ctx?: any) => boolean); 
+  read: (uri: Uri, ctx?: any) => string | undefined | Promise<string | undefined>;
 }
 
-export interface ResolverInput {
-  url: string;
-  extension: string;
+export interface ResolverOptions {
+  resolvers?: Array<Resolver>;
 }
 
-interface ResolverOptions {
-  resolvers: Array<Resolver>;
-}
+export function createResolver(options: ResolverOptions = {}): SpectralResolver {
+  const availableResolvers: Array<Resolver> = [
+    ...createDefaultResolvers(),
+    ...(options?.resolvers || [])
+  ].map(r => ({ 
+    ...r,
+    order: r.order || Number.MAX_SAFE_INTEGER,
+    canRead: typeof r.canRead === 'undefined' ? true: r.canRead, 
+  }));
+  const availableSchemas = [...new Set(availableResolvers.map(r => r.schema))];
+  const resolvers = availableSchemas.reduce((acc, schema) => {
+    acc[schema] = { resolve: createSchemaResolver(schema, availableResolvers) };
+    return acc;
+  }, {} as Record<string, { resolve: (uri: Uri, ctx?: any) => string | Promise<string> }>);
 
-export function createResolver(options?: ResolverOptions): SpectralResolver {
   return new SpectralResolver({
-    resolvers: {
-      https: { resolve: resolveHttp },
-      http: { resolve: resolveHttp },
-      file: { resolve: resolveFile },
-    },
+    resolvers: resolvers as any,
   });
 }
 
-export function createFileResolver() {
-
+function createDefaultResolvers(): Array<Resolver> {
+  return [
+    {
+      schema: 'file',
+      read: resolveFile as (input: Uri, ctx?: any) => string | Promise<string>,
+    },
+    {
+      schema: 'https',
+      read: resolveHttp as (input: Uri, ctx?: any) => string | Promise<string>,
+    },
+    {
+      schema: 'http',
+      read: resolveHttp as (input: Uri, ctx?: any) => string | Promise<string>,
+    },
+  ]
 }
 
-export function createHttpResolver() {
-  
+function createSchemaResolver(schema: string, allResolvers: Array<Resolver>): (uri: Uri, ctx?: any) => string | Promise<string> {
+  const resolvers = allResolvers.filter(r => r.schema === schema).sort((a, b) => { return (a.order as number) - (b.order as number); });
+  return async (uri, ctx) => {
+    let result: string | undefined = undefined;
+    let lastError: Error | undefined;
+    for (const resolver of resolvers) {
+      try {
+        if (!canRead(resolver, uri, ctx)) continue;
+
+        result = await resolver.read(uri, ctx);
+        if (typeof result === 'string') {
+          break;
+        }
+      } catch(e: any) {
+        lastError = e;
+        continue;
+      }
+    }
+    if (typeof result !== 'string') {
+      throw lastError || new Error(`None of the available resolvers for "${schema}" can resolve the given reference.`);
+    }
+    return result;
+  }
+}
+
+function canRead(resolver: Resolver, uri: Uri, ctx?: any) {
+  return typeof resolver.canRead === 'function' ? resolver.canRead(uri, ctx) : resolver.canRead;
 }

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,0 +1,35 @@
+import { Resolver as SpectralResolver } from '@stoplight/json-ref-resolver';
+import { resolveFile, resolveHttp } from '@stoplight/json-ref-readers';
+
+export interface Resolver {
+  order?: number;
+  canRead?: boolean | ((input: ResolverInput) => boolean); 
+  read: (input: ResolverInput) => string | Buffer | Promise<string | Buffer>;
+}
+
+export interface ResolverInput {
+  url: string;
+  extension: string;
+}
+
+interface ResolverOptions {
+  resolvers: Array<Resolver>;
+}
+
+export function createResolver(options?: ResolverOptions): SpectralResolver {
+  return new SpectralResolver({
+    resolvers: {
+      https: { resolve: resolveHttp },
+      http: { resolve: resolveHttp },
+      file: { resolve: resolveFile },
+    },
+  });
+}
+
+export function createFileResolver() {
+
+}
+
+export function createHttpResolver() {
+  
+}

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -48,7 +48,7 @@ function createDefaultResolvers(): Array<Resolver> {
       schema: 'http',
       read: resolveHttp as (input: Uri, ctx?: any) => string | Promise<string>,
     },
-  ]
+  ];
 }
 
 function createSchemaResolver(schema: string, allResolvers: Array<Resolver>): (uri: Uri, ctx?: any) => string | Promise<string> {
@@ -64,7 +64,7 @@ function createSchemaResolver(schema: string, allResolvers: Array<Resolver>): (u
         if (typeof result === 'string') {
           break;
         }
-      } catch(e: any) {
+      } catch (e: any) {
         lastError = e;
         continue;
       }
@@ -73,7 +73,7 @@ function createSchemaResolver(schema: string, allResolvers: Array<Resolver>): (u
       throw lastError || new Error(`None of the available resolvers for "${schema}" can resolve the given reference.`);
     }
     return result;
-  }
+  };
 }
 
 function canRead(resolver: Resolver, uri: Uri, ctx?: any) {

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,4 +1,5 @@
 import { Resolver as SpectralResolver } from '@stoplight/spectral-ref-resolver';
+import { Cache } from '@stoplight/json-ref-resolver/cache';
 import { resolveFile, resolveHttp } from '@stoplight/json-ref-readers';
 
 import type Uri from 'urijs';
@@ -11,6 +12,7 @@ export interface Resolver {
 }
 
 export interface ResolverOptions {
+  cache?: boolean;
   resolvers?: Array<Resolver>;
 }
 
@@ -29,7 +31,10 @@ export function createResolver(options: ResolverOptions = {}): SpectralResolver 
     return acc;
   }, {} as Record<string, { resolve: (uri: Uri, ctx?: any) => string | Promise<string> }>);
 
+  // if cache is enabled, use default Cache instance in SpectralResolver, otherwise use custom one with ttl set to 1ms
+  const cache = options.cache !== false;
   return new SpectralResolver({
+    uriCache: cache ? undefined : new Cache({ stdTTL: 1 }),
     resolvers: resolvers as any,
   });
 }

--- a/src/spectral.ts
+++ b/src/spectral.ts
@@ -1,17 +1,18 @@
 import { Spectral, createRulesetFunction } from '@stoplight/spectral-core';
 import aasRuleset from '@stoplight/spectral-rulesets/dist/asyncapi';
 
+import { createResolver } from './resolver';
 import { asyncApi2SchemaParserRule } from './schema-parser/spectral-rule-v2';
 import { specVersions } from './constants';
 import { isObject } from './utils';
 
 import type { RuleDefinition, RulesetDefinition } from '@stoplight/spectral-core';
-import type { Parser } from './parser';
+import type { Parser, ParserOptions } from './parser';
 import type { MaybeAsyncAPI } from './types';
 
-export function createSpectral(parser: Parser): Spectral {
+export function createSpectral(parser: Parser, options: ParserOptions): Spectral {
+  const spectral = new Spectral({ resolver: createResolver(options.__unstableResolver) });
   const ruleset = configureRuleset(parser);
-  const spectral = new Spectral();
   spectral.setRuleset(ruleset);
   return spectral;
 }

--- a/src/spectral.ts
+++ b/src/spectral.ts
@@ -10,7 +10,7 @@ import type { RuleDefinition, RulesetDefinition } from '@stoplight/spectral-core
 import type { Parser, ParserOptions } from './parser';
 import type { MaybeAsyncAPI } from './types';
 
-export function createSpectral(parser: Parser, options: ParserOptions): Spectral {
+export function createSpectral(parser: Parser, options: ParserOptions = {}): Spectral {
   const spectral = new Spectral({ resolver: createResolver(options.__unstable?.resolver) });
   const ruleset = configureRuleset(parser);
   spectral.setRuleset(ruleset);

--- a/src/spectral.ts
+++ b/src/spectral.ts
@@ -11,7 +11,7 @@ import type { Parser, ParserOptions } from './parser';
 import type { MaybeAsyncAPI } from './types';
 
 export function createSpectral(parser: Parser, options: ParserOptions): Spectral {
-  const spectral = new Spectral({ resolver: createResolver(options.__unstableResolver) });
+  const spectral = new Spectral({ resolver: createResolver(options.__unstable?.resolver) });
   const ruleset = configureRuleset(parser);
   spectral.setRuleset(ruleset);
   return spectral;

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -57,13 +57,6 @@ export function copy(data: Record<string, any>) {
   return unstringifiedData;
 }
 
-export function unfreeze(data: Record<string, any>) {
-  const stringifiedData = JSON.stringify(data, refReplacer());
-  const unstringifiedData = JSON.parse(stringifiedData);
-  traverseStringifiedDoc(unstringifiedData, undefined, unstringifiedData, new Map(), new Map());
-  return unstringifiedData;
-}
-
 function refReplacer() {
   const modelPaths = new Map();
   const paths = new Map();

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -57,6 +57,13 @@ export function copy(data: Record<string, any>) {
   return unstringifiedData;
 }
 
+export function unfreeze(data: Record<string, any>) {
+  const stringifiedData = JSON.stringify(data, refReplacer());
+  const unstringifiedData = JSON.parse(stringifiedData);
+  traverseStringifiedDoc(unstringifiedData, undefined, unstringifiedData, new Map(), new Map());
+  return unstringifiedData;
+}
+
 function refReplacer() {
   const modelPaths = new Map();
   const paths = new Map();

--- a/test/mocks/simple-message.yaml
+++ b/test/mocks/simple-message.yaml
@@ -1,0 +1,5 @@
+payload:
+  type: object
+  properties:
+    someProperty:
+      type: string

--- a/test/resolver.spec.ts
+++ b/test/resolver.spec.ts
@@ -1,0 +1,150 @@
+import { AsyncAPIDocumentV2 } from '../src/models';
+import { Parser } from '../src/parser';
+import { parse } from '../src/parse';
+
+describe('custom resolver', function() {
+  it('should resolve document references', async function() {
+    const parser = new Parser();
+
+    const document = {
+      asyncapi: '2.0.0',
+      info: {
+        title: 'Valid AsyncApi document',
+        version: '1.0',
+      },
+      channels: {
+        channel: {
+          publish: {
+            operationId: 'publish',
+            message: {
+              $ref: '#/components/messages/message'
+            }
+          },
+        }
+      },
+      components: {
+        messages: {
+          message: {
+            payload: {
+              type: 'string'
+            }
+          }
+        }
+      }
+    }
+    const { parsed } = await parse(parser, document);
+    
+    expect(parsed).toBeInstanceOf(AsyncAPIDocumentV2);
+    const refMessage = parsed?.channels().get('channel')?.operations().get('publish')?.messages()[0];
+    expect(refMessage?.json()).not.toBeUndefined();
+    expect(refMessage?.json() === parsed?.components().messages().get('message')?.json()).toEqual(true);
+  });
+
+  it('should resolve file references', async function() {
+    const parser = new Parser();
+
+    const document = {
+      asyncapi: '2.0.0',
+      info: {
+        title: 'Valid AsyncApi document',
+        version: '1.0',
+      },
+      channels: {
+        channel: {
+          publish: {
+            operationId: 'publish',
+            message: {
+              $ref: './mocks/simple-message.yaml'
+            }
+          },
+        }
+      },
+    }
+    const { parsed } = await parse(parser, document, { validateOptions: { path: __filename } });
+    
+    expect(parsed).toBeInstanceOf(AsyncAPIDocumentV2);
+    const refMessage = parsed?.channels().get('channel')?.operations().get('publish')?.messages()[0];
+    expect(refMessage?.json()).not.toBeUndefined();
+    expect(refMessage?.json('$ref')).toBeUndefined();
+  });
+
+  it('should resolve http references', async function() {
+    const parser = new Parser();
+
+    const document = {
+      asyncapi: '2.0.0',
+      info: {
+        title: 'Valid AsyncApi document',
+        version: '1.0',
+      },
+      channels: {
+        channel: {
+          publish: {
+            operationId: 'publish',
+            message: {
+              $ref: 'https://raw.githubusercontent.com/asyncapi/spec/v2.0.0/examples/2.0.0/streetlights.yml#/components/messages/lightMeasured'
+            }
+          },
+        }
+      },
+    }
+    const { parsed } = await parse(parser, document);
+    
+    expect(parsed).toBeInstanceOf(AsyncAPIDocumentV2); // we should have parsed document
+  });
+
+  it('should resolve custom protocols', async function() {
+    const parser = new Parser({
+      __unstableResolver: {
+        resolvers: [
+          {
+            schema: 'customProtocol',
+            read(uri) {
+              if (uri.path() === '/someRef') {
+                return '{"someRef": "value"}';
+              }
+              return '{"anotherRef": "value"}';
+            },
+          }
+        ]
+      }
+    });
+
+    const document = {
+      asyncapi: '2.0.0',
+      info: {
+        title: 'Valid AsyncApi document',
+        version: '1.0',
+      },
+      channels: {
+        channel: {
+          publish: {
+            operationId: 'publish',
+            message: {
+              payload: {
+                $ref: 'customProtocol:///someRef'
+              }
+            }
+          },
+          subscribe: {
+            operationId: 'subscribe',
+            message: {
+              payload: {
+                $ref: 'customProtocol:///anotherRef'
+              }
+            }
+          },
+        }
+      },
+    }
+    const { parsed } = await parse(parser, document);
+    
+    expect(parsed).toBeInstanceOf(AsyncAPIDocumentV2);
+    const someRef = parsed?.channels().get('channel')?.operations().get('publish')?.messages()[0]?.payload();
+    expect(someRef?.json()).toEqual({ someRef: 'value' });
+    expect(someRef?.json('$ref')).toBeUndefined();
+    const anotherRef = parsed?.channels().get('channel')?.operations().get('subscribe')?.messages()[0]?.payload();
+    expect(anotherRef?.json()).toEqual({ anotherRef: 'value' });
+    expect(anotherRef?.json('$ref')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Add possibility to pass custom resolvers. With `json-schema-ref-resolvers` we have possibility to pass custom ref resolvers. Atm we use that feature in Generator and in ServerAPI. Unfortunately, ref-resolver from Spectral doesn't have such a thing, so that PR "wraps" default Spectral resolvers with adding similar functionality. Of course that feature will be used only by us, so I annotated that feature by `__unstable` prefix. Spectral team is preparing to switch to the `json-schema-ref-parser` and we will provide this functionality when Spectral will support it natively.

cc @smoya 

**Related issue(s)**
Part of #481 
Part of #482 