### PR TITLE
fix: iterating between operations, channels and messages

### DIFF
--- a/src/custom-operations/apply-unique-ids.ts
+++ b/src/custom-operations/apply-unique-ids.ts
@@ -3,23 +3,42 @@ import { xParserObjectUniqueId } from '../constants';
 /**
  * This function applies unique ids for objects whose key's function as ids, ensuring that the key is part of the value.
  * 
- * For v3; Apply unique ids to channel's, and message's
+ * For v3; Apply unique ids to all channel's, operations, and message's.
+ * 
+ * Does not apply unique ids to $ref objects
  */
 export function applyUniqueIds(structure: any) {
   const asyncapiVersion = structure.asyncapi.charAt(0);
   switch (asyncapiVersion) {
   case '3':
-    if (structure.channels) {
-      for (const [channelId, channel] of Object.entries(structure.channels as Record<string, any>)) {
-        channel[xParserObjectUniqueId] = channelId;
-        if (channel.messages) {
-          for (const [messageId, message] of Object.entries(channel.messages as Record<string, any>)) {
-            message[xParserObjectUniqueId] = messageId; 
-          }
-        }
-      }
+    applyUniqueIdToChannels(structure.channels);
+    applyUniqueIdToObjects(structure.operations);
+    if (structure.components) {
+      applyUniqueIdToObjects(structure.components.messages);
+      applyUniqueIdToObjects(structure.components.operations);
+      applyUniqueIdToChannels(structure.components.channels);
     }
     break;
   }
 }
-  
+
+function applyUniqueIdToChannels(channels: any) {
+  for (const [channelId, channel] of Object.entries((channels ?? {}) as Record<string, any>)) {
+    if (!channel.$ref) {
+      channel[xParserObjectUniqueId] = channelId;
+    }
+    for (const [messageId, message] of Object.entries((channel.messages ?? {}) as Record<string, any>)) {
+      if (!message.$ref) {
+        message[xParserObjectUniqueId] = messageId;
+      }
+    }
+  }
+}
+
+function applyUniqueIdToObjects(objects: any) {
+  for (const [objectKey, object] of Object.entries((objects ?? {}) as Record<string, any>)) {
+    if (!object.$ref) {
+      object[xParserObjectUniqueId] = objectKey;
+    }
+  }
+}

--- a/src/custom-operations/apply-unique-ids.ts
+++ b/src/custom-operations/apply-unique-ids.ts
@@ -4,8 +4,6 @@ import { xParserObjectUniqueId } from '../constants';
  * This function applies unique ids for objects whose key's function as ids, ensuring that the key is part of the value.
  * 
  * For v3; Apply unique ids to all channel's, operations, and message's.
- * 
- * Does not apply unique ids to $ref objects
  */
 export function applyUniqueIds(structure: any) {
   const asyncapiVersion = structure.asyncapi.charAt(0);
@@ -24,20 +22,16 @@ export function applyUniqueIds(structure: any) {
 
 function applyUniqueIdToChannels(channels: any) {
   for (const [channelId, channel] of Object.entries((channels ?? {}) as Record<string, any>)) {
-    if (!channel.$ref) {
+    if (!channel[xParserObjectUniqueId]) {
       channel[xParserObjectUniqueId] = channelId;
     }
-    for (const [messageId, message] of Object.entries((channel.messages ?? {}) as Record<string, any>)) {
-      if (!message.$ref) {
-        message[xParserObjectUniqueId] = messageId;
-      }
-    }
+    applyUniqueIdToObjects(channel.messages);
   }
 }
 
 function applyUniqueIdToObjects(objects: any) {
   for (const [objectKey, object] of Object.entries((objects ?? {}) as Record<string, any>)) {
-    if (!object.$ref) {
+    if (!object[xParserObjectUniqueId]) {
       object[xParserObjectUniqueId] = objectKey;
     }
   }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -55,8 +55,6 @@ export async function parse(parser: Parser, spectral: Spectral, asyncapi: Input,
     } else {
       loadedObj = asyncapi;
     }
-    // Apply unique ids before resolving references
-    applyUniqueIds(loadedObj);
     const { validated, diagnostics, extras } = await validate(parser, spectral, loadedObj, { ...options.validateOptions, source: options.source, __unstable: options.__unstable });
     if (validated === undefined) {
       return {
@@ -71,6 +69,9 @@ export async function parse(parser: Parser, spectral: Spectral, asyncapi: Input,
   
     // unfreeze the object - Spectral makes resolved document "freezed" 
     const validatedDoc = copy(validated as Record<string, any>);
+
+    // Apply unique ids which are used as part of iterating between channels <-> operations <-> messages
+    applyUniqueIds(validatedDoc);
     const detailed = createDetailedAsyncAPI(validatedDoc, loadedObj as DetailedAsyncAPI['input'], options.source);
     const document = createAsyncAPIDocument(detailed);
     setExtension(xParserSpecParsed, true, document);

--- a/test/custom-operations/apply-unique-ids.spec.ts
+++ b/test/custom-operations/apply-unique-ids.spec.ts
@@ -20,9 +20,45 @@ describe('applying unique ids', function() {
       applyUniqueIds(input);
       expect(input).toEqual(output);
     });
+    it('should set unique id when input has operations', async function() {
+      const input = {asyncapi: '3.0.0', operations: {testOperation: {}}};
+      const output = {...input, operations: {testOperation: {'x-parser-unique-object-id': 'testOperation'}}};
+      applyUniqueIds(input);
+      expect(input).toEqual(output);
+    });
     it('should set unique id when input has messages in channels', async function() {
       const input = {asyncapi: '3.0.0', channels: {testChannel: {messages: {testMessage: {}}}}};
       const output = {...input, channels: {testChannel: {'x-parser-unique-object-id': 'testChannel', messages: {testMessage: {'x-parser-unique-object-id': 'testMessage'}}}}};
+      applyUniqueIds(input);
+      expect(input).toEqual(output);
+    });
+    it('should set unique id when input has channels under components', async function() {
+      const input = {asyncapi: '3.0.0', components: {channels: {testChannel: {}}}};
+      const output = {...input, components: {channels: {testChannel: {'x-parser-unique-object-id': 'testChannel'}}}};
+      applyUniqueIds(input);
+      expect(input).toEqual(output);
+    });
+    it('should set unique id when input has operations under components', async function() {
+      const input = {asyncapi: '3.0.0', components: {operations: {testOperation: {}}}};
+      const output = {...input, components: {operations: {testOperation: {'x-parser-unique-object-id': 'testOperation'}}}};
+      applyUniqueIds(input);
+      expect(input).toEqual(output);
+    });
+    it('should set unique id when input has messages in channels under components', async function() {
+      const input = {asyncapi: '3.0.0', components: {channels: {testChannel: {messages: {testMessage: {}}}}}};
+      const output = {...input, components: {channels: {testChannel: {'x-parser-unique-object-id': 'testChannel', messages: {testMessage: {'x-parser-unique-object-id': 'testMessage'}}}}}};
+      applyUniqueIds(input);
+      expect(input).toEqual(output);
+    });
+    it('should set unique id when input has messages under components', async function() {
+      const input = {asyncapi: '3.0.0', components: { messages: {testMessage: {}}}};
+      const output = {...input, components: { messages: {testMessage: {'x-parser-unique-object-id': 'testMessage'}}}};
+      applyUniqueIds(input);
+      expect(input).toEqual(output);
+    });
+    it('should not overwrite existing unique ids', async function() {
+      const input = {asyncapi: '3.0.0', components: { messages: {testMessage: {'x-parser-unique-object-id': 'testMessage2'}}}};
+      const output = {...input, components: { messages: {testMessage: {'x-parser-unique-object-id': 'testMessage2'}}}};
       applyUniqueIds(input);
       expect(input).toEqual(output);
     });


### PR DESCRIPTION
**Description**
Once before I implemented this functionality incorrectly. this PR fixes that operations, channels, and messages could not be iterated between each other. On top of that, the functionality did not work when references were local files, this has also been fixed. 

**Related issue(s)**
Raised on slack: https://asyncapi.slack.com/archives/CQVJXFNQL/p1707760039073239