### PR TITLE
fix: validate channel parameters when address is empty

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1941,18 +1941,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/eslint": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.0.tgz",
-      "integrity": "sha512-gi6WQJ7cHRgZxtkQEoyHMppPjq9Kxo5Tjn2prSKDSmZrCz8TZ3jSRCeTJm+WoM+oB0WG37bRqLzaaU3q7JypGg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",

--- a/packages/parser/src/ruleset/v2/functions/channelParameters.ts
+++ b/packages/parser/src/ruleset/v2/functions/channelParameters.ts
@@ -18,10 +18,20 @@ export const channelParameters = createRulesetFunction<{ parameters: Record<stri
     options: null,
   },
   (targetVal, _, ctx) => {
-    const path = ctx.path[ctx.path.length - 1] as string;
     const results: IFunctionResult[] = [];
 
-    const parameters = parseUrlVariables(path);
+    // Channel address is the key under `channels`
+    const channelAddress = ctx.path[ctx.path.length - 1];
+
+    if (typeof channelAddress !== 'string' || channelAddress.trim().length === 0) {
+      results.push({
+        message: 'Channel address must be a non-empty string when "parameters" are provided.',
+        path: [...ctx.path],
+      });
+      return results;
+    }
+
+    const parameters = parseUrlVariables(channelAddress);
     if (parameters.length === 0) return;
 
     const missingParameters = getMissingProps(parameters, targetVal.parameters);

--- a/packages/parser/test/old-api/tag.spec.ts
+++ b/packages/parser/test/old-api/tag.spec.ts
@@ -1,4 +1,4 @@
-import { Tag } from '../../src/old-api/tag';
+import * as tag from '../../src/old-api/tag';
 import { assertDescriptionMixin, assertExtensionsMixin, assertExternalDocumentationMixin } from './mixins';
 
 describe('Tag', function() {
@@ -6,12 +6,12 @@ describe('Tag', function() {
 
   describe('name()', function() {
     it('should return a string', function() {
-      const d = new Tag(json);
+      const d = new tag.Tag(json);
       expect(d.name()).toEqual(json.name);
     });
   });
 
-  assertDescriptionMixin(Tag);
-  assertExtensionsMixin(Tag);
-  assertExternalDocumentationMixin(Tag);
+  assertDescriptionMixin(tag.Tag);
+  assertExtensionsMixin(tag.Tag);
+  assertExternalDocumentationMixin(tag.Tag);
 });

--- a/packages/parser/test/ruleset/rules/v2/asyncapi2-channel-parameters.spec.ts
+++ b/packages/parser/test/ruleset/rules/v2/asyncapi2-channel-parameters.spec.ts
@@ -86,4 +86,26 @@ testRule('asyncapi2-channel-parameters', [
       },
     ],
   },
+
+  // NEW: address is empty but parameters exist
+  {
+    name: 'invalid when channel address is empty but parameters exist',
+    document: {
+      asyncapi: '2.0.0',
+      channels: {
+        '': {
+          parameters: {
+            userId: {},
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        message: 'Channel address must be a non-empty string when "parameters" are provided.',
+        path: ['channels', ''],
+        severity: DiagnosticSeverity.Error,
+      },
+    ],
+  },
 ]);


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Hi maintainers! This PR is a small bug fix (validate channel parameters when address is empty). I didn’t add a changeset since I’m not sure if you want a release bump for this. Happy to add one if needed.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The 3rd option will not close the issue automatically after the merge. -->