### PR TITLE
chore: add dependency on building `@asyncapi/parser` for `turbo run test`

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "pipeline": {
-   "test": {"cache": false},
+   "test": {"cache": false, "dependsOn": ["@asyncapi/parser#build"]},
    "prepublishOnly": {"cache": false},
    "test:unit": {"cache": false},
    "test:integration": {"cache": false},


### PR DESCRIPTION
This PR instructs `turbo` to wait for the build of `@asyncapi/parser` before executing `turbo run test`.