### PR TITLE
fix: isAsyncAPIDocument not recognizing correct documents

### DIFF
--- a/src/document.ts
+++ b/src/document.ts
@@ -43,7 +43,7 @@ export function isAsyncAPIDocument(maybeDoc: unknown): maybeDoc is AsyncAPIDocum
   }
   if (maybeDoc && typeof (maybeDoc as AsyncAPIDocumentInterface).json === 'function') {
     const versionOfParserAPI = (maybeDoc as AsyncAPIDocumentInterface).json()[xParserApiVersion];
-    return versionOfParserAPI === 1;
+    return versionOfParserAPI === 2;
   }
   return false;
 }

--- a/src/models/asyncapi.ts
+++ b/src/models/asyncapi.ts
@@ -12,7 +12,7 @@ import type { ServersInterface } from './servers';
 import type { v2, v3 } from '../spec-types';
 
 // https://github.com/asyncapi/parser-api/releases/tag/v2.0.0
-export const ParserAPIVersion = '2';
+export const ParserAPIVersion = 2;
 
 export interface AsyncAPIDocumentInterface extends BaseModel<v2.AsyncAPIObject | v3.AsyncAPIObject>, ExtensionsMixinInterface {
   version(): string;

--- a/src/models/asyncapi.ts
+++ b/src/models/asyncapi.ts
@@ -12,7 +12,7 @@ import type { ServersInterface } from './servers';
 import type { v2, v3 } from '../spec-types';
 
 // https://github.com/asyncapi/parser-api/releases/tag/v2.0.0
-export const ParserAPIVersion = '2.0.0';
+export const ParserAPIVersion = '2';
 
 export interface AsyncAPIDocumentInterface extends BaseModel<v2.AsyncAPIObject | v3.AsyncAPIObject>, ExtensionsMixinInterface {
   version(): string;

--- a/test/document.spec.ts
+++ b/test/document.spec.ts
@@ -114,8 +114,12 @@ describe('utils', function() {
       expect(isAsyncAPIDocument(createAsyncAPIDocument(detailed))).toEqual(true);
     });
 
-    it('document with the x-parser-api-version extension set to 1 should be AsyncAPI document', async function() {
-      expect(isAsyncAPIDocument({ json() { return { [xParserApiVersion]: 1 }; } })).toEqual(true);
+    it('document with the x-parser-api-version extension set to 2 should be AsyncAPI document', async function() {
+      expect(isAsyncAPIDocument({ json() { return { [xParserApiVersion]: 2 }; } })).toEqual(true);
+    });
+
+    it('document with the x-parser-api-version extension set to 1 should not be AsyncAPI document', async function() {
+      expect(isAsyncAPIDocument({ json() { return { [xParserApiVersion]: 1 }; } })).toEqual(false);
     });
 
     it('document with the x-parser-api-version extension set to 0 should not be AsyncAPI document', async function() {


### PR DESCRIPTION
**Description**
This PR fixes a problem where `isAsyncAPIDocument` cannot recognize parsed documents which means a lot of support functions are not working correctly. 