### PR TITLE
chore: remove @derberg from `CODEOWNERS`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
-* @fmvilas @magicmatatjahu @jonaslagoni @derberg @smoya @asyncapi-bot-eve
+* @fmvilas @magicmatatjahu @jonaslagoni @smoya @asyncapi-bot-eve


### PR DESCRIPTION
Let's be honest. Since v2 this is almost completely different projects. I did not follow development and have no clue what is happening with the code 😅 and TS definitely do not encourage me to look closely into it 🤣 

Enough great maintainers here. I also step down as owner of custom schema parsers
