### PR TITLE
fix: remove action and channel fields from Operation Trait Object

### DIFF
--- a/src/models/operation-trait.ts
+++ b/src/models/operation-trait.ts
@@ -1,17 +1,11 @@
 import type { BaseModel } from './base';
-import type { ChannelsInterface } from './channels';
-import type { OperationAction } from './operation';
 import type { SecurityRequirements } from './security-requirements';
 import type { BindingsMixinInterface, DescriptionMixinInterface, ExtensionsMixinInterface, ExternalDocumentationMixinInterface, TagsMixinInterface } from './mixins';
 
 export interface OperationTraitInterface extends BaseModel, BindingsMixinInterface, DescriptionMixinInterface, ExtensionsMixinInterface, ExternalDocumentationMixinInterface, TagsMixinInterface {
-  id(): string | undefined;
   hasId(): boolean;
-  action(): OperationAction | undefined;
-  isSend(): boolean;
-  isReceive(): boolean;
+  id(): string | undefined;
   hasSummary(): boolean;
   summary(): string | undefined;
   security(): SecurityRequirements[];
-  channels(): ChannelsInterface;
 }

--- a/src/models/operation.ts
+++ b/src/models/operation.ts
@@ -1,14 +1,18 @@
 import type { BaseModel } from './base';
-import type { MessagesInterface } from './messages';
 import type { OperationTraitsInterface } from './operation-traits';
 import type { OperationTraitInterface } from './operation-trait';
+import type { ChannelsInterface } from './channels';
 import type { ServersInterface } from './servers';
+import type { MessagesInterface } from './messages';
 
 export type OperationAction = 'send' | 'receive' | 'publish' | 'subscribe';
 
 export interface OperationInterface extends BaseModel, OperationTraitInterface {
-  action(): OperationAction;
+  action(): OperationAction | undefined;
+  isSend(): boolean;
+  isReceive(): boolean;
   servers(): ServersInterface;
+  channels(): ChannelsInterface
   messages(): MessagesInterface;
   traits(): OperationTraitsInterface;
 }

--- a/src/models/operation.ts
+++ b/src/models/operation.ts
@@ -8,7 +8,7 @@ import type { MessagesInterface } from './messages';
 export type OperationAction = 'send' | 'receive' | 'publish' | 'subscribe';
 
 export interface OperationInterface extends BaseModel, OperationTraitInterface {
-  action(): OperationAction | undefined;
+  action(): OperationAction;
   isSend(): boolean;
   isReceive(): boolean;
   servers(): ServersInterface;

--- a/src/models/v2/operation-trait.ts
+++ b/src/models/v2/operation-trait.ts
@@ -1,5 +1,4 @@
 import { BaseModel } from '../base';
-import { Channels } from '../channels';
 import { SecurityScheme } from './security-scheme';
 import { SecurityRequirements } from '../security-requirements';
 import { SecurityRequirement } from './security-requirement';
@@ -9,7 +8,6 @@ import { bindings, hasDescription, description, extensions, hasExternalDocs, ext
 import type { BindingsInterface } from '../bindings';
 import type { ExtensionsInterface } from '../extensions';
 import type { ExternalDocumentationInterface } from '../external-documentation';
-import type { ChannelsInterface } from '../channels';
 import type { OperationAction } from '../operation';
 import type { OperationTraitInterface } from '../operation-trait';
 import type { TagsInterface } from '../tags';
@@ -23,10 +21,6 @@ export class OperationTrait<J extends v2.OperationTraitObject = v2.OperationTrai
 
   hasId(): boolean {
     return this.id() !== undefined;
-  }
-
-  action(): OperationAction | undefined {
-    return this._meta.action;
   }
 
   hasSummary(): boolean {
@@ -53,14 +47,6 @@ export class OperationTrait<J extends v2.OperationTraitObject = v2.OperationTrai
     return externalDocs(this);
   }
 
-  isSend(): boolean {
-    return this.action() === 'subscribe';
-  }
-
-  isReceive(): boolean {
-    return this.action() === 'publish';
-  }
-
   security(): SecurityRequirements[] {
     const securitySchemes = (this._meta?.asyncapi?.parsed?.components?.securitySchemes || {}) as Record<string, v2.SecuritySchemeObject>;
     return (this._json.security || []).map((requirement, index) => {
@@ -73,10 +59,6 @@ export class OperationTrait<J extends v2.OperationTraitObject = v2.OperationTrai
       });
       return new SecurityRequirements(requirements);
     });
-  }
-
-  channels(): ChannelsInterface {
-    return new Channels([]);
   }
 
   tags(): TagsInterface {

--- a/src/models/v2/operation.ts
+++ b/src/models/v2/operation.ts
@@ -23,6 +23,14 @@ export class Operation extends OperationTrait<v2.OperationObject> implements Ope
     return this._meta.action;
   }
 
