### PR TITLE
fix: remove v2 Spectral schema rules from v3 rules

### DIFF
--- a/src/ruleset/v2/ruleset.ts
+++ b/src/ruleset/v2/ruleset.ts
@@ -192,6 +192,7 @@ export const v2CoreRuleset = {
 export const v2SchemasRuleset = (parser: Parser) => {
   return {
     description: 'Schemas AsyncAPI 2.x.x ruleset.',
+    formats: AsyncAPIFormats.filterByMajorVersions(['2']).formats(),
     rules: {
       'asyncapi2-schemas': asyncApi2SchemaParserRule(parser),
       'asyncapi2-schema-default': {

--- a/test/validate.spec.ts
+++ b/test/validate.spec.ts
@@ -1,3 +1,4 @@
+import { AsyncAPIDocument } from '../src/models/v3/asyncapi';
 import { Parser } from '../src/parser';
 import { hasErrorDiagnostic, hasWarningDiagnostic } from '../src/utils';
 
@@ -91,7 +92,7 @@ describe('validate()', function() {
       }
     };
     const { document, diagnostics } = await parser.parse(documentRaw, { validateOptions: { allowedSeverity: { warning: false } } });
-    console.log(diagnostics);
     expect(diagnostics).toHaveLength(0);
+    expect(document).toBeInstanceOf(AsyncAPIDocument);
   });
 });


### PR DESCRIPTION
**Description**
The workflow that [validates examples](https://github.com/asyncapi/spec/blob/master/.github/workflows/validate-examples.yml) in the Spec repo is failing due to the [following reason](https://github.com/asyncapi/spec/actions/runs/9481679937/job/26125504690#step:5:46):

> examples/adeo-kafka-request-reply-asyncapi.yml
Error:  217:11  error  asyncapi2-schema-examples  "0" property type must be string  components.schemas.RequesterCode.examples[0]
Error:  244:11  error  asyncapi2-schema-examples  "0" property type must be string  components.schemas.BuCode.examples[0]

Besides the example is ok or not, that rule should not apply to any v3 document because it is not a valid v3 rule (target paths inside the rule are exclusive for v2). I believe I missed this one when filtering rules for v3 in the past.

This PR filters such a rule to only v2 documents. 


**Related issue(s)**
https://github.com/asyncapi/spec/actions/runs/9481679937/job/26125504690#step:5:46