### PR TITLE
fix: add missing title and summary fields to ServerObject type

### DIFF
--- a/.changeset/fix-server-object-missing-title-summary-1137.md
+++ b/.changeset/fix-server-object-missing-title-summary-1137.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/parser": patch
+---
+
+fix: add missing `title` and `summary` fields to ServerObject in v3 spec types to align with the AsyncAPI 3.x specification.

--- a/packages/parser/src/spec-types/v3.ts
+++ b/packages/parser/src/spec-types/v3.ts
@@ -44,6 +44,8 @@ export interface ServerObject extends SpecificationExtensions {
   protocol: string;
   pathname?: string;
   protocolVersion?: string;
+  title?: string;
+  summary?: string;
   description?: string;
   variables?: Record<string, ServerVariableObject | ReferenceObject>;
   security?: Array<SecuritySchemeObject | ReferenceObject>;


### PR DESCRIPTION
## Description

The AsyncAPI 3.0 specification defines `title` and `summary` as optional fields in the [ServerObject](https://www.asyncapi.com/docs/reference/specification/v3.0.0#serverObject), but the parser-js TypeScript type definition was missing these fields.

## Changes

- Added `title?: string` field to `ServerObject` in `packages/parser/src/spec-types/v3.ts`
- Added `summary?: string` field to `ServerObject` in `packages/parser/src/spec-types/v3.ts`

## Related Issue

Fixes #1137

## Reference

Per the [AsyncAPI 3.0.0 Specification - Server Object](https://www.asyncapi.com/docs/reference/specification/v3.0.0#serverObject):

| Field Name | Type | Description |
|---|---|---|
| title | string | A human-friendly title for the server. |
| summary | string | A short summary of what the server is. |

## Testing

- This is a backward-compatible change (adding optional fields)
- No existing code is affected
- The new fields align with the AsyncAPI 3.0 specification

## MICROGRANT

This PR resolves issue #1137 which is part of the [MICROGRANT Program 2026-06](https://github.com/asyncapi/parser-js/issues/1167).