### PR TITLE
fix: drop archived @asyncapi/raml-dt-schema-parser dep

### DIFF
--- a/.changeset/drop-archived-raml-dep.md
+++ b/.changeset/drop-archived-raml-dep.md
@@ -1,0 +1,7 @@
+---
+"@asyncapi/multi-parser": minor
+---
+
+Move `@asyncapi/raml-dt-schema-parser` from a required dependency to an optional peer dependency. The upstream parser was archived on 2025-08-04 and its transitive chain pulled in unmaintained packages with several CVEs.
+
+Consumers who do not need RAML schema parsing get a smaller install footprint with the archived chain removed. Consumers who do need it must declare `@asyncapi/raml-dt-schema-parser` themselves; the runtime registration in `NewParser(..., { includeSchemaParsers: true })` then behaves exactly as before.

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,7 @@
       "version": "4.0.24",
       "resolved": "https://registry.npmjs.org/@asyncapi/raml-dt-schema-parser/-/raml-dt-schema-parser-4.0.24.tgz",
       "integrity": "sha512-Fy9IwCXPpXoG4Mkm7sXgWucSwYg8POwdx16xuHAmV6AerpcM8nk5mT/tARLtR3wrMst3OBwReEVYzwT3esSb8g==",
+      "dev": true,
       "dependencies": {
         "@asyncapi/parser": "^3.1.0",
         "js-yaml": "^4.1.0",
@@ -11835,11 +11836,11 @@
         "@asyncapi/openapi-schema-parser": "^3.0.4",
         "@asyncapi/parser": "*",
         "@asyncapi/protobuf-schema-parser": "^3.3.0",
-        "@asyncapi/raml-dt-schema-parser": "^4.0.4",
         "parserapiv1": "npm:@asyncapi/parser@^2.1.0",
         "parserapiv2": "npm:@asyncapi/parser@3.0.0-next-major-spec.8"
       },
       "devDependencies": {
+        "@asyncapi/raml-dt-schema-parser": "^4.0.4",
         "@jest/types": "^29.0.2",
         "@swc/core": "^1.2.248",
         "@swc/jest": "^0.2.22",
@@ -11856,6 +11857,14 @@
         "ts-loader": "^9.3.1",
         "ts-node": "^10.9.1",
         "typescript": "^4.8.2"
+      },
+      "peerDependencies": {
+        "@asyncapi/raml-dt-schema-parser": "^4.0.4"
+      },
+      "peerDependenciesMeta": {
+        "@asyncapi/raml-dt-schema-parser": {
+          "optional": true
+        }
       }
     },
     "packages/parser": {

--- a/packages/multi-parser/package.json
+++ b/packages/multi-parser/package.json
@@ -43,11 +43,19 @@
     "@asyncapi/openapi-schema-parser": "^3.0.4",
     "@asyncapi/parser": "*",
     "@asyncapi/protobuf-schema-parser": "^3.3.0",
-    "@asyncapi/raml-dt-schema-parser": "^4.0.4",
     "parserapiv1": "npm:@asyncapi/parser@^2.1.0",
     "parserapiv2": "npm:@asyncapi/parser@3.0.0-next-major-spec.8"
   },
+  "peerDependencies": {
+    "@asyncapi/raml-dt-schema-parser": "^4.0.4"
+  },
+  "peerDependenciesMeta": {
+    "@asyncapi/raml-dt-schema-parser": {
+      "optional": true
+    }
+  },
   "devDependencies": {
+    "@asyncapi/raml-dt-schema-parser": "^4.0.4",
     "@jest/types": "^29.0.2",
     "@swc/core": "^1.2.248",
     "@swc/jest": "^0.2.22",

--- a/packages/multi-parser/src/parse.ts
+++ b/packages/multi-parser/src/parse.ts
@@ -4,8 +4,9 @@ import { Parser as ParserV3 } from '@asyncapi/parser';
 
 import { AvroSchemaParser } from '@asyncapi/avro-schema-parser';
 import { OpenAPISchemaParser } from '@asyncapi/openapi-schema-parser';
-import { RamlDTSchemaParser } from '@asyncapi/raml-dt-schema-parser';
 import { ProtoBuffSchemaParser } from '@asyncapi/protobuf-schema-parser';
+
+import { loadRamlDTSchemaParser } from './raml-dt-schema-parser-loader';
 
 import type { ParserOptions as ParserOptionsParserV1 } from 'parserapiv1/esm/parser';
 import type { ParserOptions as ParserOptionsParserV2 } from 'parserapiv2/esm/parser';
@@ -25,10 +26,11 @@ export function NewParser(parserAPIMajorVersion?: number, options?: Options): Pa
   // This is done globally instead of per version because latest versions of those schema parsers are still compatible with newer versions of the Parser-JS.
   // If a breaking change is introduced in the future, then we would need to register the schema parsers compatible with each version of the Parser-JS.
   if (options?.includeSchemaParsers) {
+    const RamlDTSchemaParser = loadRamlDTSchemaParser();
     const defaultSchemaParsers = [
       AvroSchemaParser(),
       OpenAPISchemaParser(),
-      RamlDTSchemaParser(),
+      ...(RamlDTSchemaParser ? [RamlDTSchemaParser()] : []),
       ProtoBuffSchemaParser(),
     ];
 

--- a/packages/multi-parser/src/raml-dt-schema-parser-loader.ts
+++ b/packages/multi-parser/src/raml-dt-schema-parser-loader.ts
@@ -1,0 +1,11 @@
+// `@asyncapi/raml-dt-schema-parser` is an optional peer dependency. The upstream
+// repository was archived (2025-08-04) and its transitive chain ships several
+// CVEs, so consumers must opt in by installing it themselves.
+export function loadRamlDTSchemaParser(): (() => any) | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, global-require
+    return require('@asyncapi/raml-dt-schema-parser').RamlDTSchemaParser;
+  } catch {
+    return null;
+  }
+}

