### PR TITLE
fix: change schema.uid() method to schema.id()

### DIFF
--- a/src/custom-operations/anonymous-naming.ts
+++ b/src/custom-operations/anonymous-naming.ts
@@ -37,7 +37,7 @@ function assignNameToAnonymousMessages(document: AsyncAPIDocumentInterface) {
 function assignUidToComponentParameterSchemas(document: AsyncAPIDocumentInterface) {
   document.components().channelParameters().forEach(parameter => {
     const schema = parameter.schema();
-    if (schema && !schema.uid()) {
+    if (schema && !schema.id()) {
       setExtension(xParserSchemaId, parameter.id(), schema);
     }
   });
@@ -47,7 +47,7 @@ function assignUidToChannelParameterSchemas(document: AsyncAPIDocumentInterface)
   document.channels().forEach(channel => {
     channel.parameters().forEach(parameter => {
       const schema = parameter.schema();
-      if (schema && !schema.uid()) {
+      if (schema && !schema.id()) {
         setExtension(xParserSchemaId, parameter.id(), schema);
       }
     });
@@ -56,14 +56,14 @@ function assignUidToChannelParameterSchemas(document: AsyncAPIDocumentInterface)
 
 function assignUidToComponentSchemas(document: AsyncAPIDocumentInterface) {
   document.components().schemas().forEach(schema => {
-    setExtension(xParserSchemaId, schema.uid(), schema);
+    setExtension(xParserSchemaId, schema.id(), schema);
   });
 }
   
 function assignUidToAnonymousSchemas(doc: AsyncAPIDocumentInterface) {
   let anonymousSchemaCounter = 0;
   function callback(schema: SchemaInterface) {
-    if (!schema.uid()) {
+    if (!schema.id()) {
       setExtension(xParserSchemaId, `<anonymous-schema-${++anonymousSchemaCounter}>`, schema);
     }
   }

--- a/src/models/schema.ts
+++ b/src/models/schema.ts
@@ -3,7 +3,6 @@ import type { ExtensionsMixinInterface, ExternalDocumentationMixinInterface } fr
 import type { v2 } from '../spec-types';
 
 export interface SchemaInterface extends BaseModel<v2.AsyncAPISchemaObject>, ExtensionsMixinInterface, ExternalDocumentationMixinInterface {
-  uid(): string;
   $comment(): string | undefined;
   $id(): string | undefined;
   $schema(): string;
@@ -27,6 +26,7 @@ export interface SchemaInterface extends BaseModel<v2.AsyncAPISchemaObject>, Ext
   exclusiveMaximum(): number | undefined;
   exclusiveMinimum(): number | undefined;
   format(): string | undefined;
+  id(): string;
   isBooleanSchema(): boolean;
   if(): SchemaInterface | undefined;
   isCircular(): boolean;

--- a/src/models/v2/schema.ts
+++ b/src/models/v2/schema.ts
@@ -20,7 +20,7 @@ export class Schema extends BaseModel<v2.AsyncAPISchemaObject, { id?: string, pa
     super(_json, _meta);
   }
 
-  uid(): string {
+  id(): string {
     return this._meta.id || this.json(xParserSchemaId as any) as string;
   }
 

--- a/src/models/v2/schemas.ts
+++ b/src/models/v2/schemas.ts
@@ -5,6 +5,6 @@ import type { SchemaInterface } from '../schema';
 
 export class Schemas extends Collection<SchemaInterface> implements SchemasInterface {
   override get(id: string): SchemaInterface | undefined {
-    return this.collections.find(schema => schema.uid() === id);
+    return this.collections.find(schema => schema.id() === id);
   }
 }

--- a/test/models/v2/schema.spec.ts
+++ b/test/models/v2/schema.spec.ts
@@ -9,7 +9,7 @@ describe('Channel model', function() {
     it('should return id of model', function() {
       const doc = {};
       const d = new Schema(doc, { asyncapi: {} as any, pointer: '', id: 'schema' });
-      expect(d.uid()).toEqual('schema');
+      expect(d.id()).toEqual('schema');
     });
   });
 


### PR DESCRIPTION
**Description**

This PR renames the `schema.uid()` method to become `schema.id()` to be consistent with all the other models (which are using `id()` as well).

The change in the `parser-api` can be seen [here](https://github.com/asyncapi/parser-api/pull/71/commits/0ae8f98405ed49e26bb46b7d73eea5efd51f1d4f).

