### PR TITLE
feat: export `AsyncAPISchema` and `v2` types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,6 @@ export type { ValidateOptions, ValidateOutput } from './validate';
 export type { ParseOptions, ParseOutput } from './parse';
 export type { StringifyOptions } from './stringify';
 export type { ValidateSchemaInput, ParseSchemaInput, SchemaParser } from './schema-parser';
-export type { v2 as specTypesV2 } from './spec-types';
+export type { v2 as SpecTypesV2 } from './spec-types';
 
 export default Parser;

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,14 +8,15 @@ export { Parser };
 export { stringify, unstringify } from './stringify';
 export { fromURL, fromFile } from './from';
 export { createAsyncAPIDocument, toAsyncAPIDocument, isAsyncAPIDocument } from './document';
+export { DiagnosticSeverity };
 
 export * from './old-api';
 
-export { DiagnosticSeverity };
-export type { AsyncAPISemver, Input, Diagnostic, SchemaValidateResult, AsyncAPISchema, AsyncAPISchemaDefinition } from './types';
+export type { AsyncAPISemver, Input, Diagnostic, SchemaValidateResult, AsyncAPISchema } from './types';
 export type { ValidateOptions, ValidateOutput } from './validate';
 export type { ParseOptions, ParseOutput } from './parse';
 export type { StringifyOptions } from './stringify';
 export type { ValidateSchemaInput, ParseSchemaInput, SchemaParser } from './schema-parser';
+export type { v2 as specTypesV2 } from './spec-types';
 
 export default Parser;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export { createAsyncAPIDocument, toAsyncAPIDocument, isAsyncAPIDocument } from '
 export * from './old-api';
 
 export { DiagnosticSeverity };
-export type { AsyncAPISemver, Input, Diagnostic, SchemaValidateResult } from './types';
+export type { AsyncAPISemver, Input, Diagnostic, SchemaValidateResult, AsyncAPISchema, AsyncAPISchemaDefinition } from './types';
 export type { ValidateOptions, ValidateOutput } from './validate';
 export type { ParseOptions, ParseOutput } from './parse';
 export type { StringifyOptions } from './stringify';

--- a/src/schema-parser/spectral-rule-v2.ts
+++ b/src/schema-parser/spectral-rule-v2.ts
@@ -1,5 +1,5 @@
 import { createRulesetFunction } from '@stoplight/spectral-core';
-import { aas2_0, aas2_1, aas2_2, aas2_3, aas2_4 } from '@stoplight/spectral-formats';
+import { aas2_0, aas2_1, aas2_2, aas2_3, aas2_4, aas2_5 } from '@stoplight/spectral-formats';
 
 import { validateSchema, getSchemaFormat, getDefaultSchemaFormat } from './index';
 import { createDetailedAsyncAPI } from '../utils';
@@ -13,7 +13,7 @@ import type { v2 } from '../spec-types';
 export function asyncApi2SchemaParserRule(parser: Parser): RuleDefinition {
   return {
     description: 'Custom schema must be correctly formatted from the point of view of the used format.',
-    formats: [aas2_0, aas2_1, aas2_2, aas2_3, aas2_4],
+    formats: [aas2_0, aas2_1, aas2_2, aas2_3, aas2_4, aas2_5],
     message: '{{error}}',
     severity: 'error',
     type: 'validation',

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,3 +22,4 @@ export type Diagnostic = ISpectralDiagnostic;
 export type SchemaValidateResult = IFunctionResult;
 export type AsyncAPIObject = v2.AsyncAPIObject;
 export type AsyncAPISchema = v2.AsyncAPISchemaObject;
+export type AsyncAPISchemaDefinition = v2.AsyncAPISchemaDefinition;

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,4 +22,3 @@ export type Diagnostic = ISpectralDiagnostic;
 export type SchemaValidateResult = IFunctionResult;
 export type AsyncAPIObject = v2.AsyncAPIObject;
 export type AsyncAPISchema = v2.AsyncAPISchemaObject;
-export type AsyncAPISchemaDefinition = v2.AsyncAPISchemaDefinition;


### PR DESCRIPTION
**Description**

This PR exports some types that are required by other packages. In particular, by [this avro-schema-parser PR](https://github.com/asyncapi/avro-schema-parser/pull/168).

**Related issue(s)**
https://github.com/asyncapi/avro-schema-parser/issues/166