### PR TITLE
ci: disable code duplication analysis for files under src/spec-types

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,3 +1,3 @@
 # Disable specific duplicate code since it would introduce more complexity to reduce it.
-sonar.cpd.exclusions=src/models/**/*.ts
+sonar.cpd.exclusions=src/models/**/*.ts,src/spec-types/*.ts
 sonar.exclusions=test/**/*

--- a/src/spec-types/v3.ts
+++ b/src/spec-types/v3.ts
@@ -297,7 +297,6 @@ export type SecuritySchemaLocation =
   | 'password'
   | 'query'
   | 'header'
-  | 'header'
   | 'cookie';
 
 export interface SecuritySchemeObjectBase extends SpecificationExtensions {


### PR DESCRIPTION
**Description**

Code duplication analysis makes sense most of the time. However, for models and types related with different versions of the spec, duplication is completely expected. 
[This PR](https://github.com/asyncapi/parser-js/pull/526) is blocked by such analysis.

This PR adds `src/spect-types/*.ts` to the previously existing list of exclusions. After that change, SonarCloud analysis should stop complaining about [this](https://sonarcloud.io/component_measures?metric=new_duplicated_lines_density&selected=asyncapi_parser-js%3Asrc%2Fspec-types%2Fv3.ts&view=list&pullRequest=526&id=asyncapi_parser-js).