### PR TITLE
fix: allow $refs to component messages with special characters in names

### DIFF
--- a/packages/parser/src/ruleset/functions/documentStructure.ts
+++ b/packages/parser/src/ruleset/functions/documentStructure.ts
@@ -84,6 +84,25 @@ function getCopyOfSchema(version: AsyncAPIVersions): RawSchema {
   return JSON.parse(JSON.stringify(specs.schemas[version])) as RawSchema;
 }
 
+/**
+ * Removes the `format` constraint from ReferenceObject schema definitions.
+ *
+ * The ajv-formats `uri-reference` format validator rejects valid URI references
+ * containing square brackets (`[`, `]`), which are legal per RFC 3986 and RFC 6901.
+ * This causes false validation failures for $refs pointing to components whose keys
+ * contain special characters (e.g. message names from messaging systems like JMS).
+ */
+function relaxRefFormat(schema: { definitions?: RawSchema }): void {
+  for (const key of Object.keys(schema.definitions || {})) {
+    if (key.endsWith('/ReferenceObject.json')) {
+      const refObjDef = (schema.definitions as Record<string, any>)[key];
+      if (refObjDef?.format) {
+        delete refObjDef.format;
+      }
+    }
+  }
+}
+
 const serializedSchemas = new Map<AsyncAPIVersions, RawSchema>();
 function getSerializedSchema(version: AsyncAPIVersions, resolved: boolean): RawSchema {
   const serializedSchemaKey = resolved ? `${version}-resolved` : `${version}-unresolved`;
@@ -103,6 +122,14 @@ function getSerializedSchema(version: AsyncAPIVersions, resolved: boolean): RawS
   const { major } = getSemver(version);
   if (resolved && major === 3) {
     copied = prepareV3ResolvedSchema(copied, version);
+  }
+
+  // For unresolved schemas, relax the uri-reference format on $ref fields.
+  // The ajv-formats uri-reference validator incorrectly rejects valid URI
+  // references containing square brackets (e.g. message names with [, ]).
+  // See https://github.com/asyncapi/parser-js/issues/1132
+  if (!resolved) {
+    relaxRefFormat(copied);
   }
 
   serializedSchemas.set(serializedSchemaKey as AsyncAPIVersions, copied);


### PR DESCRIPTION
Fixes #1132

## Problem

The parser incorrectly rejected valid `$refs` to component messages whose names contain square brackets (e.g., JMS-style names like `test:[HandleFirst,HandleSecond]:SubscribeMessage`).

Root cause: The `ajv-formats` library's `uri-reference` format validator rejects URI references containing square brackets, even though they are legal per RFC 3986 and RFC 6901. This caused a cascade of false validation failures:
- The `$ref` value failed format validation → Reference schema rejected
- Channel/message `oneOf` validation failed → reported as "Referencing in this place is not allowed"

## Fix

In the unresolved schema validation, remove the `format` constraint from `ReferenceObject.json` definitions. The format check for `uri-reference` on `$ref` fields provides little practical benefit (Spectral's ref resolver already validates resolvability) and causes false positives for valid documents.

## How to verify

```js
const { Parser } = require("@asyncapi/parser");
const parser = new Parser();

const doc = {
  asyncapi: "3.0.0",
  info: { title: "Test", version: "1.0" },
  channels: {
    "test:[HandleFirst,HandleSecond]": {
      address: "test-queue",
      messages: {
        SubscribeMessage: {
          "$ref": "#/components/messages/test:[HandleFirst,HandleSecond]:SubscribeMessage"
        }
      }
    }
  },
  components: {
    messages: {
      "test:[HandleFirst,HandleSecond]:SubscribeMessage": {
        name: "SubscribeMessage",
        payload: { type: "object", properties: { data: { type: "string" } } }
      }
    }
  },
  operations: {}
};

const { document, diagnostics } = await parser.parse(doc);
// Before fix: diagnostics contains error "Referencing in this place is not allowed"
// After fix: document is parsed successfully, no errors
```
