### PR TITLE
refactor: export cjs and esm modules

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,4 +4,6 @@ node_modules
 /docs
 /coverage
 /lib
+/esm
+/cjs
 /browser

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@ node_modules
 /docs
 /coverage
 /lib
+/esm
+/cjs
 /browser

--- a/package.json
+++ b/package.json
@@ -15,14 +15,20 @@
   "license": "Apache-2.0",
   "homepage": "https://github.com/asyncapi/parser-js",
   "sideEffects": false,
+  "main": "cjs/index.js",
+  "module": "esm/index.js",
+  "types": "esm/index.d.ts",
   "files": [
-    "./lib",
-    "./browser",
+    "/esm",
+    "/cjs",
+    "/browser",
     "LICENSE",
     "README.md"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "npm run build:esm && npm run build:cjs && npm run build:browser",
+    "build:esm": "tsc",
+    "build:cjs": "tsc --project ./tsconfig.cjs.json",
     "build:browser": "webpack",
     "test": "npm run test:unit && npm run test:browser",
     "test:unit": "cross-env CI=true jest --coverage --testPathIgnorePatterns=test/browser/*",

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "./cjs"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
-    "outDir": "./lib",
+    "outDir": "./esm",
     "baseUrl": "./src",
     "target": "es6",
+    "module": "esnext",
     "lib": [
       "esnext",
       "DOM"
@@ -15,7 +16,6 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
-    "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Export `cjs` and `esm` (with TS typings) modules from package. It's needed to packages which will consume parser-js. `ESM` is for website and treeshakable apps and `CJS` is for NodeJS app (but never versions can use ESM).

cc @smoya 

**Related issue(s)**
Part of #481 
Part of #482