### PR TITLE
test: cover reply channel with null address

### DIFF
--- a/packages/parser/test/ruleset/rules/asyncapi-document-resolved.spec.ts
+++ b/packages/parser/test/ruleset/rules/asyncapi-document-resolved.spec.ts
@@ -394,4 +394,60 @@ testRule('asyncapi-document-resolved', [
     },
     errors: [],
   },
+
+  {
+    name: 'valid case for 3.X.X (reply with address location can reference channel with null address)',
+    document: {
+      asyncapi: '3.0.0',
+      info: {
+        title: 'Signup service example (internal)',
+        version: '0.1.0',
+      },
+      channels: {
+        userSignup: {
+          address: 'user/signup',
+          messages: {
+            UserSignup: {
+              payload: {}
+            }
+          }
+        },
+        userSignupReply: {
+          address: null,
+          messages: {
+            UserSignupReply: {
+              payload: {}
+            }
+          }
+        }
+      },
+      operations: {
+        sendUserSignup: {
+          action: 'send',
+          channel: {
+            $ref: '#/channels/userSignup'
+          },
+          messages: [
+            {
+              $ref: '#/channels/userSignup/messages/UserSignup'
+            }
+          ],
+          reply: {
+            address: {
+              location: '$message.header#/replyTo'
+            },
+            channel: {
+              $ref: '#/channels/userSignupReply'
+            },
+            messages: [
+              {
+                $ref: '#/channels/userSignupReply/messages/UserSignupReply'
+              }
+            ]
+          }
+        }
+      },
+    },
+    errors: [],
+  },
 ]);


### PR DESCRIPTION
﻿## Why

Issue #876 describes a resolved-document validation edge case where an operation reply uses `address.location` and references a reply channel whose `address` is `null`. Current `master` already accepts this scenario, but there was no focused regression coverage for it.

Related to #876.

## What Changed

Added a v3 resolved validation test showing that a reply channel with `address: null` is valid when the reply address is supplied via `address.location`.

## Verification

- `npm install`
- `npx jest test/ruleset/rules/asyncapi-document-resolved.spec.ts --runInBand`
- `npm run parser:build`

`npm run parser:test:unit` still has existing external-reference timeout failures unrelated to this test.
