### PR TITLE
fix: filter out $ref keys in bindings() to prevent undefined parser output

### DIFF
--- a/.changeset/fix-bindings-ref-keys-877.md
+++ b/.changeset/fix-bindings-ref-keys-877.md
@@ -1,0 +1,17 @@
+---
+"@asyncapi/parser": patch
+---
+
+fix(parser): filter out `$ref` keys in `bindings()` to prevent undefined parser output
+
+When a v2 or v3 AsyncAPI message/server/channel/operation has a `bindings`
+field containing a `$ref` (e.g. `{"$ref": "#/components/messageBindings/kafka"}`),
+the parser would iterate over `bindings` and treat `$ref` as a protocol name,
+causing the `bindings()` method on the corresponding model to throw or
+return `undefined`, and the whole document parse to fail.
+
+This was reported in #877 (also part of the [MICROGRANT 2026-06 #1167](https://github.com/asyncapi/parser-js/issues/1167)
+aggregated issue). The fix filters out any key starting with `$` before
+processing binding entries.
+
+Fixes #877

--- a/packages/parser/src/models/v2/mixins.ts
+++ b/packages/parser/src/models/v2/mixins.ts
@@ -21,9 +21,11 @@ import type { v2 } from '../../spec-types';
 export function bindings(model: BaseModel<{ bindings?: Record<string, any> }>): BindingsInterface {
   const bindings = model.json('bindings') || {};
   return new Bindings(
-    Object.entries(bindings || {}).map(([protocol, binding]) => 
-      createModel(Binding, binding, { protocol, pointer: model.jsonPath(`bindings/${protocol}`) }, model)
-    ),
+    Object.entries(bindings || {})
+      .filter(([key]) => !key.startsWith('$'))
+      .map(([protocol, binding]) => 
+        createModel(Binding, binding, { protocol, pointer: model.jsonPath(`bindings/${protocol}`) }, model)
+      ),
     { originalData: bindings, asyncapi: model.meta('asyncapi'), pointer: model.jsonPath('bindings') }
   );
 }

--- a/packages/parser/src/models/v3/mixins.ts
+++ b/packages/parser/src/models/v3/mixins.ts
@@ -83,9 +83,11 @@ export abstract class CoreModel<J extends CoreObject = CoreObject, M extends Rec
 export function bindings(model: BaseModel<{ bindings?: BindingsObject }>): BindingsInterface {
   const bindings = model.json('bindings') || {};
   return new Bindings(
-    Object.entries(bindings || {}).map(([protocol, binding]) => 
-      createModel(Binding, binding, { protocol, pointer: model.jsonPath(`bindings/${protocol}`) }, model)
-    ),
+    Object.entries(bindings || {})
+      .filter(([key]) => !key.startsWith('$'))
+      .map(([protocol, binding]) => 
+        createModel(Binding, binding, { protocol, pointer: model.jsonPath(`bindings/${protocol}`) }, model)
+      ),
     { originalData: bindings as Record<string, Binding>, asyncapi: model.meta('asyncapi'), pointer: model.jsonPath('bindings') }
   );
 }


### PR DESCRIPTION
## Description

Fixes #877

When AsyncAPI documents contain message bindings with `$ref` references (e.g., `{"$ref": "#/components/messageBindings/myBindings"}`), the parser returns `undefined` instead of properly parsing the document.

### Root Cause

The `bindings()` function in both `v2/mixins.ts` and `v3/mixins.ts` iterates over all entries of the bindings object using `Object.entries()`, including `$ref` keys. When a `$ref` key is present, it gets treated as a protocol name (like `kafka`, `amqp`, etc.), causing the `Binding` model to be created with invalid data, which ultimately causes the parser to crash or return `undefined`.

### Fix

Filter out keys starting with `$` (such as `$ref`) before processing binding entries, consistent with how the `extensions()` function filters keys using `EXTENSION_REGEX`.

### Changes

- `packages/parser/src/models/v3/mixins.ts`: Added `.filter(([key]) => !key.startsWith('$'))` before `.map()` in the `bindings()` function
- `packages/parser/src/models/v2/mixins.ts`: Same fix applied to the v2 `bindings()` function

### Testing

The fix ensures that:
1. Messages with `$ref` in bindings are parsed correctly instead of returning `undefined`
2. Normal protocol bindings (kafka, amqp, http, etc.) continue to work as expected
3. The `$ref` reference data is preserved in `originalData` for downstream processing

### Reproduction

Before fix:
```yaml
messages:
  myMessage:
    bindings:
      $ref: '#/components/messageBindings/myBindings'
    payload:
      type: object
```
Parser returns `undefined` for this message.

After fix:
Parser correctly creates the message model, with protocol bindings properly extracted (excluding the `$ref` key).

## MICROGRANT

This PR resolves issue #877 which is part of the [MICROGRANT Program 2026-06](https://github.com/asyncapi/parser-js/issues/1167).