### PR TITLE
fix: add missed methods to the SecurityScheme model

### DIFF
--- a/src/models/security-requirement.ts
+++ b/src/models/security-requirement.ts
@@ -2,6 +2,6 @@ import type { BaseModel } from './base';
 import type { SecuritySchemeInterface } from './security-scheme';
 
 export interface SecurityRequirementInterface extends BaseModel {
-  scheme(): SecuritySchemeInterface
+  scheme(): SecuritySchemeInterface;
   scopes(): string[];
 }

--- a/src/models/security-scheme.ts
+++ b/src/models/security-scheme.ts
@@ -5,10 +5,16 @@ import type { DescriptionMixinInterface, ExtensionsMixinInterface } from './mixi
 export interface SecuritySchemeInterface extends BaseModel, DescriptionMixinInterface, ExtensionsMixinInterface {
   id(): string;
   type(): string;
+  hasName(): boolean;
   name(): string | undefined;
+  hasIn(): boolean;
   in(): string | undefined;
+  hasScheme(): boolean;
   scheme(): string | undefined;
+  hasBearerFormat(): boolean;
   bearerFormat(): string | undefined;
+  hasFlows(): boolean;
   flows(): OAuthFlowsInterface | undefined;
+  hasOpenIdConnectUrl(): boolean;
   openIdConnectUrl(): string | undefined;
 }

--- a/src/models/security-scheme.ts
+++ b/src/models/security-scheme.ts
@@ -3,12 +3,12 @@ import type { OAuthFlowsInterface } from './oauth-flows';
 import type { DescriptionMixinInterface, ExtensionsMixinInterface } from './mixins';
 
 export interface SecuritySchemeInterface extends BaseModel, DescriptionMixinInterface, ExtensionsMixinInterface {
-  id(): string
-  hasBearerFormat(): boolean;
-  bearerFormat(): string | undefined;
-  openIdConnectUrl(): string | undefined;
-  scheme(): string | undefined;
-  flows(): OAuthFlowsInterface | undefined;
+  id(): string;
   type(): string;
+  name(): string | undefined;
   in(): string | undefined;
+  scheme(): string | undefined;
+  bearerFormat(): string | undefined;
+  flows(): OAuthFlowsInterface | undefined;
+  openIdConnectUrl(): string | undefined;
 }

--- a/src/models/v2/security-scheme.ts
+++ b/src/models/v2/security-scheme.ts
@@ -26,25 +26,49 @@ export class SecurityScheme extends BaseModel<v2.SecuritySchemeObject, { id: str
     return description(this);
   }
 
+  hasName(): boolean {
+    return !!this._json.name;
+  }
+
   name(): string | undefined {
     return this._json.name;
+  }
+
+  hasIn(): boolean {
+    return !!this._json.in;
   }
 
   in(): v2.SecuritySchemaLocation | undefined {
     return this._json.in;
   }
 
+  hasScheme(): boolean {
+    return !!this._json.scheme;
+  }
+
   scheme(): string | undefined {
     return this._json.scheme;
+  }
+
+  hasBearerFormat(): boolean {
+    return !!this._json.bearerFormat;
   }
 
   bearerFormat(): string | undefined {
     return this._json.bearerFormat;
   }
 
