### PR TITLE
fix(parser): add title and summary to v3 ServerObject type

### DIFF
--- a/.changeset/fix-server-object-title-summary-1137.md
+++ b/.changeset/fix-server-object-title-summary-1137.md
@@ -1,0 +1,14 @@
+---
+"@asyncapi/parser": patch
+---
+
+fix(parser): add missing `title` and `summary` fields to v3 ServerObject type
+
+AsyncAPI 3.0 spec allows `title` and `summary` on the Server Object (see
+https://www.asyncapi.com/docs/reference/specification/v3.0.0#serverObject),
+but the parser's TypeScript types omitted them. This meant users could not
+type-safely access `server.title` / `server.summary` even though the
+runtime model methods (`server.title()`, `server.hasTitle()`, etc.,
+provided by `CoreModel`) already supported them.
+
+Fixes #1137

--- a/packages/parser/src/spec-types/v3.ts
+++ b/packages/parser/src/spec-types/v3.ts
@@ -45,6 +45,8 @@ export interface ServerObject extends SpecificationExtensions {
   pathname?: string;
   protocolVersion?: string;
   description?: string;
+  title?: string;
+  summary?: string;
   variables?: Record<string, ServerVariableObject | ReferenceObject>;
   security?: Array<SecuritySchemeObject | ReferenceObject>;
   tags?: TagsObject;


### PR DESCRIPTION
## What

Adds the missing `title?: string` and `summary?: string` fields to the v3
`ServerObject` TypeScript type in `packages/parser/src/spec-types/v3.ts`.

## Why

As reported in #1137, the AsyncAPI 3.0 specification allows `title` and
`summary` on the [Server Object](https://www.asyncapi.com/docs/reference/specification/v3.0.0#serverObject),
but the parser's TypeScript types omitted them. The runtime model already
exposed them via the inherited `CoreModel` methods (`server.title()`,
`server.hasTitle()`, `server.summary()`, `server.hasSummary()`), so users
could not type-safely access `server.title` / `server.summary` even though
the values were populated.

This is part of the [MICROGRANT 2026-06 #1167](https://github.com/asyncapi/parser-js/issues/1167)
aggregated issue.

## Changes

**`packages/parser/src/spec-types/v3.ts`** : 2 fields added to `ServerObject`.

Plus a changeset for `@asyncapi/parser` (patch).

2 files changed, 16 insertions(+).

Fixes #1137