### PR TITLE
fix: add missing title() and summary() getters to Server class (#1075, #1076)

### DIFF
--- a/.changeset/brave-lands-fold.md
+++ b/.changeset/brave-lands-fold.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/parser": patch
+---
+
+fix: add missing title() and summary() getters to Server class (#1075, #1076)

--- a/packages/parser/src/models/v3/server.ts
+++ b/packages/parser/src/models/v3/server.ts
@@ -63,6 +63,22 @@ export class Server extends CoreModel<v3.ServerObject, { id: string }> implement
     return this._json.protocolVersion;
   }
 
+  hasTitle(): boolean {
+    return !!this._json.title;
+  }
+
+  title(): string | undefined {
+    return this._json.title;
+  }
+
+  hasSummary(): boolean {
+    return !!this._json.summary;
+  }
+
+  summary(): string | undefined {
+    return this._json.summary;
+  }
+
   channels(): ChannelsInterface {
     const channels: ChannelInterface[] = [];
     Object.entries((this._meta.asyncapi?.parsed as v3.AsyncAPIObject)?.channels || {}).forEach(([channelName, channel]) => {


### PR DESCRIPTION
Fixes #1075 and #1076 by adding missing getter methods for title and summary to the Server class.\n\nThe methods follow the exact same pattern as existing getters like hasPathname()/pathname().\n\nCloses #1075\nCloses #1076