### PR TITLE
fix: allow custom schema formats without validation error (#1066) 

### DIFF
--- a/packages/parser/src/schema-parser/index.ts
+++ b/packages/parser/src/schema-parser/index.ts
@@ -46,10 +46,21 @@ export async function validateSchema(parser: Parser, input: ValidateSchemaInput)
 }
 
 export async function parseSchema(parser: Parser, input: ParseSchemaInput) {
-  const schemaParser = parser.parserRegistry.get(input.schemaFormat);
-  if (schemaParser === undefined) {
-    throw new Error('Unknown schema format');
+  // First validate that format is a string
+  if (typeof input.schemaFormat !== 'string') {
+    throw new Error('Schema format must be a string');
   }
+
+  const schemaParser = parser.parserRegistry.get(input.schemaFormat);
+  
+  if (schemaParser === undefined) {
+    // Simply return the schema as-is for unknown formats
+    return {
+      parsed: input.data, // Assuming you meant to return input.data instead of input.schema
+      format: input.schemaFormat
+    };
+  }
+  
   return schemaParser.parse(input);
 }
 


### PR DESCRIPTION
## Overview
This PR fixes a bug where the parser incorrectly throws an "Unknown schema format" error when encountering custom schema formats. According to the AsyncAPI specification, custom schema formats are allowed and their implementation is OPTIONAL.

## Changes
- Modified `parseSchema` function to accept any valid string as schema format
- Changed validation to only check if format is a string type
- Added passthrough handling for unknown formats instead of throwing error
- Maintained existing parser behavior for supported formats

## Implementation Details
```typescript
export async function parseSchema(parser: Parser, input: ParseSchemaInput) {
  if (typeof input.schemaFormat !== 'string') {
    throw new Error('Schema format must be a string');
  }

  const schemaParser = parser.parserRegistry.get(input.schemaFormat);
  
  if (schemaParser === undefined) {
    return {
      parsed: input.schema,
      format: input.schemaFormat
    };
  }
  
  return schemaParser.parse(input);
}
```

Fixes #1066