### PR TITLE
fix(parser): add missing title and summary fields to v3 ServerObject

### DIFF
--- a/packages/parser/src/spec-types/v3.ts
+++ b/packages/parser/src/spec-types/v3.ts
@@ -44,6 +44,8 @@ export interface ServerObject extends SpecificationExtensions {
   protocol: string;
   pathname?: string;
   protocolVersion?: string;
+  title?: string;
+  summary?: string;
   description?: string;
   variables?: Record<string, ServerVariableObject | ReferenceObject>;
   security?: Array<SecuritySchemeObject | ReferenceObject>;


### PR DESCRIPTION
## Problem

The AsyncAPI **3.0.0 specification** defines optional `title` and `summary` fields on the [Server Object](https://www.asyncapi.com/docs/reference/specification/v3.0.0#serverObject), but these fields were missing from the TypeScript type definition in `packages/parser/src/spec-types/v3.ts`.

This means users cannot properly type server objects that include these standard fields.

## Solution

Add `title?: string` and `summary?: string` to the `ServerObject` interface in v3.ts, matching the official specification.

## Changes

- `packages/parser/src/spec-types/v3.ts`: Added 2 optional string fields to `ServerObject`
  - `title?: string;`
  - `summary?: string;`

Fixes #1138