### PR TITLE
feat: validate message object examples with spectral schemas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "webapi-parser": "^0.5.0"
       },
       "devDependencies": {
+        "@asyncapi/avro-schema-parser": "^3.0.1",
         "@jest/types": "^29.0.2",
         "@swc/core": "^1.2.248",
         "@swc/jest": "^0.2.22",
@@ -67,6 +68,42 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@asyncapi/avro-schema-parser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/avro-schema-parser/-/avro-schema-parser-3.0.1.tgz",
+      "integrity": "sha512-jXovhjvkFQvcv9PfTldS7jRAWuExLkeQKn/2HQf8vAR9azCVw63GfqJQ3HBPlouWt0CoS2VtGu/SpN2MS8Li8Q==",
+      "dev": true,
+      "dependencies": {
+        "@asyncapi/parser": "^2.0.1",
+        "@types/json-schema": "^7.0.11",
+        "avsc": "^5.7.6"
+      }
+    },
+    "node_modules/@asyncapi/parser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.0.1.tgz",
+      "integrity": "sha512-T6Z8PPD+U3XPL05sjT0yLHtDyoqA16pj1j7xNbvpt8SCFzdzw4QMsbvJFAKaXk1/bztzlMq+oWVmeiGazt5WGA==",
+      "dev": true,
+      "dependencies": {
+        "@asyncapi/specs": "^5.0.1",
+        "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
+        "@stoplight/json-ref-resolver": "^3.1.5",
+        "@stoplight/spectral-core": "^1.16.1",
+        "@stoplight/spectral-functions": "^1.7.2",
+        "@stoplight/spectral-parsers": "^1.0.2",
+        "@types/json-schema": "^7.0.11",
+        "@types/urijs": "^1.19.19",
+        "ajv": "^8.11.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-formats": "^2.1.1",
+        "avsc": "^5.7.5",
+        "js-yaml": "^4.1.0",
+        "jsonpath-plus": "^7.2.0",
+        "node-fetch": "2.6.7",
+        "ramldt2jsonschema": "^1.2.3",
+        "webapi-parser": "^0.5.0"
       }
     },
     "node_modules/@asyncapi/specs": {
@@ -11277,6 +11314,42 @@
       "requires": {
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@asyncapi/avro-schema-parser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/avro-schema-parser/-/avro-schema-parser-3.0.1.tgz",
+      "integrity": "sha512-jXovhjvkFQvcv9PfTldS7jRAWuExLkeQKn/2HQf8vAR9azCVw63GfqJQ3HBPlouWt0CoS2VtGu/SpN2MS8Li8Q==",
+      "dev": true,
+      "requires": {
+        "@asyncapi/parser": "^2.0.1",
+        "@types/json-schema": "^7.0.11",
+        "avsc": "^5.7.6"
+      }
+    },
+    "@asyncapi/parser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.0.1.tgz",
+      "integrity": "sha512-T6Z8PPD+U3XPL05sjT0yLHtDyoqA16pj1j7xNbvpt8SCFzdzw4QMsbvJFAKaXk1/bztzlMq+oWVmeiGazt5WGA==",
+      "dev": true,
+      "requires": {
+        "@asyncapi/specs": "^5.0.1",
+        "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
+        "@stoplight/json-ref-resolver": "^3.1.5",
+        "@stoplight/spectral-core": "^1.16.1",
+        "@stoplight/spectral-functions": "^1.7.2",
+        "@stoplight/spectral-parsers": "^1.0.2",
+        "@types/json-schema": "^7.0.11",
+        "@types/urijs": "^1.19.19",
+        "ajv": "^8.11.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-formats": "^2.1.1",
+        "avsc": "^5.7.5",
+        "js-yaml": "^4.1.0",
+        "jsonpath-plus": "^7.2.0",
+        "node-fetch": "2.6.7",
+        "ramldt2jsonschema": "^1.2.3",
+        "webapi-parser": "^0.5.0"
       }
     },
     "@asyncapi/specs": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "webapi-parser": "^0.5.0"
   },
   "devDependencies": {
+    "@asyncapi/avro-schema-parser": "^3.0.1",
     "@jest/types": "^29.0.2",
     "@swc/core": "^1.2.248",
     "@swc/jest": "^0.2.22",

--- a/src/ruleset/v2/functions/messageExamples-spectral-rule-v2.ts
+++ b/src/ruleset/v2/functions/messageExamples-spectral-rule-v2.ts
@@ -1,14 +1,13 @@
 import { RuleDefinition, createRulesetFunction } from '@stoplight/spectral-core';
-import { schema as schemaFn } from '@stoplight/spectral-functions';
 
 import type { JsonPath } from '@stoplight/types';
-import type { IFunctionResult, RulesetFunctionContext } from '@stoplight/spectral-core';
-import type { JSONSchema7 } from 'json-schema';
+import type { IFunctionResult } from '@stoplight/spectral-core';
 import type { v2 } from 'spec-types';
 import type { Parser } from 'parser';
 import type { DetailedAsyncAPI } from 'types';
 import { ParseSchemaInput, getDefaultSchemaFormat, getSchemaFormat, parseSchema } from '../../../schema-parser';
 import { createDetailedAsyncAPI } from '../../../utils';
+import { getMessageExamples, validate } from './messageExamples';
 
 export function asyncApi2MessageExamplesParserRule(parser: Parser): RuleDefinition {
   return {
@@ -136,38 +135,4 @@ async function parseExampleSchema(parser: Parser, schema: unknown, type: 'payloa
     };
     return {path, schema: undefined, errors: [error]};
   }
-}
-
-function getMessageExamples(message: v2.MessageObject): Array<{ path: JsonPath; value: v2.MessageExampleObject }> {
-  if (!Array.isArray(message.examples)) {
-    return [];
-  }
-  return (
-    message.examples.map((example, index) => {
-      return {
-        path: ['examples', index],
-        value: example,
-      };
-    }) ?? []
-  );
-}
-
-function validate(
-  value: unknown,
-  path: JsonPath,
-  type: 'payload' | 'headers',
-  schema: unknown,
-  ctx: RulesetFunctionContext,
-): ReturnType<typeof schemaFn> {
-  return schemaFn(
-    value,
-    {
-      allErrors: true,
-      schema: schema as JSONSchema7,
-    },
-    {
-      ...ctx,
-      path: [...ctx.path, ...path, type],
-    },
-  );
 }

--- a/src/ruleset/v2/functions/messageExamples-spectral-rule-v2.ts
+++ b/src/ruleset/v2/functions/messageExamples-spectral-rule-v2.ts
@@ -1,0 +1,190 @@
+import { RuleDefinition, createRulesetFunction } from '@stoplight/spectral-core';
+import { schema as schemaFn } from '@stoplight/spectral-functions';
+
+import type { JsonPath } from '@stoplight/types';
+import type { IFunctionResult, RulesetFunctionContext } from '@stoplight/spectral-core';
+import type { JSONSchema7 } from 'json-schema';
+import type { v2 } from 'spec-types';
+import type { Parser } from 'parser';
+import type { DetailedAsyncAPI } from 'types';
+import { ParseSchemaInput, getDefaultSchemaFormat, getSchemaFormat, parseSchema } from '../../../schema-parser';
+import { createDetailedAsyncAPI } from '../../../utils';
+
+export function asyncApi2MessageExamplesParserRule(parser: Parser): RuleDefinition {
+  return {
+    description: 'Examples of message object should validate againt the "payload" and "headers" schemas.',
+    message: '{{error}}',
+    severity: 'error',
+    recommended: true,
+    given: [
+      // messages
+      '$.channels.*.[publish,subscribe].message',
+      '$.channels.*.[publish,subscribe].message.oneOf.*',
+      '$.components.channels.*.[publish,subscribe].message',
+      '$.components.channels.*.[publish,subscribe].message.oneOf.*',
+      '$.components.messages.*',
+      // message traits
+      '$.channels.*.[publish,subscribe].message.traits.*',
+      '$.channels.*.[publish,subscribe].message.oneOf.*.traits.*',
+      '$.components.channels.*.[publish,subscribe].message.traits.*',
+      '$.components.channels.*.[publish,subscribe].message.oneOf.*.traits.*',
+      '$.components.messages.*.traits.*',
+      '$.components.messageTraits.*',
+    ],
+    then: {
+      function: rulesetFunction(parser),
+    },
+  };
+}
+
+function rulesetFunction(parser: Parser) {
+  return createRulesetFunction<v2.MessageObject, null>(
+    {
+      input: {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+          },
+          summary: {
+            type: 'string',
+          },
+        },
+      },
+      options: null,
+    },
+    async (targetVal, _, ctx) => {
+      if (!targetVal.examples) return;
+
+      const document = ctx.document;
+      const parsedSpec = document.data as v2.AsyncAPIObject;
+      const schemaFormat = getSchemaFormat(targetVal.schemaFormat, parsedSpec.asyncapi);
+      const defaultSchemaFormat = getDefaultSchemaFormat(parsedSpec.asyncapi);
+      const asyncapi = createDetailedAsyncAPI(parsedSpec, (document as any).__parserInput, document.source || undefined);
+      const input: ParseExampleSchemaInput = {
+        asyncapi,
+        rootPath: ctx.path,
+        schemaFormat,
+        defaultSchemaFormat
+      };
+
+      const results: IFunctionResult[] = [];
+      const payloadSchemaResults = await parseExampleSchema(parser, targetVal.payload, 'payload', input);
+      const payloadSchema = payloadSchemaResults.schema;
+      results.push(...payloadSchemaResults.errors);
+
+      const headersSchemaResults = await parseExampleSchema(parser, targetVal.headers, 'headers', input);
+      const headersSchema = headersSchemaResults.schema;
+      results.push(...headersSchemaResults.errors);
+
+      for (const example of getMessageExamples(targetVal)) {
+        const { path, value } = example;
+        // validate payload
+        if (value.payload !== undefined && payloadSchema !== undefined) {
+          const errors = validate(value.payload, path, 'payload', payloadSchema, ctx);
+          if (Array.isArray(errors)) {
+            results.push(...errors);
+          }
+        }
+  
+        // validate headers
+        if (value.headers !== undefined && headersSchema !== undefined) {
+          const errors = validate(value.headers, path, 'headers', headersSchema, ctx);
+          if (Array.isArray(errors)) {
+            results.push(...errors);
+          }
+        }
+      }
+      return results;
+    }
+  );
+}
+
+interface ParseExampleSchemaInput {
+  asyncapi: DetailedAsyncAPI;
+  rootPath: JsonPath;
+  schemaFormat: string;
+  defaultSchemaFormat: string;
+}
+
+interface ParseExampleSchemaResult {
+  path: Array<string | number>;
+  schema: v2.AsyncAPISchemaObject | undefined;
+  errors: IFunctionResult[]
+}
+
+async function parseExampleSchema(parser: Parser, schema: unknown, type: 'payload' | 'headers', input: ParseExampleSchemaInput): Promise<ParseExampleSchemaResult> {
+  const path = [...input.rootPath, type];
+  if (schema === undefined) {
+    return {path, schema: undefined, errors: []};
+  }
+  try {
+    const parseSchemaInput: ParseSchemaInput = {
+      asyncapi: input.asyncapi,
+      data: serializeSchema(schema, type),
+      meta: {},
+      path,
+      schemaFormat: input.schemaFormat,
+      defaultSchemaFormat: input.defaultSchemaFormat,
+    }; 
+    const parsedSchema = await parseSchema(parser, parseSchemaInput);
+    return {path, schema: parsedSchema, errors: []};
+  } catch (err: any) {
+    const error: IFunctionResult = {
+      message: `Error thrown during schema validation. Name: ${err.name}, message: ${err.message}, stack: ${err.stack}`,
+      path
+    };
+    return {path, schema: undefined, errors: [error]};
+  }
+}
+
+function serializeSchema(schema: unknown, type: 'payload' | 'headers'): any {
+  if (!schema && typeof schema !== 'boolean') { // if schema is falsy then
+    if (type === 'headers') { // object for headers
+      schema = { type: 'object' };
+    } else { // anything for payload
+      schema = {};
+    }
+  } else if (typeof schema === 'boolean') { // spectral cannot handle boolean schemas
+    if (schema === true) {
+      schema = {}; // everything
+    } else {
+      schema = { not: {} }; // nothing
+    }
+  }
+  return schema;
+}
+
+function getMessageExamples(message: v2.MessageObject): Array<{ path: JsonPath; value: v2.MessageExampleObject }> {
+  if (!Array.isArray(message.examples)) {
+    return [];
+  }
+  return (
+    message.examples.map((example, index) => {
+      return {
+        path: ['examples', index],
+        value: example,
+      };
+    }) ?? []
+  );
+}
+
+function validate(
+  value: unknown,
+  path: JsonPath,
+  type: 'payload' | 'headers',
+  schema: unknown,
+  ctx: RulesetFunctionContext,
+): ReturnType<typeof schemaFn> {
+  return schemaFn(
+    value,
+    {
+      allErrors: true,
+      schema: schema as JSONSchema7,
+    },
+    {
+      ...ctx,
+      path: [...ctx.path, ...path, type],
+    },
+  );
+}

