### PR TITLE
feat(parser): add title() method to v3 Channel model

### DIFF
--- a/.changeset/feat-channel-title-1067.md
+++ b/.changeset/feat-channel-title-1067.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/parser": minor
+---
+
+feat(parser): add `title()` method to v3 Channel model so users can read the channel's title field from the parser API, matching the corresponding v3 spec field.

--- a/packages/parser/src/models/channel.ts
+++ b/packages/parser/src/models/channel.ts
@@ -8,6 +8,7 @@ import type { ServersInterface } from './servers';
 export interface ChannelInterface extends BaseModel, BindingsMixinInterface, DescriptionMixinInterface, ExtensionsMixinInterface {
   id(): string;
   address(): string | null | undefined;
+  title?(): string | undefined;
   servers(): ServersInterface;
   operations(): OperationsInterface;
   messages(): MessagesInterface;

--- a/packages/parser/src/models/v3/channel.ts
+++ b/packages/parser/src/models/v3/channel.ts
@@ -26,6 +26,10 @@ export class Channel extends CoreModel<v3.ChannelObject, { id: string }> impleme
     return this._json.address;
   }
 
+  title(): string | undefined {
+    return this._json.title;
+  }
+
   servers(): ServersInterface {
     const servers: ServerInterface[] = [];
     const allowedServers = this._json.servers ?? [];

--- a/packages/parser/test/models/v3/channel.spec.ts
+++ b/packages/parser/test/models/v3/channel.spec.ts
@@ -29,6 +29,20 @@ describe('Channel model', function() {
     });
   });
 
+  describe('.title()', function() {
+    it('should return the value', function() {
+      const doc = serializeInput<v3.ChannelObject>({ title: 'User Signup Channel' });
+      const d = new Channel(doc, { asyncapi: {} as any, pointer: '', id: 'channel' });
+      expect(d.title()).toEqual('User Signup Channel');
+    });
+
+    it('should return undefined when title is not set', function() {
+      const doc = serializeInput<v3.ChannelObject>({});
+      const d = new Channel(doc, { asyncapi: {} as any, pointer: '', id: 'channel' });
+      expect(d.title()).toBeUndefined();
+    });
+  });
+
   describe('.servers()', function() {
     it('should return collection of servers - available on all servers', function() {
       const doc = serializeInput<v3.ChannelObject>({});


### PR DESCRIPTION
## What
Adds a `title()` method to the v3 `Channel` model so consumers can read the `title` field from a channel object.

## Why
The AsyncAPI 3.0 spec defines `title` as an optional field on `ChannelObject` (and the parser already has it on the TypeScript type), but the `Channel` model had no accessor. Closing this gap so the parser exposes all the fields the spec allows.

Fixes #1067

## Changes
- **`packages/parser/src/models/channel.ts`**: Added optional `title?(): string | undefined` to the `ChannelInterface` (so v3 implements it, v2 doesn't have to).
- **`packages/parser/src/models/v3/channel.ts`**: Implemented `title()` returning `this._json.title`.
- **`packages/parser/test/models/v3/channel.spec.ts`**: Two tests — one verifies the value, one verifies `undefined` when unset.

3 files changed, 19 insertions. Follows the existing minimal pattern used by `address()`.