### PR TITLE
chore(deps): bump jsonpath-plus to ^10.0.0 to mitigate CVE-2024-21534

### DIFF
--- a/.changeset/new-ears-clap.md
+++ b/.changeset/new-ears-clap.md
@@ -1,0 +1,6 @@
+---
+"@asyncapi/multi-parser": minor
+"@asyncapi/parser": minor
+---
+
+Updating jsonpath-plus dependency to mitigate CVE-2024-21534

--- a/package-lock.json
+++ b/package-lock.json
@@ -1271,6 +1271,18 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.2.1.tgz",
+      "integrity": "sha512-gaHqbubTi29aZpVbBlECRpmdia+L5/lh2BwtIJTmtxdbecEyyX/ejAOg7eQDGNvGOUmPY7Z2Yxdy9ioyH/VJeA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
     "node_modules/@jsep-plugin/regex": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.3.tgz",
@@ -12219,7 +12231,7 @@
     },
     "packages/parser": {
       "name": "@asyncapi/parser",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/specs": "^6.8.0",
@@ -12239,7 +12251,7 @@
         "ajv-formats": "^2.1.1",
         "avsc": "^5.7.5",
         "js-yaml": "^4.1.0",
-        "jsonpath-plus": "^7.2.0",
+        "jsonpath-plus": "^10.0.0",
         "node-fetch": "2.6.7"
       },
       "devDependencies": {
@@ -12279,6 +12291,24 @@
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "packages/parser/node_modules/jsonpath-plus": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.0.0.tgz",
+      "integrity": "sha512-v7j76HGp/ibKlXYeZ7UrfCLSNDaBWuJMA0GaMjA4sZJtCtY89qgPyToDDcl2zdeHh4B5q/B3g2pQdW76fOg/dA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.2.1",
+        "@jsep-plugin/regex": "^1.0.3",
+        "jsep": "^1.3.9"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "packages/parser/node_modules/undici-types": {

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -59,7 +59,7 @@
     "ajv-formats": "^2.1.1",
     "avsc": "^5.7.5",
     "js-yaml": "^4.1.0",
-    "jsonpath-plus": "^7.2.0",
+    "jsonpath-plus": "^10.0.0",
     "node-fetch": "2.6.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Builds upon https://github.com/asyncapi/parser-js/pull/1056 by adding the needed changeset file so that a new minor version can be released.