### PR TITLE
fix: use JSON Pointer last element as ID for reply.channel and reply.messages[]

### DIFF
--- a/src/models/utils.ts
+++ b/src/models/utils.ts
@@ -12,3 +12,21 @@ export type InferModelMetadata<T> = T extends BaseModel<infer _, infer M> ? M : 
 export function createModel<T extends BaseModel>(Model: Constructor<T>, value: InferModelData<T>, meta: Omit<ModelMetadata, 'asyncapi'> & { asyncapi?: DetailedAsyncAPI } & InferModelMetadata<T>, parent?: BaseModel): T {
   return new Model(value, { ...meta, asyncapi: meta.asyncapi || parent?.meta().asyncapi });
 }
+
+export function objectIdFromJSONPointer(path: string, data: any): string {
+  if (typeof data === 'string') {
+    data = JSON.parse(data); 
+  }
+
+  if (!path.endsWith('/$ref')) path += '/$ref';
+
+  path = path.replace(/^\//, ''); // removing the leading slash
+  path.split('/').forEach((subpath) => {
+    const key = subpath.replace(/~1/, '/'); // recover escaped slashes
+    if (data[key] !== undefined) {
+      data = data[key];
+    }
+  });
+  
+  return data.split('/').pop().replace(/~1/, '/');
+}

--- a/src/models/v3/operation-reply.ts
+++ b/src/models/v3/operation-reply.ts
@@ -14,6 +14,8 @@ import type { ChannelInterface } from '../channel';
 
 import type { v3 } from '../../spec-types';
 
+import { objectIdFromJSONPointer } from '../utils';
+
 export class OperationReply extends BaseModel<v3.OperationReplyObject, { id?: string }> implements OperationReplyInterface {
   id(): string | undefined {
     return this._meta.id;
@@ -35,14 +37,14 @@ export class OperationReply extends BaseModel<v3.OperationReplyObject, { id?: st
 
   channel(): ChannelInterface | undefined {
     if (this._json.channel) {
-      return this.createModel(Channel, this._json.channel as v3.ChannelObject, { id: '', pointer: this.jsonPath('channel') });
+      return this.createModel(Channel, this._json.channel as v3.ChannelObject, { id: objectIdFromJSONPointer(this.jsonPath('channel'), this._meta.asyncapi.input), pointer: this.jsonPath('channel') });
     }
     return this._json.channel;
   }
   messages(): MessagesInterface {
-    return new Messages(
-      Object.entries(this._json.messages || {}).map(([messageName, message]) => {
-        return this.createModel(Message, message as v3.MessageObject, { id: messageName, pointer: this.jsonPath(`messages/${messageName}`) });
+    return new Messages(  
+      Object.entries(this._json.messages || {}).map(([i, message]) => {
+        return this.createModel(Message, message as v3.MessageObject, { id: objectIdFromJSONPointer(this.jsonPath(`messages/${i}`), this._meta.asyncapi.input), pointer: this.jsonPath(`messages/${i}`) });
       })
     );
   }

--- a/src/spec-types/v3.ts
+++ b/src/spec-types/v3.ts
@@ -143,7 +143,7 @@ export interface OperationTraitObject extends SpecificationExtensions {
 
 export interface OperationReplyObject extends SpecificationExtensions {
   channel?: ChannelObject | ReferenceObject;
-  messages?: MessagesObject;
+  messages?: Array<MessageObject | ReferenceObject>;
   address?: OperationReplyAddressObject | ReferenceObject;
 }
 

--- a/test/models/v3/operation-reply.spec.ts
+++ b/test/models/v3/operation-reply.spec.ts
@@ -64,20 +64,20 @@ describe('OperationReply model', function() {
   
   describe('.messages()', function() {
     it('should return collection of messages - single message', function() {
-      const d = new OperationReply({ messages: { someMessage: {} } });
+      const d = new OperationReply({ messages: [{}] });
       expect(d.messages()).toBeInstanceOf(Messages);
       expect(d.messages().all()).toHaveLength(1);
       expect(d.messages().all()[0]).toBeInstanceOf(Message);
     });
 
     it('should return collection of messages - more than one messages', function() {
-      const d = new OperationReply({ messages: { someMessage1: {}, someMessage2: {} } });
+      const d = new OperationReply({ messages: [{name: 'someMessage1'}, {name: 'someMessage2'}] });
       expect(d.messages()).toBeInstanceOf(Messages);
       expect(d.messages().all()).toHaveLength(2);
       expect(d.messages().all()[0]).toBeInstanceOf(Message);
-      expect(d.messages().all()[0].id()).toEqual('someMessage1');
+      expect(d.messages().all()[0].name()).toEqual('someMessage1');
       expect(d.messages().all()[1]).toBeInstanceOf(Message);
-      expect(d.messages().all()[1].id()).toEqual('someMessage2');
+      expect(d.messages().all()[1].name()).toEqual('someMessage2');
     });
 
     it('should return undefined if address is not present', function() {


### PR DESCRIPTION
**Description**

Fixes https://github.com/asyncapi/parser-js/issues/873

This PR puts on practice one of the solutions we might opt in for getting Id's on referenced objects via the last element of their JSON Pointer. In this case, we are doing this for the `reply.channel` and `reply.messages[]`, since in the Operation Reply those are referenced via a JSON Pointer.

I'm also fixing a bug where `reply.messages` were expected to be a map instead of an array.



**Related issue(s)**
Fixes https://github.com/asyncapi/parser-js/issues/873