### PR TITLE
feat!: remove messageId()

### DIFF
--- a/src/models/message-trait.ts
+++ b/src/models/message-trait.ts
@@ -9,7 +9,6 @@ export interface MessageTraitInterface extends BaseModel, BindingsMixinInterface
   hasSchemaFormat(): boolean;
   schemaFormat(): string | undefined;
   hasMessageId(): boolean;
-  messageId(): string | undefined;
   hasCorrelationId(): boolean;
   correlationId(): CorrelationIdInterface | undefined;
   hasContentType(): boolean;

--- a/src/models/v2/message-trait.ts
+++ b/src/models/v2/message-trait.ts
@@ -21,7 +21,7 @@ import type { v2 } from '../../spec-types';
 
 export class MessageTrait<J extends v2.MessageTraitObject = v2.MessageTraitObject> extends BaseModel<J, { id: string }> implements MessageTraitInterface {
   id(): string {
-    return this.messageId() || this._meta.id || this.json(xParserMessageName) as string;
+    return this._json.messageId || this._meta.id || this.json(xParserMessageName) as string;
   }
 
   hasSchemaFormat(): boolean {
@@ -34,10 +34,6 @@ export class MessageTrait<J extends v2.MessageTraitObject = v2.MessageTraitObjec
 
   hasMessageId(): boolean {
     return !!this._json.messageId;
-  }
-
-  messageId(): string | undefined {
-    return this._json.messageId;
   }
   
   hasCorrelationId(): boolean {

--- a/src/models/v3/message-trait.ts
+++ b/src/models/v3/message-trait.ts
@@ -15,11 +15,11 @@ import type { v3 } from '../../spec-types';
 
 export class MessageTrait<J extends v3.MessageTraitObject = v3.MessageTraitObject> extends CoreModel<J, { id: string }> implements MessageTraitInterface {
   id(): string {
-    return this.messageId() || this._meta.id || this.extensions().get(xParserMessageName)?.value<string>() as string;
+    return this._meta.id || this.extensions().get(xParserMessageName)?.value<string>() as string;
   }
 
   hasMessageId(): boolean {
-    return !!this._json.messageId;
+    return false;
   }
 
   hasSchemaFormat(): boolean {
@@ -28,10 +28,6 @@ export class MessageTrait<J extends v3.MessageTraitObject = v3.MessageTraitObjec
 
   schemaFormat(): string | undefined {
     return undefined;
-  }
-
-  messageId(): string | undefined {
-    return this._json.messageId;
   }
   
   hasCorrelationId(): boolean {

--- a/src/spec-types/v3.ts
+++ b/src/spec-types/v3.ts
@@ -180,7 +180,6 @@ export interface MessageObject extends MessageTraitObject, SpecificationExtensio
 }
 
 export interface MessageTraitObject extends SpecificationExtensions {
-  messageId?: string;
   headers?: MultiFormatSchemaObject;
   correlationId?: CorrelationIDObject | ReferenceObject;
   contentType?: string;

--- a/test/custom-operations/apply-traits-v3.spec.ts
+++ b/test/custom-operations/apply-traits-v3.spec.ts
@@ -76,7 +76,7 @@ describe('custom operations - apply traits v3', function() {
             someMessage: {
               traits: [
                 {
-                  messageId: 'traitMessageId',
+                  summary: 'some summary',
                   description: 'some description' 
                 },
                 {
@@ -89,11 +89,11 @@ describe('custom operations - apply traits v3', function() {
         someChannel2: {
           messages: {
             someMessage: {
-              messageId: 'rootMessageId',
+              summary: 'root summary',
               description: 'root description',
               traits: [
                 {
-                  messageId: 'traitMessageId',
+                  summary: 'some summary',
                   description: 'some description' 
                 },
                 {
@@ -112,11 +112,11 @@ describe('custom operations - apply traits v3', function() {
 
     const message1 = v3Document?.json()?.channels?.someChannel1?.messages?.someMessage;
     delete (message1 as v3.MessageObject)?.traits;
-    expect(message1).toEqual({ messageId: 'traitMessageId', description: 'another description', 'x-parser-message-name': 'traitMessageId' });
+    expect(message1).toEqual({ summary: 'some summary', description: 'another description', 'x-parser-message-name': 'someMessage' });
 
     const message2 = v3Document?.json()?.channels?.someChannel2?.messages?.someMessage;
     delete (message2 as v3.MessageObject)?.traits;
-    expect(message2).toEqual({ messageId: 'rootMessageId', description: 'root description', 'x-parser-message-name': 'rootMessageId' });
+    expect(message2).toEqual({ summary: 'root summary', description: 'root description', 'x-parser-message-name': 'someMessage' });
   });
 
   it('should apply traits to messages (components)', async function() {
@@ -131,7 +131,7 @@ describe('custom operations - apply traits v3', function() {
           someMessage1: {
             traits: [
               {
-                messageId: 'traitMessageId',
+                summary: 'some summary',
                 description: 'some description' 
               },
               {
@@ -140,11 +140,11 @@ describe('custom operations - apply traits v3', function() {
             ]
           },
           someMessage2: {
-            messageId: 'rootMessageId',
+            summary: 'root summary',
             description: 'root description',
             traits: [
               {
-                messageId: 'traitMessageId',
+                summary: 'some summary',
                 description: 'some description' 
               },
               {
@@ -162,10 +162,10 @@ describe('custom operations - apply traits v3', function() {
 
     const message1 = v3Document?.json()?.components?.messages?.someMessage1;
     delete (message1 as v3.MessageObject)?.traits;
-    expect(message1).toEqual({ messageId: 'traitMessageId', description: 'another description', 'x-parser-message-name': 'traitMessageId' });
+    expect(message1).toEqual({ summary: 'some summary', description: 'another description', 'x-parser-message-name': 'someMessage1' });
 
     const message2 = v3Document?.json()?.components?.messages?.someMessage2;
     delete (message2 as v3.MessageObject)?.traits;
-    expect(message2).toEqual({ messageId: 'rootMessageId', description: 'root description', 'x-parser-message-name': 'rootMessageId' });
+    expect(message2).toEqual({ summary: 'root summary', description: 'root description', 'x-parser-message-name': 'someMessage2' });
   });
 });

--- a/test/models/v2/channel.spec.ts
+++ b/test/models/v2/channel.spec.ts
@@ -100,7 +100,7 @@ describe('Channel model', function() {
       expect(d.messages()).toBeInstanceOf(Messages);
       expect(d.messages().all()).toHaveLength(1);
       expect(d.messages().all()[0]).toBeInstanceOf(Message);
-      expect(d.messages().all()[0].messageId()).toEqual((doc as any).publish.message.messageId);
+      expect(d.messages().all()[0].id()).toEqual((doc as any).publish.message.messageId);
     });
     
     it('should return collection of messages - oneOf message', function() {
@@ -109,9 +109,9 @@ describe('Channel model', function() {
       expect(d.messages()).toBeInstanceOf(Messages);
       expect(d.messages().all()).toHaveLength(2);
       expect(d.messages().all()[0]).toBeInstanceOf(Message);
-      expect(d.messages().all()[0].messageId()).toEqual((doc as any).subscribe.message.oneOf[0].messageId);
+      expect(d.messages().all()[0].id()).toEqual((doc as any).subscribe.message.oneOf[0].messageId);
       expect(d.messages().all()[1]).toBeInstanceOf(Message);
-      expect(d.messages().all()[1].messageId()).toEqual((doc as any).subscribe.message.oneOf[1].messageId);
+      expect(d.messages().all()[1].id()).toEqual((doc as any).subscribe.message.oneOf[1].messageId);
     });
 
     it('should return collection of messages - single message and oneOf', function() {

--- a/test/models/v2/message-trait.spec.ts
+++ b/test/models/v2/message-trait.spec.ts
@@ -53,13 +53,13 @@ describe('MessageTrait model', function() {
     it('should return the value', function() {
       const doc = { messageId: '...' };
       const d = new MessageTrait(doc);
-      expect(d.messageId()).toEqual(doc.messageId);
+      expect(d.id()).toEqual(doc.messageId);
     });
     
     it('should return undefined when there is no value', function() {
       const doc = {};
       const d = new MessageTrait(doc);
-      expect(d.messageId()).toBeUndefined();
+      expect(d.id()).toBeUndefined();
     });
   });
 

--- a/test/models/v2/server.spec.ts
+++ b/test/models/v2/server.spec.ts
@@ -144,7 +144,7 @@ describe('Server Model', function () {
       expect(d.messages()).toBeInstanceOf(Messages);
       expect(d.messages().all()).toHaveLength(1);
       expect(d.messages().all()[0]).toBeInstanceOf(Message);
-      expect(d.messages().all()[0].messageId()).toEqual('1');
+      expect(d.messages().all()[0].id()).toEqual('1');
     });
 
     it('should return collection of messages - multiple channels', function() {
@@ -153,11 +153,11 @@ describe('Server Model', function () {
       expect(d.messages()).toBeInstanceOf(Messages);
       expect(d.messages().all()).toHaveLength(3);
       expect(d.messages().all()[0]).toBeInstanceOf(Message);
-      expect(d.messages().all()[0].messageId()).toEqual('1');
+      expect(d.messages().all()[0].id()).toEqual('1');
       expect(d.messages().all()[1]).toBeInstanceOf(Message);
-      expect(d.messages().all()[1].messageId()).toEqual('2');
+      expect(d.messages().all()[1].id()).toEqual('2');
       expect(d.messages().all()[2]).toBeInstanceOf(Message);
-      expect(d.messages().all()[2].messageId()).toEqual('3');
+      expect(d.messages().all()[2].id()).toEqual('3');
     });
 
     it('should return collection of messages - server available only in particular channel', function() {
@@ -166,11 +166,11 @@ describe('Server Model', function () {
       expect(d.messages()).toBeInstanceOf(Messages);
       expect(d.messages().all()).toHaveLength(3);
       expect(d.messages().all()[0]).toBeInstanceOf(Message);
-      expect(d.messages().all()[0].messageId()).toEqual('1');
+      expect(d.messages().all()[0].id()).toEqual('1');
       expect(d.messages().all()[1]).toBeInstanceOf(Message);
-      expect(d.messages().all()[1].messageId()).toEqual('2');
+      expect(d.messages().all()[1].id()).toEqual('2');
       expect(d.messages().all()[2]).toBeInstanceOf(Message);
-      expect(d.messages().all()[2].messageId()).toEqual('3');
+      expect(d.messages().all()[2].id()).toEqual('3');
     });
   });
 

--- a/test/models/v3/channel.spec.ts
+++ b/test/models/v3/channel.spec.ts
@@ -98,26 +98,26 @@ describe('Channel model', function() {
 
   describe('.messages()', function() {
     it('should return collection of messages - single message', function() {
-      const doc = serializeInput<v3.ChannelObject>({ messages: { someMessage: { messageId: 'messageId' } } });
+      const doc = serializeInput<v3.ChannelObject>({ messages: { someMessage: {} } });
       const d = new Channel(doc);
       const msg = doc.messages?.['someMessage'] as v3.MessageObject;
       expect(d.messages()).toBeInstanceOf(Messages);
       expect(d.messages().all()).toHaveLength(1);
       expect(d.messages().all()[0]).toBeInstanceOf(Message);
-      expect(d.messages().all()[0].messageId()).toEqual(msg?.messageId);
+      expect(d.messages().all()[0].id()).toEqual('someMessage');
     });
     
     it('should return collection of messages - more than one messages', function() {
-      const doc = serializeInput<v3.ChannelObject>({ messages: { someMessage1: { messageId: 'messageId1' }, someMessage2: { messageId: 'messageId2' } } });
+      const doc = serializeInput<v3.ChannelObject>({ messages: { someMessage1: {}, someMessage2: {} } });
       const d = new Channel(doc);
       const msg1 = doc.messages?.['someMessage1'] as v3.MessageObject;
       const msg2 = doc.messages?.['someMessage2'] as v3.MessageObject;
       expect(d.messages()).toBeInstanceOf(Messages);
       expect(d.messages().all()).toHaveLength(2);
       expect(d.messages().all()[0]).toBeInstanceOf(Message);
-      expect(d.messages().all()[0].id()).toEqual(msg1.messageId);
+      expect(d.messages().all()[0].id()).toEqual('someMessage1');
       expect(d.messages().all()[1]).toBeInstanceOf(Message);
-      expect(d.messages().all()[1].id()).toEqual(msg2.messageId);
+      expect(d.messages().all()[1].id()).toEqual('someMessage2');
     });
   });
 

--- a/test/models/v3/message-trait.spec.ts
+++ b/test/models/v3/message-trait.spec.ts
@@ -13,12 +13,6 @@ describe('MessageTrait model', function() {
       const d = new MessageTrait(doc, { asyncapi: {} as any, pointer: '', id: 'trait' });
       expect(d.id()).toEqual('trait');
     });
-
-    it('should reuse messageId', function() {
-      const doc = { messageId: '...' };
-      const d = new MessageTrait(doc);
-      expect(d.id()).toEqual(doc.messageId);
-    });
   });
 
   describe('.schemaFormat()', function() {
@@ -38,30 +32,16 @@ describe('MessageTrait model', function() {
   });
 
   describe('.hasMessageId()', function() {
-    it('should return true when there is a value', function() {
-      const doc = { messageId: '...' };
-      const d = new MessageTrait(doc);
-      expect(d.hasMessageId()).toEqual(true);
+    it('should return false when there is a value', function() {
+      const doc = {};
+      const d = new MessageTrait(doc, { asyncapi: {} as any, pointer: '', id: 'message' });
+      expect(d.hasMessageId()).toEqual(false);
     });
     
     it('should return false when there is no value', function() {
       const doc = {};
       const d = new MessageTrait(doc);
       expect(d.hasMessageId()).toEqual(false);
-    });
-  });
-
-  describe('.messageId()', function() {
-    it('should return the value', function() {
-      const doc = { messageId: '...' };
-      const d = new MessageTrait(doc);
-      expect(d.messageId()).toEqual(doc.messageId);
-    });
-    
-    it('should return undefined when there is no value', function() {
-      const doc = {};
-      const d = new MessageTrait(doc);
-      expect(d.messageId()).toBeUndefined();
     });
   });
 

--- a/test/models/v3/message.spec.ts
+++ b/test/models/v3/message.spec.ts
@@ -18,12 +18,6 @@ describe('Message model', function() {
       const d = new Message(doc, { asyncapi: {} as any, pointer: '', id: 'message' });
       expect(d.id()).toEqual('message');
     });
-
-    it('should reuse messageId', function() {
-      const doc = { messageId: '...' };
-      const d = new Message(doc);
-      expect(d.id()).toEqual(doc.messageId);
-    });
   });
 
   describe('.schemaFormat() + .hasSchemaFormat()', function() {

--- a/test/models/v3/operation-reply.spec.ts
+++ b/test/models/v3/operation-reply.spec.ts
@@ -64,20 +64,20 @@ describe('OperationReply model', function() {
   
   describe('.messages()', function() {
     it('should return collection of messages - single message', function() {
-      const d = new OperationReply({ messages: { someMessage: { messageId: 'messageId' } } });
+      const d = new OperationReply({ messages: { someMessage: {} } });
       expect(d.messages()).toBeInstanceOf(Messages);
       expect(d.messages().all()).toHaveLength(1);
       expect(d.messages().all()[0]).toBeInstanceOf(Message);
     });
 
     it('should return collection of messages - more than one messages', function() {
-      const d = new OperationReply({ messages: { someMessage1: { messageId: 'messageId1' }, someMessage2: { messageId: 'messageId2' } } });
+      const d = new OperationReply({ messages: { someMessage1: {}, someMessage2: {} } });
       expect(d.messages()).toBeInstanceOf(Messages);
       expect(d.messages().all()).toHaveLength(2);
       expect(d.messages().all()[0]).toBeInstanceOf(Message);
-      expect(d.messages().all()[0].messageId()).toEqual('messageId1');
+      expect(d.messages().all()[0].id()).toEqual('someMessage1');
       expect(d.messages().all()[1]).toBeInstanceOf(Message);
-      expect(d.messages().all()[1].messageId()).toEqual('messageId2');
+      expect(d.messages().all()[1].id()).toEqual('someMessage2');
     });
 
     it('should return undefined if address is not present', function() {

--- a/test/models/v3/operation.spec.ts
+++ b/test/models/v3/operation.spec.ts
@@ -89,7 +89,7 @@ describe('Operation model', function() {
 
   describe('.messages()', function() {
     it('should return collection of messages - single message', function() {
-      const channel = { messages: { someMessage: { messageId: 'messageId' } } };
+      const channel = { messages: { someMessage: { summary: 'summary' } } };
       const d = new Operation({ action: 'send', channel }, { asyncapi: { parsed: { channels: { someChannel: channel } } } as any, pointer: '', id: 'operation' });
       expect(d.messages()).toBeInstanceOf(Messages);
       expect(d.messages().all()).toHaveLength(1);
@@ -97,23 +97,23 @@ describe('Operation model', function() {
     });
 
     it('should return collection of messages - more than one messages', function() {
-      const channel = { messages: { someMessage1: { messageId: 'messageId1' }, someMessage2: { messageId: 'messageId2' } } };
+      const channel = { messages: { someMessage1: { summary: 'summary1' }, someMessage2: { summary: 'summary2' } } };
       const d = new Operation({ action: 'send', channel }, { asyncapi: { parsed: { channels: { someChannel: channel } } } as any, pointer: '', id: 'operation' });
       expect(d.messages()).toBeInstanceOf(Messages);
       expect(d.messages().all()).toHaveLength(2);
       expect(d.messages().all()[0]).toBeInstanceOf(Message);
-      expect(d.messages().all()[0].messageId()).toEqual('messageId1');
+      expect(d.messages().all()[0].summary()).toEqual('summary1');
       expect(d.messages().all()[1]).toBeInstanceOf(Message);
-      expect(d.messages().all()[1].messageId()).toEqual('messageId2');
+      expect(d.messages().all()[1].summary()).toEqual('summary2');
     });
 
     it('should return collection of messages - defined message on operation level', function() {
-      const channel = { messages: { someMessage1: { messageId: 'messageId1' }, someMessage2: { messageId: 'messageId2' } } };
+      const channel = { messages: { someMessage1: { summary: 'summary1' }, someMessage2: { summary: 'summary2' } } };
       const d = new Operation({ action: 'send', channel, messages: [channel.messages.someMessage1] }, { asyncapi: { parsed: { channels: { someChannel: channel } } } as any, pointer: '', id: 'operation' });
       expect(d.messages()).toBeInstanceOf(Messages);
       expect(d.messages().all()).toHaveLength(1);
       expect(d.messages().all()[0]).toBeInstanceOf(Message);
-      expect(d.messages().all()[0].messageId()).toEqual('messageId1');
+      expect(d.messages().all()[0].summary()).toEqual('summary1');
     });
     
     it('should return undefined when there is no value', function() {

--- a/test/models/v3/server.spec.ts
+++ b/test/models/v3/server.spec.ts
@@ -168,33 +168,33 @@ describe('Server Model', function () {
   describe('.messages()', function() {
     it('should return collection of messages - one message', function() {
       const doc = serializeInput<v3.ServerObject>({});
-      const d = new Server(doc, { asyncapi: { parsed: { channels: { someChannel: { messages: { someMessage: { messageId: 'messageId' } } } } } } as any, pointer: '', id: 'production' });
+      const d = new Server(doc, { asyncapi: { parsed: { channels: { someChannel: { messages: { someMessage: { summary: 'summary' } } } } } } as any, pointer: '', id: 'production' });
       expect(d.messages()).toBeInstanceOf(Messages);
       expect(d.messages().all()).toHaveLength(1);
       expect(d.messages().all()[0]).toBeInstanceOf(Message);
-      expect(d.messages().all()[0].messageId()).toEqual('messageId');
+      expect(d.messages().all()[0].summary()).toEqual('summary');
     });
 
     it('should return collection of messages - more than one messages', function() {
       const doc = serializeInput<v3.ServerObject>({});
-      const d = new Server(doc, { asyncapi: { parsed: { channels: { someChannel1: { messages: { someMessage1: { messageId: 'messageId1' } } }, someChannel2: { messages: { someMessage2: { messageId: 'messageId2' }, someMessage3: { messageId: 'messageId3' } } } } } } as any, pointer: '', id: 'production' });
+      const d = new Server(doc, { asyncapi: { parsed: { channels: { someChannel1: { messages: { someMessage1: { summary: 'summary1' } } }, someChannel2: { messages: { someMessage2: { summary: 'summary2' }, someMessage3: { summary: 'summary3' } } } } } } as any, pointer: '', id: 'production' });
       expect(d.messages()).toBeInstanceOf(Messages);
       expect(d.messages().all()).toHaveLength(3);
       expect(d.messages().all()[0]).toBeInstanceOf(Message);
-      expect(d.messages().all()[0].messageId()).toEqual('messageId1');
+      expect(d.messages().all()[0].summary()).toEqual('summary1');
       expect(d.messages().all()[1]).toBeInstanceOf(Message);
-      expect(d.messages().all()[1].messageId()).toEqual('messageId2');
+      expect(d.messages().all()[1].summary()).toEqual('summary2');
       expect(d.messages().all()[2]).toBeInstanceOf(Message);
-      expect(d.messages().all()[2].messageId()).toEqual('messageId3');
+      expect(d.messages().all()[2].summary()).toEqual('summary3');
     });
 
     it('should return collection of messages - server available only in particular channel', function() {
       const doc = serializeInput<v3.ServerObject>({});
-      const d = new Server(doc, { asyncapi: { parsed: { channels: { someChannel1: { servers: [doc], messages: { someMessage1: { messageId: 'messageId1' } } }, someChannel2: { servers: [{}], messages: { someMessage2: { messageId: 'messageId2' }, someMessage3: { messageId: 'messageId3' } } } } } } as any, pointer: '', id: 'production' });
+      const d = new Server(doc, { asyncapi: { parsed: { channels: { someChannel1: { servers: [doc], messages: { someMessage1: { summary: 'summary1' } } }, someChannel2: { servers: [{}], messages: { someMessage2: { summary: 'summary2' }, someMessage3: { summary: 'summary3' } } } } } } as any, pointer: '', id: 'production' });
       expect(d.messages()).toBeInstanceOf(Messages);
       expect(d.messages().all()).toHaveLength(1);
       expect(d.messages().all()[0]).toBeInstanceOf(Message);
-      expect(d.messages().all()[0].messageId()).toEqual('messageId1');
+      expect(d.messages().all()[0].summary()).toEqual('summary1');
     });
   });
 


### PR DESCRIPTION
**Description**
Removes the `messageId()` function from the Message and MessageTrait objects. Keeps the same behavior on v2 but it doesn't look for `messageId` on v3. Now we only have one method to grab the id of a message and it's `.id()`.

Also, now `.hasMessageId()` now always returns `false` for v3.

**Related issue(s)**
https://github.com/asyncapi/spec/issues/978