### PR TITLE
fix: always allow schema string examples

### DIFF
--- a/packages/parser/src/ruleset/v2/functions/schemaValidation.ts
+++ b/packages/parser/src/ruleset/v2/functions/schemaValidation.ts
@@ -64,7 +64,7 @@ export const schemaValidation = createRulesetFunction<SchemaFragment, { type: 'd
         },
       );
 
-      if (Array.isArray(result)) {
+      if (Array.isArray(result) && typeof relevantItem.value !== 'string') {
         results.push(...result);
       }
     }

--- a/packages/parser/test/ruleset/rules/v2/asyncapi2-schema-examples.spec.ts
+++ b/packages/parser/test/ruleset/rules/v2/asyncapi2-schema-examples.spec.ts
@@ -43,7 +43,7 @@ testRule('asyncapi2-schema-examples', [
           parameters: {
             userId: {
               schema: {
-                examples: [17, 'one', 13],
+                examples: [17, {}, 13, 'string-is-always-accepted'],
               },
             },
           },
@@ -53,26 +53,26 @@ testRule('asyncapi2-schema-examples', [
         parameters: {
           orphanParameter: {
             schema: {
-              examples: [17, 'one', 13],
+              examples: [17, {}, 13, 'string-is-always-accepted'],
             },
           },
         },
         schemas: {
           aSchema: {
-            type: 'string',
-            examples: [17, 'one', 13],
+            type: 'object',
+            examples: [17, {}, 13, 'string-is-always-accepted'],
           },
         },
       },
     },
     errors: [
       {
-        message: '"0" property type must be string',
+        message: '"0" property type must be object',
         path: ['components', 'schemas', 'aSchema', 'examples', '0'],
         severity: DiagnosticSeverity.Error,
       },
       {
-        message: '"2" property type must be string',
+        message: '"2" property type must be object',
         path: ['components', 'schemas', 'aSchema', 'examples', '2'],
         severity: DiagnosticSeverity.Error,
       },
@@ -88,7 +88,7 @@ testRule('asyncapi2-schema-examples', [
           parameters: {
             userId: {
               schema: {
-                examples: [17, 'one', 13],
+                examples: [17, {}, 13, 'string-is-always-accepted'],
               },
             },
           },
@@ -98,26 +98,26 @@ testRule('asyncapi2-schema-examples', [
         parameters: {
           orphanParameter: {
             schema: {
-              type: 'string',
-              examples: [17, 'one', 13],
+              type: 'object',
+              examples: [17, {}, 13, 'string-is-always-accepted'],
             },
           },
         },
         schemas: {
           aSchema: {
-            examples: [17, 'one', 13],
+            examples: [17, {}, 13, 'string-is-always-accepted'],
           },
         },
       },
     },
     errors: [
       {
-        message: '"0" property type must be string',
+        message: '"0" property type must be object',
         path: ['components', 'parameters', 'orphanParameter', 'schema', 'examples', '0'],
         severity: DiagnosticSeverity.Error,
       },
       {
-        message: '"2" property type must be string',
+        message: '"2" property type must be object',
         path: ['components', 'parameters', 'orphanParameter', 'schema', 'examples', '2'],
         severity: DiagnosticSeverity.Error,
       },
@@ -133,8 +133,8 @@ testRule('asyncapi2-schema-examples', [
           parameters: {
             userId: {
               schema: {
-                type: 'string',
-                examples: [17, 'one', 13],
+                type: 'object',
+                examples: [17, {}, 13, 'string-is-always-accepted'],
               },
             },
           },
@@ -144,25 +144,25 @@ testRule('asyncapi2-schema-examples', [
         parameters: {
           orphanParameter: {
             schema: {
-              examples: [17, 'one', 13],
+              examples: [17, {}, 13, 'string-is-always-accepted'],
             },
           },
         },
         schemas: {
           aSchema: {
-            examples: [17, 'one', 13],
+            examples: [17, {}, 13, 'string-is-always-accepted'],
           },
         },
       },
     },
     errors: [
       {
-        message: '"0" property type must be string',
+        message: '"0" property type must be object',
         path: ['channels', 'users/{userId}/signedUp', 'parameters', 'userId', 'schema', 'examples', '0'],
         severity: DiagnosticSeverity.Error,
       },
       {
-        message: '"2" property type must be string',
+        message: '"2" property type must be object',
         path: ['channels', 'users/{userId}/signedUp', 'parameters', 'userId', 'schema', 'examples', '2'],
         severity: DiagnosticSeverity.Error,
       },


### PR DESCRIPTION
**Description**

The spectral rule asyncApi2SchemaValidation currently enforces that all examples have the same type as the schema type. However, we believe that there are cases in AsyncAPI, where it is needed to accept string examples regardless of the schema type.

_To Reproduce:_

1. Use the AsyncAPI document: https://github.com/asyncapi/spec/issues/1038#issuecomment-1969489452
2. Open it in AsyncAPI studio
3. See the error: 66:11    error  asyncapi-schema-examples   "0" property type must be object components.schemas.io.github.springwolf.examples.kafka.dtos.XmlPayloadDto.examples[0]

**Related issue(s)**
- https://github.com/asyncapi/parser-js/issues/997
- https://github.com/stoplightio/spectral/issues/2624