### PR TITLE
fix: handle message bindings with $ref and return diagnostics for non-Error failures

### DIFF
--- a/packages/parser/src/models/v3/mixins.ts
+++ b/packages/parser/src/models/v3/mixins.ts
@@ -82,8 +82,12 @@ export abstract class CoreModel<J extends CoreObject = CoreObject, M extends Rec
 
 export function bindings(model: BaseModel<{ bindings?: BindingsObject }>): BindingsInterface {
   const bindings = model.json('bindings') || {};
+  // Filter out $ref entries (ReferenceObject) - they should not be treated as protocol bindings
+  // When bindings is a ReferenceObject like { $ref: '#/components/messageBindings/myBindings' },
+  // the $ref key should not be processed as a protocol name (fixes #877)
+  const bindingEntries = Object.entries(bindings || {}).filter(([key]) => !key.startsWith('$'));
   return new Bindings(
-    Object.entries(bindings || {}).map(([protocol, binding]) => 
+    bindingEntries.map(([protocol, binding]) => 
       createModel(Binding, binding, { protocol, pointer: model.jsonPath(`bindings/${protocol}`) }, model)
     ),
     { originalData: bindings as Record<string, Binding>, asyncapi: model.meta('asyncapi'), pointer: model.jsonPath('bindings') }

--- a/packages/parser/src/utils.ts
+++ b/packages/parser/src/utils.ts
@@ -95,20 +95,33 @@ export function toJSONPathArray(jsonPath: string): Array<string | number> {
 }
 
 export function createUncaghtDiagnostic(err: unknown, message: string, document?: Document): Diagnostic[] {
-  if (!(err instanceof Error)) {
-    return [];
+  const range: Diagnostic['range'] = document ? document.getRangeForJsonPath([]) as Diagnostic['range'] : Document.DEFAULT_RANGE;
+  
+  // Handle Error instances (fixes #878 - parser returning undefined for invalid docs)
+  if (err instanceof Error) {
+    return [
+      {
+        code: 'uncaught-error',
+        message: `${message}. Name: ${err.name}, message: ${err.message}, stack: ${err.stack}`,
+        path: [],
+        severity: DiagnosticSeverity.Error,
+        range,
+      }
+    ];
   }
   
-  const range: Diagnostic['range'] = document ? document.getRangeForJsonPath([]) as Diagnostic['range'] : Document.DEFAULT_RANGE;
+  // Handle non-Error values (string, object, null, undefined, etc.)
+  // Previously these were silently ignored, causing the parser to return undefined
+  const errString = err === null ? 'null' : err === undefined ? 'undefined' : String(err);
   return [
     {
       code: 'uncaught-error',
-      message: `${message}. Name: ${err.name}, message: ${err.message}, stack: ${err.stack}`,
+      message: `${message}. Non-Error value: ${errString}`,
       path: [],
       severity: DiagnosticSeverity.Error,
       range,
     }
-  ];  
+  ];
 }
 export function tilde(str: string) {
   return str.replace(/[~/]{1}/g, (sub) => {


### PR DESCRIPTION
Fixes #877 and #878

## Issue #877: Parser returns undefined when there's bindings in message

When an AsyncAPI v3 file has message bindings that include a `$ref`, the parser crashes or returns `undefined` because the `bindings()` function in `v3/mixins.ts` iterates over all entries of the bindings object, including the `$ref` key, treating it as a protocol name.

**Fix:** Filter out keys starting with `$` (like `$ref`) before processing binding entries.

## Issue #878: Parser fails to throw an error when provided invalid AsyncAPI file

When the parser encounters an invalid AsyncAPI document, internal errors that are not `Error` instances (e.g., strings, null, undefined) are silently swallowed by `createUncaghtDiagnostic()`, causing the parser to return `undefined` instead of meaningful diagnostics.

**Fix:** Handle non-Error values in `createUncaghtDiagnostic()` by converting them to string diagnostic messages, ensuring the parser always returns diagnostic information.

## Changes
- `packages/parser/src/models/v3/mixins.ts`: Filter out `$ref` entries in `bindings()` function
- `packages/parser/src/utils.ts`: Handle non-Error values in `createUncaghtDiagnostic()`

This PR is part of the [MICROGRANT Program 2026-06 #1167](https://github.com/asyncapi/parser-js/issues/1167).