### PR TITLE
feat: add Channels.filterByAddress helper

### DIFF
--- a/packages/parser/src/models/channels.ts
+++ b/packages/parser/src/models/channels.ts
@@ -4,5 +4,5 @@ import type { ChannelInterface } from './channel';
 export interface ChannelsInterface extends Collection<ChannelInterface> {
   filterBySend(): ChannelInterface[];
   filterByReceive(): ChannelInterface[];
-    filterByAddress(address: string): ChannelsInterface;
+    filterByAddress(address: string): ChannelsInterface[];
 }

--- a/packages/parser/src/models/v2/channels.ts
+++ b/packages/parser/src/models/v2/channels.ts
@@ -17,8 +17,8 @@ export class Channels extends Collection<ChannelInterface> implements ChannelsIn
     return this.filterBy(channel => channel.operations().filterByReceive().length > 0);
   }
 
-  filterByAddress(address: string): Channels {
+  filterByAddress(address: string): ChannelsInterface[] {
     const filtered = this.filterBy(channel => channel.address() === address);
-    return new Channels(filtered, this._meta);
+    return [new Channels(filtered, this._meta)];
   }
 }

--- a/packages/parser/src/models/v3/channels.ts
+++ b/packages/parser/src/models/v3/channels.ts
@@ -16,8 +16,8 @@ export class Channels extends Collection<ChannelInterface> implements ChannelsIn
     return this.filterBy(channel => channel.operations().filterByReceive().length > 0);
   }
   
-  filterByAddress(address: string): Channels {
+ filterByAddress(address: string): ChannelsInterface[] {
     const filtered = this.filterBy(channel => channel.address() === address);
-    return new Channels(filtered, this._meta);
+    return [new Channels(filtered, this._meta)];
   }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Added `filterByAddress(address: string)` helper to the Channels collection
- Returns a Channels collection  to allow chaining and consistency
- Implemented for both AsyncAPI v2 and v3
- Provides a clearer and more discoverable API for accessing channels by address
