### PR TITLE
fix: skip message object example validation for non default schemaFormats

### DIFF
--- a/src/ruleset/v2/ruleset.ts
+++ b/src/ruleset/v2/ruleset.ts
@@ -116,24 +116,24 @@ export const v2CoreRuleset = {
      * Message Object rules
      */
     'asyncapi2-message-examples': {
-      description: 'Examples of message object should follow by "payload" and "headers" schemas.',
+      description: 'Examples of message object should validate againt the "payload" and "headers" schemas.',
       message: '{{error}}',
       severity: 'error',
       recommended: true,
       given: [
         // messages
-        '$.channels.*.[publish,subscribe].message',
-        '$.channels.*.[publish,subscribe].message.oneOf.*',
-        '$.components.channels.*.[publish,subscribe].message',
-        '$.components.channels.*.[publish,subscribe].message.oneOf.*',
-        '$.components.messages.*',
+        '$.channels.*.[publish,subscribe].[?(@property === \'message\' && @.schemaFormat === void 0)]',
+        '$.channels.*.[publish,subscribe].message.oneOf[?(@.schemaFormat === void 0)]',
+        '$.components.channels.*.[publish,subscribe].[?(@property === \'message\' && @.schemaFormat === void 0)]',
+        '$.components.channels.*.[publish,subscribe].message.oneOf[?(@.schemaFormat === void 0)]',
+        '$.components.messages[?(@.schemaFormat === void 0)]',
         // message traits
-        '$.channels.*.[publish,subscribe].message.traits.*',
-        '$.channels.*.[publish,subscribe].message.oneOf.*.traits.*',
-        '$.components.channels.*.[publish,subscribe].message.traits.*',
-        '$.components.channels.*.[publish,subscribe].message.oneOf.*.traits.*',
-        '$.components.messages.*.traits.*',
-        '$.components.messageTraits.*',
+        '$.channels.*.[publish,subscribe].message.traits[?(@.schemaFormat === void 0)]',
+        '$.channels.*.[publish,subscribe].message.oneOf.*.traits[?(@.schemaFormat === void 0)]',
+        '$.components.channels.*.[publish,subscribe].message.traits[?(@.schemaFormat === void 0)]',
+        '$.components.channels.*.[publish,subscribe].message.oneOf.*.traits[?(@.schemaFormat === void 0)]',
+        '$.components.messages.*.traits[?(@.schemaFormat === void 0)]',
+        '$.components.messageTraits[?(@.schemaFormat === void 0)]',
       ],
       then: {
         function: messageExamples,

--- a/test/ruleset/rules/v2/asyncapi2-message-examples.spec.ts
+++ b/test/ruleset/rules/v2/asyncapi2-message-examples.spec.ts
@@ -327,4 +327,69 @@ testRule('asyncapi2-message-examples', [
       },
     ],
   },
+
+  {
+    name: 'valid avro spec case',
+    document: {
+      asyncapi: '2.0.0',
+      channels: {
+        someChannel: {
+          publish: {
+            message: {
+              schemaFormat: 'application/vnd.apache.avro;version=1.9.0',
+              payload: {
+                type: 'record',
+                name: 'Test',
+                fields: [
+                  {name: 'direction', type: { type: 'enum', name: 'directionEnum', symbols: ['North', 'East', 'South', 'West']}},
+                  {name: 'speed', type: 'string'}
+                ]
+              },
+              examples: [
+                {
+                  payload: {
+                    direction: 'North',
+                    speed: '18'
+                  }
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'invalid avro spec case',
+    document: {
+      asyncapi: '2.0.0',
+      channels: {
+        someChannel: {
+          publish: {
+            message: {
+              schemaFormat: 'application/vnd.apache.avro;version=1.9.0',
+              payload: {
+                type: 'record',
+                name: 'Test',
+                fields: [
+                  {name: 'direction', type: { type: 'enum', name: 'directionEnum', symbols: ['North', 'East', 'South', 'West']}},
+                  {name: 'speed', type: 'string'}
+                ]
+              },
+              examples: [
+                {
+                  payload: {
+                    direction: 'South-West',
+                    speed: '18'
+                  }
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  }
 ]);


### PR DESCRIPTION
**Description**
Small change to skip the validation of message example objects when a `schemaFormat` is
set. This allows the parser to validate schemas with non default schemaFormats that are also
providing examples.

This does mean if anyone manually sets `schemaFormat` to the default the examples will not
be checked. Also it does not validate the examples against the schema for non default formats
so they may be incompatible 

**Related issue(s)**
Fixes #772