+  hasFlows(): boolean {
+    return !!this._json.flows;
+  }
+
   flows(): OAuthFlowsInterface | undefined {
     if (!this._json.flows) return undefined;
     return new OAuthFlows(this._json.flows);
+  }
+
+  hasOpenIdConnectUrl(): boolean {
+    return !!this._json.openIdConnectUrl;
   }
 
   openIdConnectUrl(): string | undefined {

--- a/src/models/v2/security-scheme.ts
+++ b/src/models/v2/security-scheme.ts
@@ -14,6 +14,10 @@ export class SecurityScheme extends BaseModel<v2.SecuritySchemeObject, { id: str
     return this._meta.id;
   }
 
+  type(): v2.SecuritySchemeType {
+    return this._json.type;
+  }
+
   hasDescription(): boolean {
     return hasDescription(this);
   }
@@ -22,20 +26,20 @@ export class SecurityScheme extends BaseModel<v2.SecuritySchemeObject, { id: str
     return description(this);
   }
 
-  hasBearerFormat(): boolean {
-    return !!this._json.bearerFormat;
+  name(): string | undefined {
+    return this._json.name;
   }
 
-  bearerFormat(): string | undefined {
-    return this._json.bearerFormat;
-  }
-
-  openIdConnectUrl(): string | undefined {
-    return this._json.openIdConnectUrl;
+  in(): v2.SecuritySchemaLocation | undefined {
+    return this._json.in;
   }
 
   scheme(): string | undefined {
     return this._json.scheme;
+  }
+
+  bearerFormat(): string | undefined {
+    return this._json.bearerFormat;
   }
 
   flows(): OAuthFlowsInterface | undefined {
@@ -43,12 +47,8 @@ export class SecurityScheme extends BaseModel<v2.SecuritySchemeObject, { id: str
     return new OAuthFlows(this._json.flows);
   }
 
-  type(): v2.SecuritySchemeType {
-    return this._json.type;
-  }
-
-  in(): v2.SecuritySchemaLocation | undefined {
-    return this._json.in;
+  openIdConnectUrl(): string | undefined {
+    return this._json.openIdConnectUrl;
   }
 
   extensions(): ExtensionsInterface {

--- a/test/models/v2/security-requirement.spec.ts
+++ b/test/models/v2/security-requirement.spec.ts
@@ -12,6 +12,7 @@ describe('SecurityRequirement model', function() {
       expect(d.scheme()).toEqual(expectedScheme);   
     });
   });
+  
   describe('.scopes()', function() {
     it('should return scopes', function() {
       const scopes = ['scope_one'];

--- a/test/models/v2/security-scheme.spec.ts
+++ b/test/models/v2/security-scheme.spec.ts
@@ -1,5 +1,6 @@
 import { SecurityScheme } from '../../../src/models/v2/security-scheme';
 import { OAuthFlows } from '../../../src/models/v2/oauth-flows';
+import { assertDescription, assertExtensions } from './utils';
 
 import type { v2 } from '../../../src/spec-types';
 
@@ -37,9 +38,33 @@ describe('Security Scheme', function () {
     });
   });
 
+  describe('.hasName()', function () {
+    it('should return true if name is present', function () {
+      const data = new SecurityScheme({ type: 'apiKey', name: 'name' }, { asyncapi: {} as any, pointer: '', id: 'security-model' });
+      expect(data.hasName()).toEqual(true);
+    });
+
+    it('should return false if name is not present', function () {
+      const data = new SecurityScheme({ type: 'apiKey' }, { asyncapi: {} as any, pointer: '', id: 'security-model' });
+      expect(data.hasName()).toEqual(false);
+    });
+  });
+
   describe('.name()', function () {
     it('should return name if present', function () {
       expect(sc1.name()).toEqual(doc1.name);
+    });
+  });
+
+  describe('.hasIn()', function () {
+    it('should return true if in is present', function () {
+      const data = new SecurityScheme({ type: 'apiKey', in: 'header' }, { asyncapi: {} as any, pointer: '', id: 'security-model' });
+      expect(data.hasIn()).toEqual(true);
+    });
+
+    it('should return false if in is not present', function () {
+      const data = new SecurityScheme({ type: 'apiKey' }, { asyncapi: {} as any, pointer: '', id: 'security-model' });
+      expect(data.hasIn()).toEqual(false);
     });
   });
 
@@ -47,6 +72,18 @@ describe('Security Scheme', function () {
     it('should return in if present', function () {
       expect(sc1.in()).toEqual(doc1.in);
       expect(emptyItem.in()).toBeUndefined();
+    });
+  });
+
+  describe('.hasBearerFormat()', function () {
+    it('should return true if bearerFormat is present', function () {
+      const data = new SecurityScheme({ type: 'apiKey', bearerFormat: 'bearerFormat' }, { asyncapi: {} as any, pointer: '', id: 'security-model' });
+      expect(data.hasBearerFormat()).toEqual(true);
+    });
+
+    it('should return false if bearerFormat is not present', function () {
+      const data = new SecurityScheme({ type: 'apiKey' }, { asyncapi: {} as any, pointer: '', id: 'security-model' });
+      expect(data.hasBearerFormat()).toEqual(false);
     });
   });
 
@@ -57,6 +94,18 @@ describe('Security Scheme', function () {
     });
   });
 
+  describe('.hasScheme()', function () {
+    it('should return true if bearerFormat is present', function () {
+      const data = new SecurityScheme({ type: 'apiKey', scheme: 'scheme' }, { asyncapi: {} as any, pointer: '', id: 'security-model' });
+      expect(data.hasScheme()).toEqual(true);
+    });
+
+    it('should return false if bearerFormat is not present', function () {
+      const data = new SecurityScheme({ type: 'apiKey' }, { asyncapi: {} as any, pointer: '', id: 'security-model' });
+      expect(data.hasScheme()).toEqual(false);
+    });
+  });
+
   describe('.scheme()', function () {
     it('should return scheme if present', function () {
       expect(sc1.scheme()).toEqual(doc1.scheme);
@@ -64,10 +113,15 @@ describe('Security Scheme', function () {
     });
   });
 
-  describe('.in()', function () {
-    it('should return in if present', function () {
-      expect(sc1.in()).toEqual(doc1.in);
-      expect(emptyItem.in()).toBeUndefined();
+  describe('.hasFlows()', function () {
+    it('should return true if flows is present', function () {
+      const data = new SecurityScheme({ type: 'apiKey', flows: {} }, { asyncapi: {} as any, pointer: '', id: 'security-model' });
+      expect(data.hasFlows()).toEqual(true);
+    });
+
+    it('should return false if flows is not present', function () {
+      const data = new SecurityScheme({ type: 'apiKey' }, { asyncapi: {} as any, pointer: '', id: 'security-model' });
+      expect(data.hasFlows()).toEqual(false);
     });
   });
 
@@ -81,9 +135,26 @@ describe('Security Scheme', function () {
     });
   });
 
+  describe('.hasOpenIdConnectUrl()', function () {
+    it('should return true if openIdConnectUrl is present', function () {
+      const data = new SecurityScheme({ type: 'apiKey', openIdConnectUrl: 'openIdConnectUrl' }, { asyncapi: {} as any, pointer: '', id: 'security-model' });
+      expect(data.hasOpenIdConnectUrl()).toEqual(true);
+    });
+
+    it('should return false if openIdConnectUrl is not present', function () {
+      const data = new SecurityScheme({ type: 'apiKey' }, { asyncapi: {} as any, pointer: '', id: 'security-model' });
+      expect(data.hasOpenIdConnectUrl()).toEqual(false);
+    });
+  });
+
   describe('.openIdConnectUrl()', function () {
     it('should return openIdConnectUrl value', function () {
       expect(sc1.openIdConnectUrl()).toMatch(doc1.openIdConnectUrl as string);
     });
+  });
+
+  describe('mixins inheritance', function () {
+    assertDescription(SecurityScheme);
+    assertExtensions(SecurityScheme);
   });
 });

--- a/test/models/v2/security-scheme.spec.ts
+++ b/test/models/v2/security-scheme.spec.ts
@@ -5,6 +5,7 @@ import type { v2 } from '../../../src/spec-types';
 
 const doc1: v2.SecuritySchemeObject = {
   type: 'http',
+  name: 'api_key',
   in: 'header',
   scheme: 'bearer',
   bearerFormat: 'JWT',
@@ -26,38 +27,50 @@ const emptyItem = new SecurityScheme({ type: 'X509' });
 describe('Security Scheme', function () {
   describe('.id()', function () {
     it('should return name if present', function () {
-      expect(sc1.id()).toMatch('api_key');
+      expect(sc1.id()).toEqual('api_key');
     });
   });
 
   describe('.type()', function () {
     it('should return type when it is present', function () {
-      expect(sc1.type()).toMatch(doc1.type);
+      expect(sc1.type()).toEqual(doc1.type);
     });
   });
 
-  describe('.hasBearerFormat()', function () {
-    it('should return true if bearerFormat is present', function () {
-      expect(sc1.hasBearerFormat()).toBeTruthy();
-    });
-
-    it('should return false if bearerFormat is not present', function () {
-      expect(emptyItem.hasBearerFormat()).toBeFalsy();
+  describe('.name()', function () {
+    it('should return name if present', function () {
+      expect(sc1.name()).toEqual(doc1.name);
     });
   });
 
   describe('.in()', function () {
     it('should return in if present', function () {
-      expect(sc1.in()).toMatch(doc1.in as string);
+      expect(sc1.in()).toEqual(doc1.in);
       expect(emptyItem.in()).toBeUndefined();
     });
   });
 
-  describe('.openIdConnectUrl()', function () {
-    it('should return openIdConnectUrl value', function () {
-      expect(sc1.openIdConnectUrl()).toMatch(doc1.openIdConnectUrl as string);
+  describe('.bearerFormat()', function () {
+    it('should return bearerFormat if present', function () {
+      expect(sc1.bearerFormat()).toEqual(doc1.bearerFormat);
+      expect(emptyItem.bearerFormat()).toBeUndefined();
     });
   });
+
+  describe('.scheme()', function () {
+    it('should return scheme if present', function () {
+      expect(sc1.scheme()).toEqual(doc1.scheme);
+      expect(emptyItem.scheme()).toBeUndefined();
+    });
+  });
+
+  describe('.in()', function () {
+    it('should return in if present', function () {
+      expect(sc1.in()).toEqual(doc1.in);
+      expect(emptyItem.in()).toBeUndefined();
+    });
+  });
+
   describe('.flows()', function () {
     it('should return undefined if flow object is not present', function () {
       expect(emptyItem.flows()).toBeUndefined();
@@ -65,6 +78,12 @@ describe('Security Scheme', function () {
 
     it('should return OAuthFlows object', function() {
       expect(sc1.flows() instanceof OAuthFlows).toBeTruthy();
+    });
+  });
+
+  describe('.openIdConnectUrl()', function () {
+    it('should return openIdConnectUrl value', function () {
+      expect(sc1.openIdConnectUrl()).toMatch(doc1.openIdConnectUrl as string);
     });
   });
 });

--- a/test/models/v2/server-variable.spec.ts
+++ b/test/models/v2/server-variable.spec.ts
@@ -1,9 +1,11 @@
 import { ServerVariable } from '../../../src/models/v2/server-variable';
+import { assertDescription, assertExtensions } from './utils';
 
 const doc = {
   description: 'Secure connection (TLS) is available through port 8883.',
   default: '1883',
-  enum: ['1883', '8883']
+  enum: ['1883', '8883'],
+  examples: ['1883', '8883'],
 };
 
 const sv = new ServerVariable(doc, { asyncapi: {} as any, pointer: '', id: 'doc' });
@@ -35,5 +37,16 @@ describe('Server Variable ', function() {
     it('should return enum object', function() {
       expect(sv.allowedValues()).toEqual(doc.enum);
     });
+  });
+
+  describe('.examples()', function() {
+    it('should return array', function() {
+      expect(sv.examples()).toEqual(doc.examples);
+    });
+  });
+
+  describe('mixins inheritance', function () {
+    assertDescription(ServerVariable);
+    assertExtensions(ServerVariable);
   });
 });


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Add missed methods to the `SecurityScheme` model - `name()`.

I don't know if we should have methods like `hasName`, `hasScheme` for every optional fields. What do you think?

Blocks https://github.com/asyncapi/markdown-template/pull/312

cc @smoya 