### PR TITLE
refactor: exports extras and missed things

### DIFF
--- a/src/from.ts
+++ b/src/from.ts
@@ -1,4 +1,5 @@
-import { readFile } from 'fs/promises';
+import { readFile } from 'fs';
+import { promisify } from 'util';
 
 import type { RequestInit } from 'node-fetch';
 import type { Parser } from './parser';
@@ -29,9 +30,9 @@ export function fromURL(parser: Parser, source: string, options?: RequestInit): 
   };
 }
 
-export function fromFile(parser: Parser, source: string, options?: Parameters<typeof readFile>[1]): FromResult {
+export function fromFile(parser: Parser, source: string, options?: Parameters<typeof readFile.__promisify__>[1]): FromResult {
   async function readFileFn(): Promise<Input> {
-    return (await readFile(source, options)).toString();
+    return (await promisify(readFile)(source, options)).toString();
   }
 
   return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import { DiagnosticSeverity } from '@stoplight/types';
+
 import { Parser } from './parser';
 
 export * from './models';
@@ -5,10 +7,11 @@ export * from './models';
 export { Parser };
 export { stringify, unstringify } from './stringify';
 export { fromURL, fromFile } from './from';
+export { createAsyncAPIDocument, toAsyncAPIDocument, isAsyncAPIDocument } from './document';
 
-export { AsyncAPIDocument as OldAsyncAPIDocument } from './old-api/asyncapi';
-export { convertToOldAPI } from './old-api/converter';
+export * from './old-api';
 
+export { DiagnosticSeverity };
 export type { AsyncAPISemver, Input, Diagnostic, SchemaValidateResult } from './types';
 export type { ValidateOptions, ValidateOutput } from './validate';
 export type { ParseOptions, ParseOutput } from './parse';

--- a/src/old-api/index.ts
+++ b/src/old-api/index.ts
@@ -1,0 +1,22 @@
+export { convertToOldAPI } from './converter';
+
+export { AsyncAPIDocument as OldAsyncAPIDocument } from './asyncapi';
+export { Base as OldBase } from './base';
+export { ChannelParameter as OldChannelParameter } from './channel-parameter';
+export { Channel as OldChannel } from './channel';
+export { Components as OldComponents } from './components';
+export { Contact as OldContact } from './contact';
+export { CorrelationId as OldCorrelationId } from './correlation-id';
+export { ExternalDocs as OldExternalDocs } from './external-docs';
+export { License as OldLicense } from './license';
+export { MessageTrait as OldMessageTrait } from './message-trait';
+export { Message as OldMessage } from './message';
+export { OAuthFlow as OldOAuthFlow } from './oauth-flow';
+export { OperationTrait as OldOperationTrait } from './operation-trait';
+export { Operation as OldOperation } from './operation';
+export { Schema as OldSchema } from './schema';
+export { SecurityRequirement as OldSecurityRequirement } from './security-requirement';
+export { SecurityScheme as OldSecurityScheme } from './security-scheme';
+export { ServerVariable as OldServerVariable } from './server-variable';
+export { Server as OldServer } from './server';
+export { Tag as OldTag } from './tag';

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -8,14 +8,17 @@ import { createDetailedAsyncAPI, mergePatch, setExtension } from './utils';
 
 import { xParserSpecParsed } from './constants';
 
-import type { Spectral } from '@stoplight/spectral-core';
+import type { Spectral, Document } from '@stoplight/spectral-core';
 import type { Parser } from './parser';
 import type { ValidateOptions } from './validate';
 import type { Input, Diagnostic } from './types';
 
 export interface ParseOutput {
   document: AsyncAPIDocumentInterface | undefined;
-  diagnostics: Diagnostic[]; 
+  diagnostics: Diagnostic[];
+  extras?: {
+    document: Document;
+  }
 }
 
 export interface ParseOptions {
@@ -33,11 +36,12 @@ const defaultOptions: ParseOptions = {
 
 export async function parse(parser: Parser, spectral: Spectral, asyncapi: Input, options: ParseOptions = {}): Promise<ParseOutput> {
   options = mergePatch<ParseOptions>(defaultOptions, options);
-  const { validated, diagnostics } = await validate(spectral, asyncapi, { ...options.validateOptions, source: options.source });
+  const { validated, diagnostics, extras } = await validate(spectral, asyncapi, { ...options.validateOptions, source: options.source });
   if (validated === undefined) {
     return {
       document: undefined,
       diagnostics,
+      extras: undefined
     };
   }
 
@@ -52,5 +56,6 @@ export async function parse(parser: Parser, spectral: Spectral, asyncapi: Input,
   return { 
     document,
     diagnostics,
+    extras,
   };
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,10 +31,6 @@ export function normalizeInput(asyncapi: string | MaybeAsyncAPI): string {
   return JSON.stringify(asyncapi, undefined, 2);
 }
 
-export function unfreezeObject(data: unknown) {
-  return JSON.parse(JSON.stringify(data));
-}
-
 export function hasErrorDiagnostic(diagnostics: ISpectralDiagnostic[]): boolean {
   return diagnostics.some(diagnostic => diagnostic.severity === DiagnosticSeverity.Error);
 }

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -9,6 +9,7 @@ import type { Input, Diagnostic } from './types';
 export interface ValidateOptions extends IRunOpts {
   source?: string;
   allowedSeverity?: {
+    error?: boolean;
     warning?: boolean;
     info?: boolean;
     hint?: boolean;
@@ -18,10 +19,14 @@ export interface ValidateOptions extends IRunOpts {
 export interface ValidateOutput {
   validated: unknown;
   diagnostics: Diagnostic[];
+  extras: {
+    document: Document,
+  }
 }
 
 const defaultOptions: ValidateOptions = {
   allowedSeverity: {
+    error: false,
     warning: true,
     info: true,
     hint: true,
@@ -37,7 +42,7 @@ export async function validate(spectral: Spectral, asyncapi: Input, options: Val
   let { resolved: validated, results } = await spectral.runWithResolved(document);
 
   if (
-    hasErrorDiagnostic(results) ||
+    (!allowedSeverity?.error && hasErrorDiagnostic(results)) ||
     (!allowedSeverity?.warning && hasWarningDiagnostic(results)) ||
     (!allowedSeverity?.info && hasInfoDiagnostic(results)) ||
     (!allowedSeverity?.hint && hasHintDiagnostic(results))
@@ -45,5 +50,5 @@ export async function validate(spectral: Spectral, asyncapi: Input, options: Val
     validated = undefined;
   }
 
-  return { validated, diagnostics: results };
+  return { validated, diagnostics: results, extras: { document: document as Document } };
 }

--- a/test/from.spec.ts
+++ b/test/from.spec.ts
@@ -8,7 +8,7 @@ describe('fromURL() & fromFile()', function() {
 
   describe('fromURL()', function() {
     it('should operate on existing HTTP source', async function() {
-      const { document, diagnostics } = await fromURL(parser, 'https://raw.githubusercontent.com/asyncapi/spec/master/examples/simple.yml').parse();
+      const { document, diagnostics } = await fromURL(parser, 'https://raw.githubusercontent.com/asyncapi/spec/v2.0.0/examples/2.0.0/gitter-streaming.yml').parse();
       expect(document).not.toBeUndefined();
       expect(diagnostics.length > 0).toEqual(true);
       expect(hasWarningDiagnostic(diagnostics)).toEqual(true);

--- a/test/parse.spec.ts
+++ b/test/parse.spec.ts
@@ -1,3 +1,5 @@
+import { Document } from '@stoplight/spectral-core';
+
 import { AsyncAPIDocumentV2 } from '../src/models';
 import { Parser } from '../src/parser';
 
@@ -30,6 +32,22 @@ describe('parse()', function() {
     const { document, diagnostics } = await parser.parse(documentRaw);
     
     expect(document).toEqual(undefined);
+    expect(diagnostics.length > 0).toEqual(true);
+  });
+
+  it('should return extras', async function() {
+    const documentRaw = {
+      asyncapi: '2.0.0',
+      info: {
+        title: 'Valid AsyncApi document',
+        version: '1.0',
+      },
+      channels: {}
+    };
+    const { document, diagnostics, extras } = await parser.parse(documentRaw);
+    
+    expect(document).toBeInstanceOf(AsyncAPIDocumentV2);
+    expect(extras?.document).toBeInstanceOf(Document);
     expect(diagnostics.length > 0).toEqual(true);
   });
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,6 +35,7 @@ module.exports = {
     fallback: {
       fs: false,
       path: false,
+      util: false,
       buffer: require.resolve('buffer/'),
     }
   },


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Export several functions needed by Studio's integration and Generator's integration.
- Export `extras` in `parse()` output - we need `document` Spectral's instance to get location/range of given JSON Path.
- Fix import in `from` file.

**Related issue(s)**
Part of https://github.com/asyncapi/parser-js/issues/481