### PR TITLE
refactor: add isEmpty() method to components

### DIFF
--- a/src/models/components.ts
+++ b/src/models/components.ts
@@ -29,4 +29,5 @@ export interface ComponentsInterface extends BaseModel, ExtensionsMixinInterface
   channelBindings(): Record<string, BindingsInterface>;
   operationBindings(): Record<string, BindingsInterface>;
   messageBindings(): Record<string, BindingsInterface>;
+  isEmpty(): boolean;
 }

--- a/src/models/v2/components.ts
+++ b/src/models/v2/components.ts
@@ -117,6 +117,10 @@ export class Components extends BaseModel<v2.ComponentsObject> implements Compon
     return extensions(this);
   }
 
+  isEmpty(): boolean {
+    return this._json === null || this._json === undefined || Object.keys(this._json).length === 0;
+  }
+
   protected createCollection<M extends Collection<any>, T extends BaseModel>(itemsName: keyof v2.ComponentsObject, collectionModel: Constructor<M>, itemModel: Constructor<T>): M {
     const collectionItems: T[] = [];
     Object.entries(this._json[itemsName] || {}).forEach(([id, item]) => {

--- a/test/models/v2/components.spec.ts
+++ b/test/models/v2/components.spec.ts
@@ -286,6 +286,20 @@ describe('Components model', function() {
     });
   });
 
+  describe('.isEmpty()', function() {
+    it('should return false when components is not empty', function() {
+      const doc = serializeInput<v2.ComponentsObject>({ messageBindings: { binding: {} } });
+      const d = new Components(doc);
+      expect(d.isEmpty()).toBeFalsy();
+    });
+
+    it('should return true when components is empty', function() {
+      const doc = serializeInput<v2.ComponentsObject>({});
+      const d = new Components(doc);
+      expect(d.isEmpty()).toBeTruthy();
+    });
+  });
+
   describe('mixins', function() {
     assertExtensions(Components);
   });


### PR DESCRIPTION
**Description**

For some reason, I forgot to add the `isEmpty()` method to components. See https://github.com/asyncapi/parser-api/pull/71/files#diff-ac35ac6e0b0ad3629802a0e04076aa18e94da614f5392e1164dcaacdfe3ee198R84.

**Related issue(s)**
https://github.com/asyncapi/parser-js/issues/401