### PR TITLE
fix: remove unexpected support for traits at Channel Object level

### DIFF
--- a/src/custom-operations/apply-traits.ts
+++ b/src/custom-operations/apply-traits.ts
@@ -51,11 +51,9 @@ function applyTraitsToObjectV2(value: Record<string, unknown>) {
 const v3TraitPaths = [
   // operations
   '$.operations.*',
-  '$.operations.*.channel.*',
   '$.operations.*.channel.messages.*',
   '$.operations.*.messages.*',
   '$.components.operations.*',
-  '$.components.operations.*.channel.*',
   '$.components.operations.*.channel.messages.*',
   '$.components.operations.*.messages.*',
   // Channels

--- a/test/validate.spec.ts
+++ b/test/validate.spec.ts
@@ -51,4 +51,47 @@ describe('validate()', function() {
     expect(hasErrorDiagnostic(diagnostics)).toEqual(false);
     expect(hasWarningDiagnostic(diagnostics)).toEqual(true);
   });
+
+  // See https://github.com/asyncapi/parser-js/issues/996
+  it('user case - null channel address should not make operation traits appliance fail', async function() {
+    const documentRaw = {
+      asyncapi: '3.0.0',
+      info: {
+        title: 'Nexus Server API',
+        version: '1.0.0'
+      },
+      channels: {
+        Exchange: {
+          address: null,
+          messages: {
+            FooEvent: {
+              name: 'FooEvent',
+              title: 'Tenant Created',
+              contentType: 'application/json',
+              payload: {
+                type: 'string'
+              }
+            }
+          }
+        }
+      },
+      operations: {
+        sendTenantCreated: {
+          title: 'Send tenant created event to client',
+          action: 'send',
+          channel: {
+            $ref: '#/channels/Exchange'
+          },
+          messages: [
+            {
+              $ref: '#/channels/Exchange/messages/FooEvent'
+            }
+          ]
+        }
+      }
+    };
+    const { document, diagnostics } = await parser.parse(documentRaw, { validateOptions: { allowedSeverity: { warning: false } } });
+    console.log(diagnostics);
+    expect(diagnostics).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
**Description**

Fixes https://github.com/asyncapi/parser-js/issues/996

The current AsyncAPI spec (v3.0.0) support traits only at:

- [Message Object level](https://www.asyncapi.com/docs/reference/specification/v3.0.0#messageTraitObject)
- [Operation Object level](https://www.asyncapi.com/docs/reference/specification/v3.0.0#operationTraitObject)

Channels traits are not supported, however for some reason we added such support in our Parser code. 
This was causing a bug (linked above).

**Related issue(s)**
https://github.com/asyncapi/parser-js/issues/996