### PR TITLE
fix: parse payload and headers of messages defined in operation.channel with non-default parsers

### DIFF
--- a/packages/parser/src/custom-operations/parse-schema.ts
+++ b/packages/parser/src/custom-operations/parse-schema.ts
@@ -31,6 +31,8 @@ const customSchemasPathsV3 = [
   // operations
   '$.operations.*.messages.*.payload',
   '$.operations.*.messages.*.headers',
+  '$.operations.*.channel.messages.*.payload',
+  '$.operations.*.channel.messages.*.headers',
   '$.components.operations.*.messages.*.payload',
   '$.components.operations.*.messages.*.headers',
   // messages

--- a/packages/parser/test/custom-operations/parse-schema-v3.spec.ts
+++ b/packages/parser/test/custom-operations/parse-schema-v3.spec.ts
@@ -1,6 +1,7 @@
 import { AsyncAPIDocumentV3 } from '../../src/models';
 import { Parser } from '../../src/parser';
 import { filterLastVersionDiagnostics } from '../utils';
+import { AvroSchemaParser } from '@asyncapi/avro-schema-parser';
 
 import type { v3 } from '../../src/spec-types';
 
@@ -132,5 +133,62 @@ describe('custom operations for v3 - parse schemas', function() {
     
     expect(document).toBeUndefined();
     expect(diagnostics.length > 0).toEqual(true);
+  });
+
+  it('should parse message schemas defined in operation.channel with non-default schema parsers', async function() {
+    const parserWithAvroSchemaParser = new Parser();
+    parserWithAvroSchemaParser.registerSchemaParser(AvroSchemaParser());
+
+    const documentRaw = {
+      asyncapi: '3.1.0',
+      info: {
+        title: 'Valid AsyncApi document',
+        version: '1.0.0'
+      },
+      operations: {
+        operation: {
+          action: 'send',
+          channel: {
+            messages: {
+              message: {
+                payload: {
+                  schemaFormat: 'application/vnd.apache.avro;version=1.9.0',
+                  schema: {
+                    type: 'record',
+                    name: 'payload',
+                    fields: [
+                      {
+                        name: 'payloadField',
+                        type: 'string'
+                      }
+                    ]
+                  }
+                },
+                headers: {
+                  schemaFormat: 'application/vnd.apache.avro;version=1.9.0',
+                  schema: {
+                    type: 'record',
+                    name: 'header',
+                    fields: [
+                      {
+                        name: 'headerField',
+                        type: 'string'
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+    const { document, diagnostics } = await parserWithAvroSchemaParser.parse(documentRaw);
+
+    expect(document).toBeInstanceOf(AsyncAPIDocumentV3);
+    expect(diagnostics.length === 0).toEqual(true);
+
+    expect(((((document?.json() as any).operations?.operation as v3.OperationObject).channel as v3.ChannelObject)?.messages?.message as v3.MessageObject)?.payload?.schema).toEqual({ type: 'object', required: ['payloadField'], properties: { payloadField: { type: 'string' } }, 'x-parser-schema-id': 'payload',  });
+    expect((((((document?.json() as any).operations?.operation as v3.OperationObject).channel as v3.ChannelObject)?.messages?.message as v3.MessageObject)?.headers as v3.MultiFormatObject)?.schema).toEqual({ type: 'object', required: ['headerField'], properties: { headerField: { type: 'string' } }, 'x-parser-schema-id': 'header',  });
   });
 });


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
Fixes an issue where non-default parsers did not parse payload and headers schemas if the message containing them was defined only under operation.channel. This affected resolved definitions that inline resolved objects and caused the `@asyncapi/react-component` not to render these fields.

Before:
<img width="919" height="432" alt="async-before-fix" src="https://github.com/user-attachments/assets/92be460b-39a4-4338-83a7-62f256ab0a06" />


After:
<img width="965" height="719" alt="async-after-fix" src="https://github.com/user-attachments/assets/77cafebf-3e54-4995-a2bf-8669c1277dd8" />




**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The 3rd option will not close the issue automatically after the merge. -->
Fixes https://github.com/asyncapi/parser-js/issues/1099