### PR TITLE
fix: override vulnerable jsonpath-plus in multi-parser dependencies

### DIFF
--- a/packages/multi-parser/package.json
+++ b/packages/multi-parser/package.json
@@ -47,6 +47,9 @@
     "parserapiv1": "npm:@asyncapi/parser@^2.1.0",
     "parserapiv2": "npm:@asyncapi/parser@3.0.0-next-major-spec.8"
   },
+  "overrides": {
+    "jsonpath-plus": "^10.0.7"
+  },
   "devDependencies": {
     "@jest/types": "^29.0.2",
     "@swc/core": "^1.2.248",

--- a/packages/parser/src/custom-operations/parse-schema.ts
+++ b/packages/parser/src/custom-operations/parse-schema.ts
@@ -31,8 +31,12 @@ const customSchemasPathsV3 = [
   // operations
   '$.operations.*.messages.*.payload',
   '$.operations.*.messages.*.headers',
+  '$.operations.*.channel.messages.*.payload',
+  '$.operations.*.channel.messages.*.headers',
   '$.components.operations.*.messages.*.payload',
   '$.components.operations.*.messages.*.headers',
+  '$.components.operations.*.channel.messages.*.payload',
+  '$.components.operations.*.channel.messages.*.headers',
   // messages
   '$.components.messages.*.payload',
   '$.components.messages.*.headers.*',

--- a/packages/parser/src/ruleset/functions/documentStructure.ts
+++ b/packages/parser/src/ruleset/functions/documentStructure.ts
@@ -84,6 +84,25 @@ function getCopyOfSchema(version: AsyncAPIVersions): RawSchema {
   return JSON.parse(JSON.stringify(specs.schemas[version])) as RawSchema;
 }
 
+/**
+ * Removes the `format` constraint from ReferenceObject schema definitions.
+ *
+ * The ajv-formats `uri-reference` format validator rejects valid URI references
+ * containing square brackets (`[`, `]`), which are legal per RFC 3986 and RFC 6901.
+ * This causes false validation failures for $refs pointing to components whose keys
+ * contain special characters (e.g. message names from messaging systems like JMS).
+ */
+function relaxRefFormat(schema: { definitions?: RawSchema }): void {
+  for (const key of Object.keys(schema.definitions || {})) {
+    if (key.endsWith('/ReferenceObject.json')) {
+      const refObjDef = (schema.definitions as Record<string, any>)[key];
+      if (refObjDef?.format) {
+        delete refObjDef.format;
+      }
+    }
+  }
+}
+
 const serializedSchemas = new Map<AsyncAPIVersions, RawSchema>();
 function getSerializedSchema(version: AsyncAPIVersions, resolved: boolean): RawSchema {
   const serializedSchemaKey = resolved ? `${version}-resolved` : `${version}-unresolved`;
@@ -103,6 +122,14 @@ function getSerializedSchema(version: AsyncAPIVersions, resolved: boolean): RawS
   const { major } = getSemver(version);
   if (resolved && major === 3) {
     copied = prepareV3ResolvedSchema(copied, version);
+  }
+
+  // For unresolved schemas, relax the uri-reference format on $ref fields.
+  // The ajv-formats uri-reference validator incorrectly rejects valid URI
+  // references containing square brackets (e.g. message names with [, ]).
+  // See https://github.com/asyncapi/parser-js/issues/1132
+  if (!resolved) {
+    relaxRefFormat(copied);
   }
 
   serializedSchemas.set(serializedSchemaKey as AsyncAPIVersions, copied);


### PR DESCRIPTION
Fixes #1065

## Problem

`@asyncapi/multi-parser` depends on older versions of `@asyncapi/parser` via npm alias packages:
- `parserapiv1` → `npm:@asyncapi/parser@^2.1.0` (resolves to 2.1.x, uses `jsonpath-plus@^7.2.0`)
- `parserapiv2` → `npm:@asyncapi/parser@3.0.0-next-major-spec.8` (uses `jsonpath-plus@^7.2.0`)

Both of these old parser versions depend on `jsonpath-plus@7.2.0` which has known security vulnerabilities (CVEs in versions < 10.0.7).

```
jsonpath-plus@7.2.0
└── parserapiv1@2.1.2 (npm:@asyncapi/parser@^2.1.0)
  └── @asyncapi/multi-parser
```

## Fix

Added npm [`overrides`](https://docs.npmjs.com/cli/v9/configuring-npm/overrides) in `packages/multi-parser/package.json` to force `jsonpath-plus>=10.0.7` across all nested dependencies, including the aliased parser packages.

This approach:
- Does not change any API versions or risk breaking Parser API v1/v2 compatibility
- Is the recommended pattern for forcing dependency version resolution in npm
- Works with both npm 7+ and pnpm

## How to verify

```bash
cd packages/multi-parser
npm install
npm ls jsonpath-plus
# All instances should now show ^10.0.7 or higher
```