+  isSend(): boolean {
+    return this.action() === 'subscribe';
+  }
+
+  isReceive(): boolean {
+    return this.action() === 'publish';
+  }
+
   servers(): ServersInterface {
     const servers: ServerInterface[] = [];
     const serversData: any[] = [];

--- a/src/models/v3/operation-trait.ts
+++ b/src/models/v3/operation-trait.ts
@@ -1,6 +1,4 @@
 import { BaseModel } from '../base';
-// import { Channels } from '../channels';
-// import { Channel } from './channel';
 import { SecurityScheme } from './security-scheme';
 import { SecurityRequirements } from '../security-requirements';
 import { SecurityRequirement } from './security-requirement';
@@ -10,8 +8,6 @@ import { bindings, hasDescription, description, extensions, hasExternalDocs, ext
 import type { BindingsInterface } from '../bindings';
 import type { ExtensionsInterface } from '../extensions';
 import type { ExternalDocumentationInterface } from '../external-documentation';
-import type { ChannelsInterface } from '../channels';
-import type { OperationAction } from '../operation';
 import type { OperationTraitInterface } from '../operation-trait';
 import type { TagsInterface } from '../tags';
 
@@ -24,10 +20,6 @@ export class OperationTrait<J extends v3.OperationTraitObject = v3.OperationTrai
 
   hasId(): boolean {
     return this.id() !== undefined;
-  }
-
-  action(): OperationAction | undefined {
-    return this._json.action;
   }
 
   hasSummary(): boolean {
@@ -52,24 +44,6 @@ export class OperationTrait<J extends v3.OperationTraitObject = v3.OperationTrai
 
   externalDocs(): ExternalDocumentationInterface | undefined {
     return externalDocs(this);
-  }
-
-  isSend(): boolean {
-    return this.action() === 'send';
-  }
-
-  isReceive(): boolean {
-    return this.action() === 'receive';
-  }
-
-  channels(): ChannelsInterface {
-    // if (this._json.channel) {
-    //   return new Channels([
-    //     this.createModel(Channel, this._json.channel as v3.ChannelObject, { id: '', pointer: this.jsonPath('channel') })
-    //   ]);
-    // }
-    // return new Channels([]);
-    return [] as any;
   }
 
   security(): SecurityRequirements[] {

--- a/src/models/v3/operation.ts
+++ b/src/models/v3/operation.ts
@@ -20,6 +20,14 @@ export class Operation extends OperationTrait<v3.OperationObject> implements Ope
     return this._json.action;
   }
 
+  isSend(): boolean {
+    return this.action() === 'send';
+  }
+
+  isReceive(): boolean {
+    return this.action() === 'receive';
+  }
+
   servers(): ServersInterface {
     const servers: ServerInterface[] = [];
     const serversData: any[] = [];

--- a/src/spec-types/v3.ts
+++ b/src/spec-types/v3.ts
@@ -123,8 +123,6 @@ export interface OperationObject extends SpecificationExtensions {
 }
 
 export interface OperationTraitObject extends SpecificationExtensions {
-  action?: 'send' | 'receive';
-  channel?: ChannelObject | ReferenceObject;
   summary?: string;
   description?: string;
   security?: Array<SecurityRequirementObject>;

--- a/test/models/v2/operation-trait.spec.ts
+++ b/test/models/v2/operation-trait.spec.ts
@@ -34,42 +34,6 @@ describe('OperationTrait model', function() {
     });
   });
 
-  describe('.action()', function() {
-    it('should return kind/action of operation', function() {
-      const doc = {};
-      const d = new OperationTrait(doc, { asyncapi: {} as any, pointer: '', id: 'trait', action: 'publish' });
-      expect(d.action()).toEqual('publish');
-    });
-  });
-
-  describe('.isSend()', function() {
-    it('should return true when operation is subscribe', function() {
-      const doc = {};
-      const d = new OperationTrait(doc, { asyncapi: {} as any, pointer: '', id: 'trait', action: 'subscribe' });
-      expect(d.isSend()).toBeTruthy();
-    });
-
-    it('should return false when operation is publish', function() {
-      const doc = {};
-      const d = new OperationTrait(doc, { asyncapi: {} as any, pointer: '', id: 'trait', action: 'publish' });
-      expect(d.isSend()).toBeFalsy();
-    });
-  });
-
-  describe('.isReceive()', function() {
-    it('should return true when operation is publish', function() {
-      const doc = {};
-      const d = new OperationTrait(doc, { asyncapi: {} as any, pointer: '', id: 'trait', action: 'publish' });
-      expect(d.isReceive()).toBeTruthy();
-    });
-
-    it('should return false when operation is subscribe', function() {
-      const doc = {};
-      const d = new OperationTrait(doc, { asyncapi: {} as any, pointer: '', id: 'trait', action: 'subscribe' });
-      expect(d.isReceive()).toBeFalsy();
-    });
-  });
-
   describe('.hasSummary()', function() {
     it('should return true when there is a value', function() {
       const doc = { summary: '...' };

--- a/test/models/v2/operation.spec.ts
+++ b/test/models/v2/operation.spec.ts
@@ -19,6 +19,42 @@ describe('Operation model', function() {
     });
   });
 
+  describe('.action()', function() {
+    it('should return kind/action of operation', function() {
+      const doc = {};
+      const d = new Operation(doc, { asyncapi: {} as any, pointer: '', id: 'trait', action: 'publish' });
+      expect(d.action()).toEqual('publish');
+    });
+  });
+
+  describe('.isSend()', function() {
+    it('should return true when operation is subscribe', function() {
+      const doc = {};
+      const d = new Operation(doc, { asyncapi: {} as any, pointer: '', id: 'trait', action: 'subscribe' });
+      expect(d.isSend()).toBeTruthy();
+    });
+
+    it('should return false when operation is publish', function() {
+      const doc = {};
+      const d = new Operation(doc, { asyncapi: {} as any, pointer: '', id: 'trait', action: 'publish' });
+      expect(d.isSend()).toBeFalsy();
+    });
+  });
+
+  describe('.isReceive()', function() {
+    it('should return true when operation is publish', function() {
+      const doc = {};
+      const d = new Operation(doc, { asyncapi: {} as any, pointer: '', id: 'trait', action: 'publish' });
+      expect(d.isReceive()).toBeTruthy();
+    });
+
+    it('should return false when operation is subscribe', function() {
+      const doc = {};
+      const d = new Operation(doc, { asyncapi: {} as any, pointer: '', id: 'trait', action: 'subscribe' });
+      expect(d.isReceive()).toBeFalsy();
+    });
+  });
+
   describe('.servers()', function() {
     it('should return collection of servers - channel available on all servers', function() {
       const doc = {};

--- a/test/models/v3/operation-trait.spec.ts
+++ b/test/models/v3/operation-trait.spec.ts
@@ -32,40 +32,6 @@ describe('OperationTrait model', function() {
     });
   });
 
-  describe('.action()', function() {
-    it('should return kind/action of operation', function() {
-      const d = new OperationTrait({ action: 'send', channel: {} }, { asyncapi: {} as any, pointer: '', id: 'trait' });
-      expect(d.action()).toEqual('send');
-    });
-  });
-
-  describe('.isSend()', function() {
-    it('should return true when operation has send action', function() {
-      const d = new OperationTrait({ action: 'send', channel: {} }, { asyncapi: {} as any, pointer: '', id: 'trait' });
-      expect(d.isSend()).toBeTruthy();
-    });
-
-    it('should return false when operation has receive action', function() {
-      const doc = {};
-      const d = new OperationTrait({ action: 'receive', channel: {} }, { asyncapi: {} as any, pointer: '', id: 'trait' });
-      expect(d.isSend()).toBeFalsy();
-    });
-  });
-
-  describe('.isReceive()', function() {
-    it('should return true when operation has receive action', function() {
-      const doc = {};
-      const d = new OperationTrait({ action: 'receive', channel: {} }, { asyncapi: {} as any, pointer: '', id: 'trait' });
-      expect(d.isReceive()).toBeTruthy();
-    });
-
-    it('should return false when operation has send action', function() {
-      const doc = {};
-      const d = new OperationTrait({ action: 'send', channel: {} }, { asyncapi: {} as any, pointer: '', id: 'trait' });
-      expect(d.isReceive()).toBeFalsy();
-    });
-  });
-
   describe('.hasSummary()', function() {
     it('should return true when there is a value', function() {
       const doc = { summary: '...' };

--- a/test/models/v3/operation.spec.ts
+++ b/test/models/v3/operation.spec.ts
@@ -11,10 +11,44 @@ import { Server } from '../../../src/models/v3/server';
 import { assertBindings, assertDescription, assertExtensions, assertExternalDocumentation, assertTags } from './utils';
 
 describe('Operation model', function() {
+  describe('.id()', function() {
+    it('should return operationId', function() {
+      const d = new Operation({ action: 'send', channel: {} }, { asyncapi: {} as any, pointer: '', id: 'operation' });
+      expect(d.id()).toEqual('operation');
+    });
+  });
+
   describe('.action()', function() {
     it('should return kind/action of operation', function() {
-      const d = new Operation({ action: 'send', channel: {} }, { asyncapi: {} as any, pointer: '', id: 'trait' });
+      const d = new Operation({ action: 'send', channel: {} }, { asyncapi: {} as any, pointer: '', id: 'operation' });
       expect(d.action()).toEqual('send');
+    });
+  });
+
+  describe('.isSend()', function() {
+    it('should return true when operation has send action', function() {
+      const d = new Operation({ action: 'send', channel: {} }, { asyncapi: {} as any, pointer: '', id: 'operation' });
+      expect(d.isSend()).toBeTruthy();
+    });
+
+    it('should return false when operation has receive action', function() {
+      const doc = {};
+      const d = new Operation({ action: 'receive', channel: {} }, { asyncapi: {} as any, pointer: '', id: 'operation' });
+      expect(d.isSend()).toBeFalsy();
+    });
+  });
+
+  describe('.isReceive()', function() {
+    it('should return true when operation has receive action', function() {
+      const doc = {};
+      const d = new Operation({ action: 'receive', channel: {} }, { asyncapi: {} as any, pointer: '', id: 'operation' });
+      expect(d.isReceive()).toBeTruthy();
+    });
+
+    it('should return false when operation has send action', function() {
+      const doc = {};
+      const d = new Operation({ action: 'send', channel: {} }, { asyncapi: {} as any, pointer: '', id: 'operation' });
+      expect(d.isReceive()).toBeFalsy();
     });
   });
 
@@ -76,7 +110,7 @@ describe('Operation model', function() {
 
   describe('.traits()', function() {
     it('should return collection of traits', function() {
-      const d = new Operation({ action: 'send', channel: {}, traits: [{ action: 'receive' }] });
+      const d = new Operation({ action: 'send', channel: {}, traits: [{}] });
       expect(d.traits()).toBeInstanceOf(OperationTraits);
       expect(d.traits().all()).toHaveLength(1);
       expect(d.traits().all()[0]).toBeInstanceOf(OperationTrait);


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Remove `action` and `channel` fields from Operation Trait Object.

**Related issue(s)**
https://github.com/asyncapi/spec/issues/856