### PR TITLE
refactor: fix TS imports and change name of migrator to converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ The parser uses custom extensions to define additional information about the spe
 - `x-parser-original-payload` holds the original payload of the message. You can use different formats for payloads with the AsyncAPI documents and the parser converts them to. For example, it converts payload described with Avro schema to AsyncAPI schema. The original payload is preserved in the extension.
 - [`x-parser-circular`](#circular-references).
 
-In addition, the [`migrateToOldAPI()` function](#convert-to-the-old-api) which converts new API to an old one adds additional extensions:
+In addition, the [`convertToOldAPI()` function](#convert-to-the-old-api) which converts new API to an old one adds additional extensions:
 
 - `x-parser-message-parsed` is used to specify if the message is already parsed by the message parser. Property `x-parser-message-parsed` is added to the message object with the `true` value.
 - `x-parser-schema-id` is used to specify the ID of the schema if it is not provided. For schemas without IDs, the parser generates anonymous names. Property `x-parser-schema-id` is added to every object of a schema with a value that follows this pattern: `<anonymous-schema-${number}>`. This value is returned by `schema.uid()` when regular `$id` property is not present.
@@ -370,17 +370,17 @@ Check [example](#example-with-stringify-and-unstringify-parsed-documentstringify
 
 ## Convert to the old API
 
-Version `2.0.0` of package introduced a lot of breaking changes, including changing the API of the returned parsed document (parser uses [New API](https://github.com/asyncapi/parser-api)). Due to the fact that a large part of the AsyncAPI tooling ecosystem uses a Parser with the old API and rewriting the tool for the new one can be time-consuming and difficult, the package exposes the `migrateToOldAPI()` function to convert new API to old one:
+Version `2.0.0` of package introduced a lot of breaking changes, including changing the API of the returned parsed document (parser uses [New API](https://github.com/asyncapi/parser-api)). Due to the fact that a large part of the AsyncAPI tooling ecosystem uses a Parser with the old API and rewriting the tool for the new one can be time-consuming and difficult, the package exposes the `convertToOldAPI()` function to convert new API to old one:
 
 ```js
-import { Parser, migrateToOldAPI } from '@asyncapi/parser';
+import { Parser, convertToOldAPI } from '@asyncapi/parser';
 
 const parser = new Parser();
 const { document } = parser.parse(...);
-const oldAsyncAPIDocument = migrateToOldAPI(document);
+const oldAsyncAPIDocument = convertToOldAPI(document);
 ```
 
-> **Note**
+> **Warning**
 > The old api will be supported only for a certain period of time. The target date for turning off support of the old API is around the end of January 2023.
 
 ## Bundler configuration

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export { stringify, unstringify } from './stringify';
 export { fromURL, fromFile } from './from';
 
 export { AsyncAPIDocument as OldAsyncAPIDocument } from './old-api/asyncapi';
-export { migrateToOldAPI } from './old-api/migrator';
+export { convertToOldAPI } from './old-api/converter';
 
 export type { AsyncAPISemver, Input, Diagnostic, SchemaValidateResult } from './types';
 export type { ValidateOptions, ValidateOutput } from './validate';

--- a/src/models/v2/channel.ts
+++ b/src/models/v2/channel.ts
@@ -9,10 +9,10 @@ import { Server } from './server';
 
 import { bindings, hasDescription, description, extensions } from './mixins';
 
-import type { BindingsInterface } from 'models/bindings';
+import type { BindingsInterface } from '../bindings';
 import type { ChannelInterface } from '../channel';
 import type { ChannelParametersInterface } from '../channel-parameters';
-import type { ExtensionsInterface } from 'models/extensions';
+import type { ExtensionsInterface } from '../extensions';
 import type { MessagesInterface } from '../messages';
 import type { MessageInterface } from '../message';
 import type { OperationsInterface } from '../operations';

--- a/src/old-api/converter.ts
+++ b/src/old-api/converter.ts
@@ -5,7 +5,7 @@ import { getDefaultSchemaFormat } from '../schema-parser';
 
 import type { AsyncAPIDocumentInterface } from '../models/asyncapi';
 
-export function migrateToOldAPI(newDocument: AsyncAPIDocumentInterface): AsyncAPIDocument {
+export function convertToOldAPI(newDocument: AsyncAPIDocumentInterface): AsyncAPIDocument {
   const data = copy(newDocument.json());
   const document = new AsyncAPIDocument(data);
 

--- a/test/old-api/converter.spec.ts
+++ b/test/old-api/converter.spec.ts
@@ -1,4 +1,4 @@
-import { migrateToOldAPI } from '../../src/old-api/migrator';
+import { convertToOldAPI } from '../../src/old-api/converter';
 import { AsyncAPIDocument as OldAsyncAPIDocument } from '../../src/old-api/asyncapi';
 import { AsyncAPIDocumentV2 } from '../../src';
 import { anonymousNaming } from '../../src/custom-operations/anonymous-naming';
@@ -6,10 +6,10 @@ import { checkCircularRefs } from '../../src/custom-operations/check-circular-re
 import { getDefaultSchemaFormat } from '../../src/schema-parser';
 import { xParserCircular, xParserOriginalTraits, xParserOriginalSchemaFormat, xParserMessageParsed, xParserOriginalPayload } from '../../src/constants';
 
-describe('migrateToOldAPI()', function() {
+describe('convertToOldAPI()', function() {
   it('should return AsyncAPIDocument instance', function() {
     const newApi = new AsyncAPIDocumentV2({} as any);
-    expect(migrateToOldAPI(newApi)).toBeInstanceOf(OldAsyncAPIDocument);
+    expect(convertToOldAPI(newApi)).toBeInstanceOf(OldAsyncAPIDocument);
   });
 
   it('should not assign x-parser-circular extension when document has not circular schemas', function() {
@@ -26,7 +26,7 @@ describe('migrateToOldAPI()', function() {
     } as any);
 
     checkCircularRefs(newApi);
-    expect(migrateToOldAPI(newApi).ext(xParserCircular)).toEqual(undefined);
+    expect(convertToOldAPI(newApi).ext(xParserCircular)).toEqual(undefined);
   });
 
   it('should assign x-parser-circular extension when document has circular schemas', function() {
@@ -49,7 +49,7 @@ describe('migrateToOldAPI()', function() {
     } as any);
 
     checkCircularRefs(newApi);
-    expect(migrateToOldAPI(newApi).ext(xParserCircular)).toEqual(true);
+    expect(convertToOldAPI(newApi).ext(xParserCircular)).toEqual(true);
   });
 
   it('should assign x-parser-original-schema-format to the message object to the default one when field isn not defined', function() {
@@ -81,7 +81,7 @@ describe('migrateToOldAPI()', function() {
 
     // apply anonymous naming
     anonymousNaming(newApi);
-    const oldApi = migrateToOldAPI(newApi);
+    const oldApi = convertToOldAPI(newApi);
     expect(oldApi.json().channels.channel?.publish?.message?.[xParserOriginalSchemaFormat]).toEqual(getDefaultSchemaFormat('2.0.0'));
     expect((oldApi.json().channels.channel?.publish?.message as any)?.schemaFormat).toEqual(getDefaultSchemaFormat('2.0.0'));
     expect(oldApi.json().channels.channel?.subscribe?.message?.[xParserOriginalSchemaFormat]).toEqual(getDefaultSchemaFormat('2.0.0'));
@@ -119,7 +119,7 @@ describe('migrateToOldAPI()', function() {
 
     // apply anonymous naming
     anonymousNaming(newApi);
-    const oldApi = migrateToOldAPI(newApi);
+    const oldApi = convertToOldAPI(newApi);
     expect(oldApi.json().channels.channel?.publish?.message?.[xParserOriginalSchemaFormat]).toEqual('custom1');
     expect((oldApi.json().channels.channel?.publish?.message as any)?.schemaFormat).toEqual(getDefaultSchemaFormat('2.0.0'));
     expect(oldApi.json().channels.channel?.subscribe?.message?.[xParserOriginalSchemaFormat]).toEqual('custom2');
@@ -155,7 +155,7 @@ describe('migrateToOldAPI()', function() {
 
     // apply anonymous naming
     anonymousNaming(newApi);
-    const oldApi = migrateToOldAPI(newApi);
+    const oldApi = convertToOldAPI(newApi);
     expect(oldApi.json().channels.channel?.publish?.message?.[xParserMessageParsed]).toEqual(true);
     expect(oldApi.json().channels.channel?.subscribe?.message?.[xParserMessageParsed]).toEqual(true);
   });
@@ -193,7 +193,7 @@ describe('migrateToOldAPI()', function() {
 
     // apply anonymous naming
     anonymousNaming(newApi);
-    const oldApi = migrateToOldAPI(newApi);
+    const oldApi = convertToOldAPI(newApi);
     expect(oldApi.json().channels.channel?.publish?.message?.[xParserOriginalPayload]).toEqual({ type: 'string', 'x-parser-schema-id': '<anonymous-schema-1>' });
     expect(oldApi.json().channels.channel?.subscribe?.message?.[xParserOriginalPayload]).toEqual({ type: 'number', 'x-parser-schema-id': '<anonymous-schema-2>' });
   });
@@ -226,7 +226,7 @@ describe('migrateToOldAPI()', function() {
 
     // apply anonymous naming
     anonymousNaming(newApi);
-    const oldApi = migrateToOldAPI(newApi);
+    const oldApi = convertToOldAPI(newApi);
     expect(oldApi.json().channels.channel?.publish?.message?.[xParserOriginalTraits]).toEqual([{}, {}]);
     expect((oldApi.json().channels.channel?.publish?.message as any)?.traits).toBeUndefined();
     expect(oldApi.json().channels.channel?.subscribe?.message?.[xParserOriginalTraits]).toEqual([{}, {}]);
@@ -253,7 +253,7 @@ describe('migrateToOldAPI()', function() {
       }
     } as any);
 
-    const oldApi = migrateToOldAPI(newApi);
+    const oldApi = convertToOldAPI(newApi);
     expect(oldApi.json().channels.channel?.publish?.[xParserOriginalTraits]).toEqual([{}, {}]);
     expect(oldApi.json().channels.channel?.publish?.traits).toBeUndefined();
     expect(oldApi.json().channels.channel?.subscribe?.[xParserOriginalTraits]).toEqual([{}, {}]);

--- a/test/old-api/iterator.spec.ts
+++ b/test/old-api/iterator.spec.ts
@@ -1,4 +1,4 @@
-import { migrateToOldAPI } from '../../src/old-api/migrator';
+import { convertToOldAPI } from '../../src/old-api/converter';
 import { SchemaIteratorCallbackType, SchemaTypesToIterate, traverseAsyncApiDocument } from '../../src/old-api/iterator';
 import { Parser } from '../../src/parser';
 import { AsyncAPIDocument } from '../../src/old-api/asyncapi';
@@ -59,7 +59,7 @@ describe('Traverse AsyncAPI document - old API', function() {
   describe('traverseAsyncApiDocument()', function() {
     it('should traverse all possible schemas from a valid document', async function() {
       const { document } = await parser.parse(documentRaw);
-      const oldDocument = migrateToOldAPI(document!);
+      const oldDocument = convertToOldAPI(document!);
 
       expect(oldDocument).toBeInstanceOf(AsyncAPIDocument);
 
@@ -87,7 +87,7 @@ describe('Traverse AsyncAPI document - old API', function() {
 
     it('should traverse few schemas from a valid document', async function() {
       const { document } = await parser.parse(documentRaw);
-      const oldDocument = migrateToOldAPI(document!);
+      const oldDocument = convertToOldAPI(document!);
 
       expect(oldDocument).toBeInstanceOf(AsyncAPIDocument);
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- fix TS imports: in CLI integration TSCompiler throws some warnings related to typings.
- change name `migrateToOldAPI` to `convertToOldAPI`.
- Update Readme

**Related issue(s)**
Part of #481 
Part of #482 