### PR TITLE
fix: change ParserAPIVersion constant to 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ The following table shows a compatibility matrix between this parser, and the [P
 | Parser-JS | Parser-API                                                            | Spec 2.x | Spec 3.x |
 |-----------|-----------------------------------------------------------------------|----------|----------|
 | 2.x       | [1.x](https://github.com/asyncapi/parser-api/blob/v1.0.0/docs/v1.md)  | ✓        |          |
-| 3.x       | [2.x](https://github.com/asyncapi/parser-api/blob/v2.0.0/docs/api.md) | ✓        | ✓        |
+| 3.x       | [3.x](https://github.com/asyncapi/parser-api/blob/v3.0.0/docs/api.md) | ✓        | ✓        |
 
 - `✓` Fully supported version.
 - `-` The AsyncAPI Spec version has features the Parser-JS can't use but the rest are fully supported.

--- a/src/models/asyncapi.ts
+++ b/src/models/asyncapi.ts
@@ -11,8 +11,8 @@ import type { ServersInterface } from './servers';
 
 import type { v2, v3 } from '../spec-types';
 
-// https://github.com/asyncapi/parser-api/releases/tag/v2.0.0
-export const ParserAPIVersion = 2;
+// https://github.com/asyncapi/parser-api/releases/tag/v3.0.0
+export const ParserAPIVersion = 3;
 
 export interface AsyncAPIDocumentInterface extends BaseModel<v2.AsyncAPIObject | v3.AsyncAPIObject>, ExtensionsMixinInterface {
   version(): string;


### PR DESCRIPTION
**Description**

After recent changes made in https://github.com/asyncapi/parser-js/pull/889, this latest version of the Parser only supports Parser-API v3 instead of v2.

This PR fixes that.

**Related issue(s)**
https://github.com/asyncapi/parser-js/pull/889