### PR TITLE
Add new Spectral rule to check for null addresses in channels associated with operations defining reply

### DIFF
--- a/src/ruleset/functions/checkNullAddressInOperations.ts
+++ b/src/ruleset/functions/checkNullAddressInOperations.ts
@@ -1,0 +1,32 @@
+import { IFunction, IFunctionResult } from '@stoplight/spectral-core';
+import { IAsyncAPIOperation, IAsyncAPIChannel } from '@stoplight/types';
+import { Operations } from 'models/v2/operations';
+
+const checkNullAddressInOperations: IFunction = (document, opts) => {
+  const results: IFunctionResult[] = [];
+
+  const channels: Record<string, IAsyncAPIChannel> = document.channels ?? {};
+
+  for(const channelKey in channels){
+    const channel = channels[channelKey];
+
+    //check if channel has operation defined
+    if(channel.operations) {
+      for(const operationKey in channel.operations) {
+        const operation = channel.operations[operationKey];
+
+        //check if the operation defines a reply and the channel is null or undefined
+        if(operation.reply && (!channel.address || channel.address === 'null')) {
+          results.push({
+            message: `Channel "${channelKey}" associated with operation "${operationKey}" has a null or undefined address.`,
+            path: ['channels', channelKey, 'operations', operationKey, 'reply'],
+            severity: 'error'
+          })
+        }
+      }
+    }
+  }
+  return results;
+}
+
+export default checkNullAddressInOperations;

--- a/src/ruleset/ruleset.ts
+++ b/src/ruleset/ruleset.ts
@@ -76,6 +76,16 @@ export const coreRuleset = {
         function: internal,
       },
     },
+    'asyncapi-null-address-in-operations': {
+      description: 'check for null adrresses in channels associated with operations defining reply',
+      message: 'channel address should not be null when operation define a reply',
+      severity: 'error',
+      recommended: true,
+      given : '$',
+      then: {
+        function: 'checkNullAddressInOperations',
+      },
+    }
   },
 };
 


### PR DESCRIPTION
Fixes #875 