### PR TITLE
Revert "chore: add dependency on building `@asyncapi/parser` for `turbo run test`"

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "pipeline": {
-   "test": {"cache": false, "dependsOn": ["@asyncapi/parser#build"]},
+   "test": {"cache": false},
    "prepublishOnly": {"cache": false},
    "test:unit": {"cache": false},
    "test:integration": {"cache": false},


### PR DESCRIPTION
Reverts asyncapi/parser-js#1078

It's making CI to hang in an infinite loop. See https://github.com/asyncapi/parser-js/actions/runs/13070259740/job/36470125554

cc @aeworxet 