### PR TITLE
docs: fix Node req in develop README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,10 +235,10 @@ A few advantages of this solution:
 
 ## Develop
 
-1. Make sure you are using Node.js 14 or higher and npm 7 or higher
-1. Write code and tests.
-1. Make sure all tests pass `npm test`
-1. Make sure code is well formatted and secure `npm run lint`
+1. Make sure you are using Node.js 15 or higher and npm 7 or higher.
+2. Write code and tests.
+3. Make sure all tests pass `npm test`.
+4. Make sure code is well formatted and secure `npm run lint`.
 
 Release regenerates API documentation and browser bundle, so you do not have to regenerate it manually with `npm run docs` and `npm run prepublishOnly`.
 


### PR DESCRIPTION
**Description**

I noticed the right combo should be Node >=15,  NPM >= 7., according to https://nodejs.org/en/download/releases/

![](https://user-images.githubusercontent.com/1083296/196470514-48ebed57-d9c7-4eb0-9f04-06d755003d62.png)

**Related issue(s)**
- https://github.com/asyncapi/parser-js/pull/584#issuecomment-1282554472
- https://github.com/asyncapi/parser-js/issues/427
