### PR TITLE
added condition to check `parameter` is null or param.length === 0

### DIFF
--- a/src/ruleset/v2/functions/channelParameters.ts
+++ b/src/ruleset/v2/functions/channelParameters.ts
@@ -22,7 +22,15 @@ export const channelParameters = createRulesetFunction<{ parameters: Record<stri
     const results: IFunctionResult[] = [];
 
     const parameters = parseUrlVariables(path);
-    if (parameters.length === 0) return;
+    
+    const hasParameters = Object.keys(targetVal.parameters).length > 0;
+    if (hasParameters && (path === null || parameters.length === 0)) {
+      results.push({
+        message: `Channel has parameters defined, but the address is null or does not contain any parameters.`,
+        path: ctx.path.slice(0, -1),
+      });
+      return results;
+    }
 
     const missingParameters = getMissingProps(parameters, targetVal.parameters);
     if (missingParameters.length) {

--- a/test/ruleset/rules/v2/asyncapi2-channel-parameters.spec.ts
+++ b/test/ruleset/rules/v2/asyncapi2-channel-parameters.spec.ts
@@ -17,6 +17,25 @@ testRule('asyncapi2-channel-parameters', [
   },
 
   {
+    name: 'address has no parameters but parameters are defined',
+    document: {
+      asyncapi: '2.0.0',
+      channels: {
+        'users/signedUp': {
+          parameters: {
+            test: {},
+          },
+        },
+      },
+    },
+    errors: [{
+      message: 'Channel has parameters defined, but the address is null or does not contain any parameters',
+      path: ['channels', 'users/signedUp'],
+      severity: DiagnosticSeverity.Error,
+    },],
+  },
+
+  {
     name: 'channel has not defined definition for one of the parameters',
     document: {
       asyncapi: '2.0.0',


### PR DESCRIPTION


**Description**

Now when there is `parameter` but the address not contain any, then it will throw  an error

**Related issue(s)**
Fixes #875 