--- a/packages/multi-parser/test/parse.spec.ts
+++ b/packages/multi-parser/test/parse.spec.ts
@@ -90,11 +90,34 @@ describe('NewParser()', function() {
     const knownSchemaParser = AvroSchemaParser();
     const options: Options = { parserOptions: { schemaParsers: [knownSchemaParser]}, includeSchemaParsers: true };
     const parser = NewParser(0, options);
-    
+
     expect(parser).toBeInstanceOf(ParserV3);
     expect(parser.parserRegistry.get(knownSchemaParser.getMimeTypes()[0])).toStrictEqual(knownSchemaParser);
     expect(parser.parserRegistry.get(OpenAPISchemaParser().getMimeTypes()[0])).toEqual(OpenAPISchemaParser());
     expect(parser.parserRegistry.get(RamlDTSchemaParser().getMimeTypes()[0])).toEqual(RamlDTSchemaParser());
     expect(parser.parserRegistry.get(ProtoBuffSchemaParser().getMimeTypes()[0])).toEqual(ProtoBuffSchemaParser());
+  });
+
+  describe('without the optional @asyncapi/raml-dt-schema-parser peer dependency', () => {
+    afterEach(() => {
+      jest.dontMock('../src/raml-dt-schema-parser-loader');
+      jest.resetModules();
+    });
+
+    it('Registers the remaining default schema parsers but skips RAML', async function() {
+      jest.isolateModules(() => {
+        jest.doMock('../src/raml-dt-schema-parser-loader', () => ({
+          loadRamlDTSchemaParser: () => null,
+        }));
+        // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports, global-require
+        const { NewParser: NewParserWithoutRaml } = require('../src/index');
+        const parser = NewParserWithoutRaml(3, { includeSchemaParsers: true });
+
+        expect(parser.parserRegistry.get(AvroSchemaParser().getMimeTypes()[0])).not.toBeUndefined();
+        expect(parser.parserRegistry.get(OpenAPISchemaParser().getMimeTypes()[0])).not.toBeUndefined();
+        expect(parser.parserRegistry.get(ProtoBuffSchemaParser().getMimeTypes()[0])).not.toBeUndefined();
+        expect(parser.parserRegistry.get(RamlDTSchemaParser().getMimeTypes()[0])).toBeUndefined();
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary

Closes #1187.

`@asyncapi/multi-parser@2.3.0` depends on `@asyncapi/raml-dt-schema-parser`, whose upstream repo was [archived on 2025-08-04](https://github.com/asyncapi/raml-dt-schema-parser). The archived chain ships three CVEs through unmaintained transitives (`js-yaml@3.x` DoS, two `ajv` issues via `ramldt2jsonschema` / `webapi-parser`).

This PR moves `@asyncapi/raml-dt-schema-parser` to an **optional peer dependency** and looks it up at runtime so the behavior is non-breaking for existing users:

- **`packages/multi-parser/package.json`** - drops the dep from `dependencies`, adds it as an optional `peerDependencies` entry (via `peerDependenciesMeta`), and keeps it in `devDependencies` so the test suite still resolves it.
- **`packages/multi-parser/src/parse.ts`** - replaces the static `import { RamlDTSchemaParser } from '@asyncapi/raml-dt-schema-parser'` with a guarded `require()` lookup in a new `raml-dt-schema-parser-loader.ts` module. The parser is spread into `defaultSchemaParsers` only when the lookup returns non-null.
- **`packages/multi-parser/test/parse.spec.ts`** - existing assertions keep passing (dep is installed via `devDependencies`). Adds one new test that mocks the loader returning `null` and asserts that `NewParser(3, { includeSchemaParsers: true })` registers Avro / OpenAPI / Protobuf but skips RAML.
- **`.changeset/drop-archived-raml-dep.md`** - minor bump, with a note that consumers wanting RAML support must declare `@asyncapi/raml-dt-schema-parser` themselves.

### Net effect

| Consumer | Before | After |
|---|---|---|
| Doesn't use RAML | Pays for archived chain + 3 CVEs in transitives | Archived chain gone, no behavior change |
| Uses RAML | `@asyncapi/raml-dt-schema-parser` is auto-installed | Must add `@asyncapi/raml-dt-schema-parser` to their own `package.json` (optional peer) |

The jsonpath-plus issue pulled by `parserapiv1` / `parserapiv2` is tracked separately in #1065 and is out of scope here.

### Alternatives considered

- **Async `NewParser` with dynamic `import()`** - more ESM-native (no CJS interop, plays nicely with bundlers and pure-ESM runtimes); consumers already `await parser.parse(doc)` so an extra `await` on construction is cheap. But it's a breaking API change -> major bump, and every downstream caller (CLIs, generators, tooling) has to migrate.
- **Drop the dep entirely** - if we're already taking a major, the simpler move is to just remove `@asyncapi/raml-dt-schema-parser` from `multi-parser` altogether. Consumers who want RAML install it directly and pass it via `parserOptions.schemaParsers`. No optional-peer plumbing, no dynamic loader, no runtime detection - just one less thing for `multi-parser` to know about. This is the suggested fix in #1187.

Happy to follow up with either as a separate proposal if maintainers prefer to take the major; this PR sticks with the non-breaking path.

## Test plan

- [x] `npm test` (turbo build + unit + browser) - all 3 tasks pass
- [x] `npm run lint` - clean
- [x] New unit test exercises the missing-RAML branch via `jest.isolateModules` + `jest.doMock`
- [x] Existing tests still cover the RAML-present path (devDependency keeps it resolvable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)