--- a/src/ruleset/v2/functions/messageExamples-spectral-rule-v2.ts
+++ b/src/ruleset/v2/functions/messageExamples-spectral-rule-v2.ts
@@ -12,24 +12,24 @@ import { createDetailedAsyncAPI } from '../../../utils';
 
 export function asyncApi2MessageExamplesParserRule(parser: Parser): RuleDefinition {
   return {
-    description: 'Examples of message object should validate againt the "payload" and "headers" schemas.',
+    description: 'Examples of message object should validate against the "payload" and "headers" schemas.',
     message: '{{error}}',
     severity: 'error',
     recommended: true,
     given: [
       // messages
-      '$.channels.*.[publish,subscribe].message',
-      '$.channels.*.[publish,subscribe].message.oneOf.*',
-      '$.components.channels.*.[publish,subscribe].message',
-      '$.components.channels.*.[publish,subscribe].message.oneOf.*',
-      '$.components.messages.*',
+      '$.channels.*.[publish,subscribe][?(@property === \'message\' && @.schemaFormat !== void 0)]',
+      '$.channels.*.[publish,subscribe].message.oneOf[?(!@null && @.schemaFormat !== void 0)]',
+      '$.components.channels.*.[publish,subscribe].message[?(@property === \'message\' && @.schemaFormat !== void 0)]',
+      '$.components.channels.*.[publish,subscribe].message.oneOf[?(!@null && @.schemaFormat !== void 0)]',
+      '$.components.messages[?(!@null && @.schemaFormat !== void 0)]',
       // message traits
-      '$.channels.*.[publish,subscribe].message.traits.*',
-      '$.channels.*.[publish,subscribe].message.oneOf.*.traits.*',
-      '$.components.channels.*.[publish,subscribe].message.traits.*',
-      '$.components.channels.*.[publish,subscribe].message.oneOf.*.traits.*',
-      '$.components.messages.*.traits.*',
-      '$.components.messageTraits.*',
+      '$.channels.*.[publish,subscribe].message.traits[?(!@null && @.schemaFormat !== void 0)]',
+      '$.channels.*.[publish,subscribe].message.oneOf.*.traits[?(!@null && @.schemaFormat !== void 0)]',
+      '$.components.channels.*.[publish,subscribe].message.traits[?(!@null && @.schemaFormat !== void 0)]',
+      '$.components.channels.*.[publish,subscribe].message.oneOf.*.traits[?(!@null && @.schemaFormat !== void 0)]',
+      '$.components.messages.*.traits[?(!@null && @.schemaFormat !== void 0)]',
+      '$.components.messageTraits[?(!@null && @.schemaFormat !== void 0)]',
     ],
     then: {
       function: rulesetFunction(parser),
@@ -121,7 +121,7 @@ async function parseExampleSchema(parser: Parser, schema: unknown, type: 'payloa
   try {
     const parseSchemaInput: ParseSchemaInput = {
       asyncapi: input.asyncapi,
-      data: serializeSchema(schema, type),
+      data: schema,
       meta: {},
       path,
       schemaFormat: input.schemaFormat,
@@ -136,23 +136,6 @@ async function parseExampleSchema(parser: Parser, schema: unknown, type: 'payloa
     };
     return {path, schema: undefined, errors: [error]};
   }
-}
-
-function serializeSchema(schema: unknown, type: 'payload' | 'headers'): any {
-  if (!schema && typeof schema !== 'boolean') { // if schema is falsy then
-    if (type === 'headers') { // object for headers
-      schema = { type: 'object' };
-    } else { // anything for payload
-      schema = {};
-    }
-  } else if (typeof schema === 'boolean') { // spectral cannot handle boolean schemas
-    if (schema === true) {
-      schema = {}; // everything
-    } else {
-      schema = { not: {} }; // nothing
-    }
-  }
-  return schema;
 }
 
 function getMessageExamples(message: v2.MessageObject): Array<{ path: JsonPath; value: v2.MessageExampleObject }> {

--- a/src/ruleset/v2/functions/messageExamples.ts
+++ b/src/ruleset/v2/functions/messageExamples.ts
@@ -23,7 +23,7 @@ function serializeSchema(schema: unknown, type: 'payload' | 'headers'): any {
   return schema;
 }
 
-function getMessageExamples(message: v2.MessageObject): Array<{ path: JsonPath; value: v2.MessageExampleObject }> {
+export function getMessageExamples(message: v2.MessageObject): Array<{ path: JsonPath; value: v2.MessageExampleObject }> {
   if (!Array.isArray(message.examples)) {
     return [];
   }
@@ -37,7 +37,7 @@ function getMessageExamples(message: v2.MessageObject): Array<{ path: JsonPath; 
   );
 }
 
-function validate(
+export function validate(
   value: unknown,
   path: JsonPath,
   type: 'payload' | 'headers',

--- a/src/ruleset/v2/ruleset.ts
+++ b/src/ruleset/v2/ruleset.ts
@@ -116,7 +116,7 @@ export const v2CoreRuleset = {
     /**
      * Message Object rules
      */
-    'asyncapi2-message-examples-default': {
+    'asyncapi2-message-examples': {
       description: 'Examples of message object should validate againt the "payload" and "headers" schemas.',
       message: '{{error}}',
       severity: 'error',
@@ -239,7 +239,7 @@ export const v2SchemasRuleset = (parser: Parser) => {
           },
         },
       },
-      'asyncapi2-message-examples': asyncApi2MessageExamplesParserRule(parser),
+      'asyncapi2-message-examples-custom-format': asyncApi2MessageExamplesParserRule(parser),
     }
   };
 };

--- a/src/ruleset/v2/ruleset.ts
+++ b/src/ruleset/v2/ruleset.ts
@@ -123,9 +123,9 @@ export const v2CoreRuleset = {
       recommended: true,
       given: [
         // messages
-        '$.channels.*.[publish,subscribe].[?(@property === \'message\' && @.schemaFormat === void 0)]',
+        '$.channels.*.[publish,subscribe][?(@property === \'message\' && @.schemaFormat === void 0)]',
         '$.channels.*.[publish,subscribe].message.oneOf[?(!@null && @.schemaFormat === void 0)]',
-        '$.components.channels.*.[publish,subscribe].[?(@property === \'message\' && @.schemaFormat === void 0)]',
+        '$.components.channels.*.[publish,subscribe][?(@property === \'message\' && @.schemaFormat === void 0)]',
         '$.components.channels.*.[publish,subscribe].message.oneOf[?(!@null && @.schemaFormat === void 0)]',
         '$.components.messages[?(!@null && @.schemaFormat === void 0)]',
         // message traits

--- a/src/ruleset/v2/ruleset.ts
+++ b/src/ruleset/v2/ruleset.ts
@@ -7,6 +7,7 @@ import { channelParameters } from './functions/channelParameters';
 import { channelServers } from './functions/channelServers';
 import { checkId } from './functions/checkId';
 import { messageExamples } from './functions/messageExamples';
+import { asyncApi2MessageExamplesParserRule } from './functions/messageExamples-spectral-rule-v2';
 import { messageIdUniqueness } from './functions/messageIdUniqueness';
 import { operationIdUniqueness } from './functions/operationIdUniqueness';
 import { schemaValidation } from './functions/schemaValidation';
@@ -115,7 +116,7 @@ export const v2CoreRuleset = {
     /**
      * Message Object rules
      */
-    'asyncapi2-message-examples': {
+    'asyncapi2-message-examples-default': {
       description: 'Examples of message object should validate againt the "payload" and "headers" schemas.',
       message: '{{error}}',
       severity: 'error',
@@ -238,6 +239,7 @@ export const v2SchemasRuleset = (parser: Parser) => {
           },
         },
       },
+      'asyncapi2-message-examples': asyncApi2MessageExamplesParserRule(parser),
     }
   };
 };

--- a/test/ruleset/rules/v2/asyncapi2-message-examples-spectral-v2.spec.ts
+++ b/test/ruleset/rules/v2/asyncapi2-message-examples-spectral-v2.spec.ts
@@ -1,6 +1,6 @@
 import { testRule, DiagnosticSeverity } from '../../tester';
 
-testRule('asyncapi2-message-examples-default', [
+testRule('asyncapi2-message-examples', [
   {
     name: 'valid case',
     document: {
@@ -372,7 +372,7 @@ testRule('asyncapi2-message-examples-default', [
     },
     errors: [],
   },
-
+  
   {
     name: 'invalid example from avro spec case',
     document: {
@@ -415,86 +415,15 @@ testRule('asyncapi2-message-examples-default', [
         },
       },
     },
-    errors: [],
-  },
-
-  {
-    name: 'avro can contain null values',
-    document: {
-      asyncapi: '2.6.0',
-      channels: {
-        someChannel: {
-          publish: {
-            message: {
-              schemaFormat: 'application/vnd.apache.avro;version=1.9.0',
-              payload: {
-                type: 'record',
-                name: 'Command',
-                fields: [{
-                  name: 'foo',
-                  default: null,
-                  type: ['null', 'string'],
-                }],
-              },
-              examples: [
-                {
-                  payload: {}
-                },
-              ],
-            },
-          },
-        },
-      },
-    },
-    errors: [],
-  },
-
-  {
-    name: 'handles oneOf processing',
-    document: {
-      asyncapi: '2.6.0',
-      channels: {
-        someChannel: {
-          publish: {
-            message: {
-              oneOf: [
-                {
-                  schemaFormat: 'application/vnd.apache.avro;version=1.9.0',
-                  payload: {
-                    type: 'record',
-                    name: 'Command',
-                    fields: [{
-                      name: 'foo',
-                      default: null,
-                      type: ['null', 'string'],
-                    }],
-                  },
-                  examples: [
-                    {
-                      payload: {}
-                    },
-                  ],
-                },
-                {
-                  payload: {
-                    type: 'string'
-                  },
-                  examples: [
-                    {
-                      payload: 1
-                    },
-                  ],
-                },
-              ],
-            },
-          },
-        },
-      },
-    },
     errors: [
       {
-        message: '"payload" property type must be string',
-        path: ['channels', 'someChannel', 'publish', 'message', 'oneOf', '1', 'examples', '0', 'payload'],
+        message: '"direction" property must be equal to one of the allowed values: "North", "East", "South", "West"',
+        path: ['channels', 'someChannel', 'publish', 'message', 'examples', '0', 'payload', 'direction'],
+        severity: DiagnosticSeverity.Error,
+      },
+      {
+        message: '"someOtherKey" property type must be string',
+        path: ['channels', 'someChannel', 'publish', 'message', 'examples', '0', 'headers', 'someOtherKey'],
         severity: DiagnosticSeverity.Error,
       },
     ],

--- a/test/ruleset/rules/v2/asyncapi2-message-examples-spectral-v2.spec.ts
+++ b/test/ruleset/rules/v2/asyncapi2-message-examples-spectral-v2.spec.ts
@@ -1,6 +1,6 @@
 import { testRule, DiagnosticSeverity } from '../../tester';
 
-testRule('asyncapi2-message-examples', [
+testRule('asyncapi2-message-examples-custom-format', [
   {
     name: 'valid case',
     document: {

--- a/test/ruleset/rules/v2/asyncapi2-message-examples-spectral-v2.spec.ts
+++ b/test/ruleset/rules/v2/asyncapi2-message-examples-spectral-v2.spec.ts
@@ -57,23 +57,11 @@ testRule('asyncapi2-message-examples-custom-format', [
                   {name: 'speed', type: 'string'}
                 ]
               },
-              headers: {
-                type: 'record',
-                name: 'TestHeader',
-                fields: [
-                  {name: 'someKey', type: 'string'},
-                  {name: 'someOtherKey', type: 'string'}
-                ]
-              },
               examples: [
                 {
                   payload: {
                     direction: 'North',
                     speed: '18'
-                  },
-                  headers: {
-                    someKey: 'someValue',
-                    someOtherKey: 'someValue',
                   },
                 },
               ],
@@ -102,23 +90,11 @@ testRule('asyncapi2-message-examples-custom-format', [
                   {name: 'speed', type: 'string'}
                 ]
               },
-              headers: {
-                type: 'record',
-                name: 'TestHeader',
-                fields: [
-                  {name: 'someKey', type: 'string'},
-                  {name: 'someOtherKey', type: 'string'}
-                ]
-              },
               examples: [
                 {
                   payload: {
                     direction: 'South-West',
                     speed: '18'
-                  },
-                  headers: {
-                    someKey: 'someValue',
-                    someOtherKey: 123,
                   },
                 },
               ],
@@ -131,11 +107,6 @@ testRule('asyncapi2-message-examples-custom-format', [
       {
         message: '"direction" property must be equal to one of the allowed values: "North", "East", "South", "West"',
         path: ['channels', 'someChannel', 'publish', 'message', 'examples', '0', 'payload', 'direction'],
-        severity: DiagnosticSeverity.Error,
-      },
-      {
-        message: '"someOtherKey" property type must be string',
-        path: ['channels', 'someChannel', 'publish', 'message', 'examples', '0', 'headers', 'someOtherKey'],
         severity: DiagnosticSeverity.Error,
       },
     ],

--- a/test/ruleset/rules/v2/asyncapi2-message-examples-spectral-v2.spec.ts
+++ b/test/ruleset/rules/v2/asyncapi2-message-examples-spectral-v2.spec.ts
@@ -1,146 +1,7 @@
 import { testRule, DiagnosticSeverity } from '../../tester';
 
 testRule('asyncapi2-message-examples-custom-format', [
-  {
-    name: 'valid case',
-    document: {
-      asyncapi: '2.0.0',
-      channels: {
-        someChannel: {
-          publish: {
-            message: {
-              payload: {
-                type: 'string',
-              },
-              headers: {
-                type: 'object',
-              },
-              examples: [
-                {
-                  payload: 'foobar',
-                  headers: {
-                    someKey: 'someValue',
-                  },
-                },
-              ],
-            },
-          },
-        },
-      },
-    },
-    errors: [],
-  },
-
-  {
-    name: 'invalid case',
-    document: {
-      asyncapi: '2.0.0',
-      channels: {
-        someChannel: {
-          publish: {
-            message: {
-              payload: {
-                type: 'string',
-              },
-              headers: {
-                type: 'object',
-              },
-              examples: [
-                {
-                  payload: 2137,
-                  headers: {
-                    someKey: 'someValue',
-                  },
-                },
-              ],
-            },
-          },
-        },
-      },
-    },
-    errors: [
-      {
-        message: '"payload" property type must be string',
-        path: ['channels', 'someChannel', 'publish', 'message', 'examples', '0', 'payload'],
-        severity: DiagnosticSeverity.Error,
-      },
-    ],
-  },
-
-  {
-    name: 'invalid case (oneOf case)',
-    document: {
-      asyncapi: '2.0.0',
-      channels: {
-        someChannel: {
-          publish: {
-            message: {
-              oneOf: [
-                {
-                  payload: {
-                    type: 'string',
-                  },
-                  headers: {
-                    type: 'object',
-                  },
-                  examples: [
-                    {
-                      payload: 2137,
-                      headers: {
-                        someKey: 'someValue',
-                      },
-                    },
-                  ],
-                },
-              ],
-            },
-          },
-        },
-      },
-    },
-    errors: [
-      {
-        message: '"payload" property type must be string',
-        path: ['channels', 'someChannel', 'publish', 'message', 'oneOf', '0', 'examples', '0', 'payload'],
-        severity: DiagnosticSeverity.Error,
-      },
-    ],
-  },
-
-  {
-    name: 'invalid case (inside components.messages)',
-    document: {
-      asyncapi: '2.0.0',
-      components: {
-        messages: {
-          someMessage: {
-            payload: {
-              type: 'string',
-            },
-            headers: {
-              type: 'object',
-            },
-            examples: [
-              {
-                payload: 2137,
-                headers: {
-                  someKey: 'someValue',
-                },
-              },
-            ],
-          },
-        },
-      },
-    },
-    errors: [
-      {
-        message: '"payload" property type must be string',
-        path: ['components', 'messages', 'someMessage', 'examples', '0', 'payload'],
-        severity: DiagnosticSeverity.Error,
-      },
-    ],
-  },
-
+  
   {
     name: 'invalid case (with multiple errors)',
     document: {
@@ -175,157 +36,8 @@ testRule('asyncapi2-message-examples-custom-format', [
         },
       },
     },
-    errors: [
-      {
-        message: '"payload" property must have required property "key2"',
-        path: ['components', 'messages', 'someMessage', 'examples', '0', 'payload'],
-        severity: DiagnosticSeverity.Error,
-      },
-      {
-        message: '"key1" property type must be string',
-        path: ['components', 'messages', 'someMessage', 'examples', '0', 'payload', 'key1'],
-        severity: DiagnosticSeverity.Error,
-      },
-      {
-        message: '"headers" property type must be object',
-        path: ['components', 'messages', 'someMessage', 'examples', '0', 'headers'],
-        severity: DiagnosticSeverity.Error,
-      },
-    ],
-  },
-
-  {
-    name: 'case with omitted payload',
-    document: {
-      asyncapi: '2.0.0',
-      components: {
-        messages: {
-          someMessage: {
-            examples: [
-              {
-                payload: {
-                  key1: 2137,
-                },
-              },
-            ],
-          },
-        },
-      },
-    },
+    // no errors as this rule is just checking examples where schemaFormat is set
     errors: [],
-  },
-
-  {
-    name: 'case with falsy payload (valid case)',
-    document: {
-      asyncapi: '2.0.0',
-      components: {
-        messages: {
-          someMessage: {
-            payload: false,
-            examples: [
-              {},
-            ],
-          },
-        },
-      },
-    },
-    errors: [],
-  },
-
-  {
-    name: 'case with falsy payload (invalid case)',
-    document: {
-      asyncapi: '2.0.0',
-      components: {
-        messages: {
-          someMessage: {
-            payload: false,
-            examples: [
-              {
-                payload: {
-                  key: '2137'
-                }
-              },
-            ],
-          },
-        },
-      },
-    },
-    errors: [
-      {
-        message: '"payload" property must not be valid',
-        path: ['components', 'messages', 'someMessage', 'examples', '0', 'payload'],
-        severity: DiagnosticSeverity.Error,
-      },
-    ],
-  },
-
-  {
-    name: 'case with omitted headers',
-    document: {
-      asyncapi: '2.0.0',
-      components: {
-        messages: {
-          someMessage: {
-            examples: [
-              {
-                headers: {
-                  key1: 2137,
-                },
-              },
-            ],
-          },
-        },
-      },
-    },
-    errors: [],
-  },
-
-  {
-    name: 'case with falsy headers (valid case)',
-    document: {
-      asyncapi: '2.0.0',
-      components: {
-        messages: {
-          someMessage: {
-            headers: false,
-            examples: [
-              {},
-            ],
-          },
-        },
-      },
-    },
-    errors: [],
-  },
-
-  {
-    name: 'case with falsy headers (invalid case)',
-    document: {
-      asyncapi: '2.0.0',
-      components: {
-        messages: {
-          someMessage: {
-            headers: false,
-            examples: [
-              {
-                headers: {
-                  key: '2137'
-                }
-              },
-            ],
-          },
-        },
-      },
-    },
-    errors: [
-      {
-        message: '"headers" property must not be valid',
-        path: ['components', 'messages', 'someMessage', 'examples', '0', 'headers'],
-        severity: DiagnosticSeverity.Error,
-      },
-    ],
   },
 
   {
@@ -426,6 +138,99 @@ testRule('asyncapi2-message-examples-custom-format', [
         path: ['channels', 'someChannel', 'publish', 'message', 'examples', '0', 'headers', 'someOtherKey'],
         severity: DiagnosticSeverity.Error,
       },
+    ],
+  },
+
+  {
+    name: 'avro can contain null values',
+    document: {
+      asyncapi: '2.6.0',
+      channels: {
+        someChannel: {
+          publish: {
+            message: {
+              schemaFormat: 'application/vnd.apache.avro;version=1.9.0',
+              payload: {
+                type: 'record',
+                name: 'Command',
+                fields: [{
+                  name: 'foo',
+                  default: null,
+                  type: ['null', 'string'],
+                }],
+              },
+              examples: [
+                {
+                  payload: {}
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+
+  {
+    name: 'handles oneOf processing',
+    document: {
+      asyncapi: '2.6.0',
+      channels: {
+        someChannel: {
+          publish: {
+            message: {
+              oneOf: [
+                {
+                  schemaFormat: 'application/vnd.apache.avro;version=1.9.0',
+                  payload: {
+                    type: 'record',
+                    name: 'Command',
+                    fields: [{
+                      name: 'foo',
+                      default: null,
+                      type: ['null', 'string'],
+                    }],
+                  },
+                  examples: [
+                    {
+                      payload: {foo: 1}
+                    },
+                  ],
+                },
+                {
+                  payload: {
+                    type: 'string'
+                  },
+                  examples: [
+                    {
+                      // no error for this as this rule is just checking examples where schemaFormat is set
+                      payload: 1 
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        message: '"foo" property type must be string',
+        path: ['channels', 'someChannel', 'publish', 'message', 'oneOf', '0', 'examples', '0', 'payload', 'foo'],
+        severity: DiagnosticSeverity.Error,
+      },
+      {
+        message: '"foo" property type must be null',
+        path: ['channels', 'someChannel', 'publish', 'message', 'oneOf', '0', 'examples', '0', 'payload', 'foo'],
+        severity: DiagnosticSeverity.Error,
+      },
+      {
+        message: '"foo" property must match exactly one schema in oneOf',
+        path: ['channels', 'someChannel', 'publish', 'message', 'oneOf', '0', 'examples', '0', 'payload', 'foo'],
+        severity: DiagnosticSeverity.Error,
+      }
     ],
   },
 ]);

--- a/test/ruleset/rules/v2/asyncapi2-message-examples.spec.ts
+++ b/test/ruleset/rules/v2/asyncapi2-message-examples.spec.ts
@@ -345,23 +345,11 @@ testRule('asyncapi2-message-examples', [
                   {name: 'speed', type: 'string'}
                 ]
               },
-              headers: {
-                type: 'record',
-                name: 'TestHeader',
-                fields: [
-                  {name: 'someKey', type: 'string'},
-                  {name: 'someOtherKey', type: 'string'}
-                ]
-              },
               examples: [
                 {
                   payload: {
                     direction: 'North',
                     speed: '18'
-                  },
-                  headers: {
-                    someKey: 'someValue',
-                    someOtherKey: 'someValue',
                   },
                 },
               ],
@@ -390,23 +378,11 @@ testRule('asyncapi2-message-examples', [
                   {name: 'speed', type: 'string'}
                 ]
               },
-              headers: {
-                type: 'record',
-                name: 'TestHeader',
-                fields: [
-                  {name: 'someKey', type: 'string'},
-                  {name: 'someOtherKey', type: 'string'}
-                ]
-              },
               examples: [
                 {
                   payload: {
                     direction: 'South-West',
                     speed: '18'
-                  },
-                  headers: {
-                    someKey: 'someValue',
-                    someOtherKey: 123,
                   },
                 },
               ],

--- a/test/ruleset/rules/v2/asyncapi2-message-examples.spec.ts
+++ b/test/ruleset/rules/v2/asyncapi2-message-examples.spec.ts
@@ -1,6 +1,6 @@
 import { testRule, DiagnosticSeverity } from '../../tester';
 
-testRule('asyncapi2-message-examples-default', [
+testRule('asyncapi2-message-examples', [
   {
     name: 'valid case',
     document: {

--- a/test/ruleset/rules/v2/asyncapi2-message-examples.spec.ts
+++ b/test/ruleset/rules/v2/asyncapi2-message-examples.spec.ts
@@ -415,6 +415,7 @@ testRule('asyncapi2-message-examples', [
         },
       },
     },
+    // no errors as this rule is just checking examples where schemaFormat is set
     errors: [],
   },
 
@@ -471,7 +472,8 @@ testRule('asyncapi2-message-examples', [
                   },
                   examples: [
                     {
-                      payload: {}
+                      // no error for this as this rule is just checking examples where schemaFormat is not set
+                      payload: {foo: 1}
                     },
                   ],
                 },

--- a/test/ruleset/tester.ts
+++ b/test/ruleset/tester.ts
@@ -1,4 +1,5 @@
 import { Parser } from '../../src/parser';
+import { AvroSchemaParser } from '@asyncapi/avro-schema-parser'; // allows testing non default schema parsers
 
 // rulesets
 import { coreRuleset, recommendedRuleset } from '../../src/ruleset/ruleset';
@@ -28,6 +29,7 @@ export function testRule(ruleName: RuleNames, tests: Scenario,): void {
     for (const testCase of tests) {
       it(testCase.name, async () => {
         const parser = createParser([ruleName]);
+        parser.registerSchemaParser(AvroSchemaParser());
         const doc = JSON.stringify(testCase.document);
 
         const errors = await parser.validate(doc);


### PR DESCRIPTION
validate message object examples against the schemas in the
object by parsing the schemas using spectral before validating
this proves that the examples are valid.

**Related issue(s)**
Contributes to: #781

Signed-off-by: Chris Patmore <chrism.patmore@btinternet.com>