### PR TITLE
fix: add missing title and summary fields to ServerObject (fixes #1137)

### DIFF
--- a/.changeset/server-object-fields.md
+++ b/.changeset/server-object-fields.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/parser": patch
+---
+
+fix: add missing `title` and `summary` fields to `ServerObject` type definition (AsyncAPI 3.0)

--- a/packages/parser/src/spec-types/v3.ts
+++ b/packages/parser/src/spec-types/v3.ts
@@ -44,6 +44,8 @@ export interface ServerObject extends SpecificationExtensions {
   protocol: string;
   pathname?: string;
   protocolVersion?: string;
+  title?: string;
+  summary?: string;
   description?: string;
   variables?: Record<string, ServerVariableObject | ReferenceObject>;
   security?: Array<SecuritySchemeObject | ReferenceObject>;


### PR DESCRIPTION
## Description

Closes #1137

### Problem

AsyncAPI 3.0 specification defines optional **`title`** and **`summary`** fields on the ServerObject, but these were missing from the TypeScript type definition in `v3.ts`.

### Spec Reference

https://www.asyncapi.com/docs/reference/specification/v3.0.0#serverObject

### Changes

- **packages/parser/src/spec-types/v3.ts**: Added `title?: string` and `summary?: string` to `ServerObject` interface

### Testing

- [x] Change is minimal (2 lines added)
- [x] Matches AsyncAPI 3.0 spec exactly
- [x] No runtime behavior change (type-only)