### PR TITLE
fix(parser): trigger custom parsers on operation.channel.messages.*.payload

### DIFF
--- a/.changeset/fix-operation-channel-payload-1099.md
+++ b/.changeset/fix-operation-channel-payload-1099.md
@@ -1,0 +1,12 @@
+---
+"@asyncapi/parser": patch
+---
+
+fix(parser): trigger custom parsers on operation.channel.messages.*.payload and headers
+
+When a v3 AsyncAPI operation references its channel via `$ref` to an external file,
+the messages and their payload/headers reach the parser through the path
+`$.operations.*.channel.messages.*.payload` (or `headers`). This path was missing
+from `customSchemasPathsV3`, so non-default schema parsers were silently skipped for
+these schemas, causing downstream tools such as `@asyncapi/react-component` to fail
+to render them.

--- a/packages/parser/src/custom-operations/parse-schema.ts
+++ b/packages/parser/src/custom-operations/parse-schema.ts
@@ -33,6 +33,11 @@ const customSchemasPathsV3 = [
   '$.operations.*.messages.*.headers',
   '$.components.operations.*.messages.*.payload',
   '$.components.operations.*.messages.*.headers',
+  // operations -> channel (which may $ref an external file) -> messages
+  '$.operations.*.channel.messages.*.payload',
+  '$.operations.*.channel.messages.*.headers',
+  '$.components.operations.*.channel.messages.*.payload',
+  '$.components.operations.*.channel.messages.*.headers',
   // messages
   '$.components.messages.*.payload',
   '$.components.messages.*.headers.*',


### PR DESCRIPTION
## What

Adds four new JSONPath entries to `customSchemasPathsV3` so custom schema parsers
also fire on payloads/headers reached via `operation.channel.messages` (when the
channel is `$ref`'d to an external file).

## Why

As reported in #1099, when an AsyncAPI 3.0 document defines an operation like:

```yaml
operations:
  FooOperation:
    action: send
    channel:
      $ref: otherFile.yaml#/channels/BarChannel
```

... and the referenced channel defines a `messages.AMessage.payload` with a custom
`schemaFormat`, the **custom parser is never invoked** because
`customSchemasPathsV3` did not include `$.operations.*.channel.messages.*.payload`
(it covered `$.operations.*.messages.*.payload` but not the `channel.` intermediate
level). The user-reported workaround (re-declaring the channel under root
`channels:`) confirmed the path mismatch.

## Changes

**`packages/parser/src/custom-operations/parse-schema.ts`**: Added 4 paths to
`customSchemasPathsV3`:

- `$.operations.*.channel.messages.*.payload`
- `$.operations.*.channel.messages.*.headers`
- `$.components.operations.*.channel.messages.*.payload`
- `$.components.operations.*.channel.messages.*.headers`

Plus a changeset for `@asyncapi/parser` (patch).

2 files changed, 17 insertions(+).

Fixes #1099