### PR TITLE
fix: wrong parserAPI number being checked

### DIFF
--- a/src/document.ts
+++ b/src/document.ts
@@ -1,4 +1,4 @@
-import { AsyncAPIDocumentV2, AsyncAPIDocumentV3 } from './models';
+import { AsyncAPIDocumentV2, AsyncAPIDocumentV3, ParserAPIVersion } from './models';
 import { unstringify } from './stringify';
 import { createDetailedAsyncAPI } from './utils';
 
@@ -43,7 +43,7 @@ export function isAsyncAPIDocument(maybeDoc: unknown): maybeDoc is AsyncAPIDocum
   }
   if (maybeDoc && typeof (maybeDoc as AsyncAPIDocumentInterface).json === 'function') {
     const versionOfParserAPI = (maybeDoc as AsyncAPIDocumentInterface).json()[xParserApiVersion];
-    return versionOfParserAPI === 2;
+    return versionOfParserAPI === ParserAPIVersion;
   }
   return false;
 }

--- a/test/document.spec.ts
+++ b/test/document.spec.ts
@@ -114,8 +114,12 @@ describe('utils', function() {
       expect(isAsyncAPIDocument(createAsyncAPIDocument(detailed))).toEqual(true);
     });
 
-    it('document with the x-parser-api-version extension set to 2 should be AsyncAPI document', async function() {
-      expect(isAsyncAPIDocument({ json() { return { [xParserApiVersion]: 2 }; } })).toEqual(true);
+    it('document with the x-parser-api-version extension set to 3 should be AsyncAPI document', async function() {
+      expect(isAsyncAPIDocument({ json() { return { [xParserApiVersion]: 3 }; } })).toEqual(true);
+    });
+
+    it('document with the x-parser-api-version extension set to 2 should not be AsyncAPI document', async function() {
+      expect(isAsyncAPIDocument({ json() { return { [xParserApiVersion]: 2 }; } })).toEqual(false);
     });
 
     it('document with the x-parser-api-version extension set to 1 should not be AsyncAPI document', async function() {


### PR DESCRIPTION
**Description**
This PR fixes that we hardcoded a number to check the parser API when checking whether a document is from this parser version or not. This causes the check to fail, even though it was correct.

**Related issue(s)**
Related to https://github.com/asyncapi/html-template/issues/456