### PR TITLE
fix: pin @openapi-contrib/openapi-schema-to-json-schema to ~3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@asyncapi/specs": "^4.1.0",
-    "@openapi-contrib/openapi-schema-to-json-schema": "^3.2.0",
+    "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
     "@stoplight/json-ref-resolver": "^3.1.5",
     "@stoplight/spectral-core": "^1.16.1",
     "@stoplight/spectral-functions": "^1.7.2",


### PR DESCRIPTION
**Description**

Fixes https://github.com/asyncapi/generator/issues/927

Even though this dependency will be out once we remove schema parsers from this repo in favor of their own repo. See https://github.com/asyncapi/openapi-schema-parser/pull/142#discussion_r1153125770

