### PR TITLE
fix: reply id not accessible

### DIFF
--- a/packages/parser/src/models/v3/operation-reply.ts
+++ b/packages/parser/src/models/v3/operation-reply.ts
@@ -14,7 +14,7 @@ import type { v3 } from '../../spec-types';
 
 export class OperationReply extends BaseModel<v3.OperationReplyObject, { id?: string }> implements OperationReplyInterface {
   id(): string | undefined {
-    return this._meta.id;
+    return this._json.id;
   }
 
   hasAddress(): boolean {

--- a/packages/parser/test/models/v3/operation-reply.spec.ts
+++ b/packages/parser/test/models/v3/operation-reply.spec.ts
@@ -9,7 +9,7 @@ import { assertExtensions } from './utils';
 describe('OperationReply model', function() {
   describe('.id()', function() {
     it('should return id', function() {
-      const d = new OperationReply({}, { asyncapi: {} as any, pointer: '', id: 'reply' });
+      const d = new OperationReply({id: 'reply'}, { asyncapi: {} as any, pointer: '' });
       expect(d.id()).toEqual('reply');
     });
   });


### PR DESCRIPTION
**Description**
The reply.id is not part of meta but the underlying json variable.