### PR TITLE
fix(types): add missing title and summary fields to v3 ServerObject (#1137)

### DIFF
--- a/packages/parser/src/spec-types/v3.ts
+++ b/packages/parser/src/spec-types/v3.ts
@@ -42,6 +42,8 @@ export type ServersObject = Record<string, ServerObject | ReferenceObject>;
 export interface ServerObject extends SpecificationExtensions {
   host: string;
   protocol: string;
+  title?: string;
+  summary?: string;
   pathname?: string;
   protocolVersion?: string;
   description?: string;


### PR DESCRIPTION
## Problem

**Fixes #1137**

The `ServerObject` type in `spec-types/v3.ts` is missing the optional `title` and `summary` fields defined in the [AsyncAPI 3.0.0 specification](https://www.asyncapi.com/docs/reference/specification/v3.0.0#serverObject).

This causes TypeScript type errors when parsing valid AsyncAPI 3.0 documents that include these fields.

## Fix

Add two optional string fields to the `ServerObject` interface:

```typescript
export interface ServerObject extends SpecificationExtensions {
  host: string;
  protocol: string;
+ title?: string;
+ summary?: string;
  pathname?: string;
  ...
}
```

Note: Other v3 objects like `ChannelObject`, `OperationObject`, and `InfoObject` already have these fields — only `ServerObject` was missing them.

## Testing

Local tests cannot run due to an environment issue (Node/Jest compatibility) — confirmed that the same test failure occurs on the unmodified `master` branch.