### PR TITLE
fix: set proper parser-api version

### DIFF
--- a/src/models/asyncapi.ts
+++ b/src/models/asyncapi.ts
@@ -11,6 +11,9 @@ import type { ServersInterface } from './servers';
 
 import type { v2, v3 } from '../spec-types';
 
+// https://github.com/asyncapi/parser-api/releases/tag/v2.0.0
+export const ParserAPIVersion = '2.0.0';
+
 export interface AsyncAPIDocumentInterface extends BaseModel<v2.AsyncAPIObject | v3.AsyncAPIObject>, ExtensionsMixinInterface {
   version(): string;
   defaultContentType(): string | undefined;

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,4 +1,4 @@
-import { AsyncAPIDocumentInterface } from './models';
+import { AsyncAPIDocumentInterface, ParserAPIVersion } from './models';
 
 import { customOperations } from './custom-operations';
 import { validate } from './validate';
@@ -61,7 +61,7 @@ export async function parse(parser: Parser, spectral: Spectral, asyncapi: Input,
     const detailed = createDetailedAsyncAPI(validatedDoc, asyncapi as DetailedAsyncAPI['input'], options.source);
     const document = createAsyncAPIDocument(detailed);
     setExtension(xParserSpecParsed, true, document);
-    setExtension(xParserApiVersion, 1, document);
+    setExtension(xParserApiVersion, ParserAPIVersion, document);
     await customOperations(parser, document, detailed, inventory, options);
   
     return { 

--- a/test/parse.spec.ts
+++ b/test/parse.spec.ts
@@ -1,6 +1,6 @@
 import { Document } from '@stoplight/spectral-core';
 
-import { AsyncAPIDocumentV2, AsyncAPIDocumentV3 } from '../src/models';
+import { AsyncAPIDocumentV2, AsyncAPIDocumentV3, ParserAPIVersion } from '../src/models';
 import { Parser } from '../src/parser';
 import { xParserApiVersion } from '../src/constants';
 
@@ -92,7 +92,7 @@ describe('parse()', function() {
     const { document } = await parser.parse(documentRaw);
     
     expect(document).toBeInstanceOf(AsyncAPIDocumentV2);
-    expect(document?.extensions().get(xParserApiVersion)?.value()).toEqual(1);
+    expect(document?.extensions().get(xParserApiVersion)?.value()).toEqual(ParserAPIVersion);
   });
 
   it('should preserve references', async function() {


### PR DESCRIPTION
**Description**

This PR fixes the parser-api version in use from `1` to `2.0.0`. It moves the value to a constant set in the same file as `AsyncAPIDocumentInterface` is declared.