### PR TITLE
chore(deps): bump node-fetch to 2.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12318,6 +12318,25 @@
         "undici-types": "~5.26.4"
       }
     },
+    "packages/parser/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "packages/parser/node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",


### PR DESCRIPTION
**Description**

- Use 2.7.0+ version of node-fetch that fixes bug with NodeJS20, see issue for more details

**Related issue(s)**

fixes #1047