### PR TITLE
fix(parser): trigger custom parsers on operation.channel.messages.*.payload

### DIFF
--- a/packages/parser/src/custom-operations/parse-schema.ts
+++ b/packages/parser/src/custom-operations/parse-schema.ts
@@ -33,6 +33,11 @@ const customSchemasPathsV3 = [
   '$.operations.*.messages.*.headers',
   '$.components.operations.*.messages.*.payload',
   '$.components.operations.*.messages.*.headers',
+  // operations -> channel (which may $ref an external file) -> messages
+  '$.operations.*.channel.messages.*.payload',
+  '$.operations.*.channel.messages.*.headers',
+  '$.components.operations.*.channel.messages.*.payload',
+  '$.components.operations.*.channel.messages.*.headers',
   // messages
   '$.components.messages.*.payload',
   '$.components.messages.*.headers.*',

--- a/packages/parser/src/models/channel.ts
+++ b/packages/parser/src/models/channel.ts
@@ -8,6 +8,7 @@ import type { ServersInterface } from './servers';
 export interface ChannelInterface extends BaseModel, BindingsMixinInterface, DescriptionMixinInterface, ExtensionsMixinInterface {
   id(): string;
   address(): string | null | undefined;
+  title?(): string | undefined;
   servers(): ServersInterface;
   operations(): OperationsInterface;
   messages(): MessagesInterface;

--- a/packages/parser/src/models/v3/channel.ts
+++ b/packages/parser/src/models/v3/channel.ts
@@ -26,6 +26,10 @@ export class Channel extends CoreModel<v3.ChannelObject, { id: string }> impleme
     return this._json.address;
   }
 
+  title(): string | undefined {
+    return this._json.title;
+  }
+
   servers(): ServersInterface {
     const servers: ServerInterface[] = [];
     const allowedServers = this._json.servers ?? [];

--- a/packages/parser/src/ruleset/v3/functions/channelParameters.ts
+++ b/packages/parser/src/ruleset/v3/functions/channelParameters.ts
@@ -1,0 +1,61 @@
+import { createRulesetFunction } from '@stoplight/spectral-core';
+
+import { getMissingProps, getRedundantProps, parseUrlVariables } from '../../utils';
+
+import type { IFunctionResult } from '@stoplight/spectral-core';
+
+export const v3ChannelParameters = createRulesetFunction<{ address?: string | null; parameters?: Record<string, unknown> }, null>(
+  {
+    input: {
+      type: 'object',
+      properties: {
+        address: {
+          type: ['string', 'null'],
+        },
+        parameters: {
+          type: 'object',
+        },
+      },
+    },
+    options: null,
+  },
+  (targetVal, _, ctx) => {
+    const results: IFunctionResult[] = [];
+
+    const address = targetVal.address;
+    const parameters = targetVal.parameters;
+
+    // If parameters is provided but address has no template variables (or is null/empty), it's redundant.
+    if (parameters && Object.keys(parameters).length > 0) {
+      const variables = address ? parseUrlVariables(address) : [];
+      if (variables.length === 0) {
+        results.push({
+          message: 'Channel\'s "parameters" object is defined but "address" does not contain any parameter placeholders, or "address" is null/empty. The "parameters" object is redundant.',
+          path: [...ctx.path, 'parameters'],
+        });
+        return results;
+      }
+
+      // If address has variables, check that all are defined and there are no redundant parameters.
+      const missingParameters = getMissingProps(variables, parameters);
+      if (missingParameters.length) {
+        results.push({
+          message: `Not all channel's parameters are described with "parameters" object. Missed: ${missingParameters.join(', ')}.`,
+          path: [...ctx.path, 'parameters'],
+        });
+      }
+
+      const redundantParameters = getRedundantProps(variables, parameters);
+      if (redundantParameters.length) {
+        redundantParameters.forEach(param => {
+          results.push({
+            message: `Channel's "parameters" object has redundant defined "${param}" parameter.`,
+            path: [...ctx.path, 'parameters', param],
+          });
+        });
+      }
+    }
+
+    return results;
+  },
+);

--- a/packages/parser/src/ruleset/v3/ruleset.ts
+++ b/packages/parser/src/ruleset/v3/ruleset.ts
@@ -1,8 +1,8 @@
-
 /* eslint-disable sonarjs/no-duplicate-string */
 
 import { AsyncAPIFormats } from '../formats';
 import { operationMessagesUnambiguity } from './functions/operationMessagesUnambiguity';
+import { v3ChannelParameters } from './functions/channelParameters';
 import { pattern } from '@stoplight/spectral-functions';
 import { channelServers } from '../functions/channelServers';
 
@@ -32,7 +32,7 @@ export const v3CoreRuleset = {
       severity: 'error',
       recommended: true,
       resolved: false, // We use the JSON pointer to match the channel.
-      given: '$.operations.*',      
+      given: '$.operations.*',
       then: {
         field: 'channel.$ref',
         function: pattern,
@@ -41,7 +41,7 @@ export const v3CoreRuleset = {
         },
       },
     },
-    
+
     /**
      * Channel Object rules
      */
@@ -50,7 +50,7 @@ export const v3CoreRuleset = {
       severity: 'error',
       recommended: true,
       resolved: false, // We use the JSON pointer to match the channel.
-      given: '$.channels.*',      
+      given: '$.channels.*',
       then: {
         field: '$.servers.*.$ref',
         function: pattern,
@@ -80,6 +80,19 @@ export const v3CoreRuleset = {
         functionOptions: {
           notMatch: '[\\?#]',
         },
+      },
+    },
+    'asyncapi3-channel-parameters': {
+      description: 'Channel parameters must be defined and there must be no redundant parameters.',
+      message: '{{error}}',
+      severity: 'error',
+      recommended: true,
+      given: [
+        '$.channels.*',
+        '$.components.channels.*',
+      ],
+      then: {
+        function: v3ChannelParameters,
       },
     },
   },

--- a/packages/parser/test/models/v3/channel.spec.ts
+++ b/packages/parser/test/models/v3/channel.spec.ts
@@ -29,6 +29,20 @@ describe('Channel model', function() {
     });
   });
 
+  describe('.title()', function() {
+    it('should return the value', function() {
+      const doc = serializeInput<v3.ChannelObject>({ title: 'User Signup Channel' });
+      const d = new Channel(doc, { asyncapi: {} as any, pointer: '', id: 'channel' });
+      expect(d.title()).toEqual('User Signup Channel');
+    });
+
+    it('should return undefined when title is not set', function() {
+      const doc = serializeInput<v3.ChannelObject>({});
+      const d = new Channel(doc, { asyncapi: {} as any, pointer: '', id: 'channel' });
+      expect(d.title()).toBeUndefined();
+    });
+  });
+
   describe('.servers()', function() {
     it('should return collection of servers - available on all servers', function() {
       const doc = serializeInput<v3.ChannelObject>({});


### PR DESCRIPTION
Superseded by a cleaner branch (fix/operation-channel-payload-1099) that contains only the fix for #1099, no extra commits from other tasks. Closing this to avoid confusion.