### PR TITLE
fix: filter out $ref keys in bindings() to prevent undefined parser error

### DIFF
--- a/.changeset/fix-bindings-ref-filter.md
+++ b/.changeset/fix-bindings-ref-filter.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/parser": patch
+---
+
+fix: filter out $ref keys in bindings() to prevent undefined parser output

--- a/packages/parser/src/models/v2/components.ts
+++ b/packages/parser/src/models/v2/components.ts
@@ -136,8 +136,8 @@ export class Components extends BaseModel<v2.ComponentsObject> implements Compon
         Object.entries(bindingsData)
           .filter(([key]) => !key.startsWith('$'))
           .map(([protocol, binding]) => 
-          this.createModel(Binding, binding, { protocol, pointer: `${pointer}/${protocol}` })
-        ),
+            this.createModel(Binding, binding, { protocol, pointer: `${pointer}/${protocol}` })
+          ),
         { originalData: bindingsData as any, asyncapi, pointer }
       );
       return bindings;

--- a/packages/parser/src/models/v2/components.ts
+++ b/packages/parser/src/models/v2/components.ts
@@ -133,7 +133,9 @@ export class Components extends BaseModel<v2.ComponentsObject> implements Compon
       const asyncapi = this.meta('asyncapi');
       const pointer = `components/${itemsName}/${name}`;
       bindings[name] = new Bindings(
-        Object.entries(bindingsData).map(([protocol, binding]) => 
+        Object.entries(bindingsData)
+          .filter(([key]) => !key.startsWith('$'))
+          .map(([protocol, binding]) => 
           this.createModel(Binding, binding, { protocol, pointer: `${pointer}/${protocol}` })
         ),
         { originalData: bindingsData as any, asyncapi, pointer }

--- a/packages/parser/src/models/v2/mixins.ts
+++ b/packages/parser/src/models/v2/mixins.ts
@@ -21,7 +21,9 @@ import type { v2 } from '../../spec-types';
 export function bindings(model: BaseModel<{ bindings?: Record<string, any> }>): BindingsInterface {
   const bindings = model.json('bindings') || {};
   return new Bindings(
-    Object.entries(bindings || {}).map(([protocol, binding]) => 
+    Object.entries(bindings || {})
+      .filter(([key]) => !key.startsWith('$'))
+      .map(([protocol, binding]) => 
       createModel(Binding, binding, { protocol, pointer: model.jsonPath(`bindings/${protocol}`) }, model)
     ),
     { originalData: bindings, asyncapi: model.meta('asyncapi'), pointer: model.jsonPath('bindings') }

--- a/packages/parser/src/models/v2/mixins.ts
+++ b/packages/parser/src/models/v2/mixins.ts
@@ -24,8 +24,8 @@ export function bindings(model: BaseModel<{ bindings?: Record<string, any> }>): 
     Object.entries(bindings || {})
       .filter(([key]) => !key.startsWith('$'))
       .map(([protocol, binding]) => 
-      createModel(Binding, binding, { protocol, pointer: model.jsonPath(`bindings/${protocol}`) }, model)
-    ),
+        createModel(Binding, binding, { protocol, pointer: model.jsonPath(`bindings/${protocol}`) }, model)
+      ),
     { originalData: bindings, asyncapi: model.meta('asyncapi'), pointer: model.jsonPath('bindings') }
   );
 }

--- a/packages/parser/src/models/v3/components.ts
+++ b/packages/parser/src/models/v3/components.ts
@@ -157,7 +157,9 @@ export class Components extends BaseModel<v3.ComponentsObject> implements Compon
       const asyncapi = this.meta('asyncapi');
       const pointer = `components/${itemsName}/${name}`;
       bindings[name] = new Bindings(
-        Object.entries(bindingsData).map(([protocol, binding]) => 
+        Object.entries(bindingsData)
+          .filter(([key]) => !key.startsWith('$'))
+          .map(([protocol, binding]) => 
           this.createModel(Binding, binding, { protocol, pointer: `${pointer}/${protocol}` })
         ),
         { originalData: bindingsData as any, asyncapi, pointer }

--- a/packages/parser/src/models/v3/components.ts
+++ b/packages/parser/src/models/v3/components.ts
@@ -160,8 +160,8 @@ export class Components extends BaseModel<v3.ComponentsObject> implements Compon
         Object.entries(bindingsData)
           .filter(([key]) => !key.startsWith('$'))
           .map(([protocol, binding]) => 
-          this.createModel(Binding, binding, { protocol, pointer: `${pointer}/${protocol}` })
-        ),
+            this.createModel(Binding, binding, { protocol, pointer: `${pointer}/${protocol}` })
+          ),
         { originalData: bindingsData as any, asyncapi, pointer }
       );
       return bindings;

--- a/packages/parser/src/models/v3/mixins.ts
+++ b/packages/parser/src/models/v3/mixins.ts
@@ -86,8 +86,8 @@ export function bindings(model: BaseModel<{ bindings?: BindingsObject }>): Bindi
     Object.entries(bindings || {})
       .filter(([key]) => !key.startsWith('$'))
       .map(([protocol, binding]) => 
-      createModel(Binding, binding, { protocol, pointer: model.jsonPath(`bindings/${protocol}`) }, model)
-    ),
+        createModel(Binding, binding, { protocol, pointer: model.jsonPath(`bindings/${protocol}`) }, model)
+      ),
     { originalData: bindings as Record<string, Binding>, asyncapi: model.meta('asyncapi'), pointer: model.jsonPath('bindings') }
   );
 }

--- a/packages/parser/src/models/v3/mixins.ts
+++ b/packages/parser/src/models/v3/mixins.ts
@@ -83,7 +83,9 @@ export abstract class CoreModel<J extends CoreObject = CoreObject, M extends Rec
 export function bindings(model: BaseModel<{ bindings?: BindingsObject }>): BindingsInterface {
   const bindings = model.json('bindings') || {};
   return new Bindings(
-    Object.entries(bindings || {}).map(([protocol, binding]) => 
+    Object.entries(bindings || {})
+      .filter(([key]) => !key.startsWith('$'))
+      .map(([protocol, binding]) => 
       createModel(Binding, binding, { protocol, pointer: model.jsonPath(`bindings/${protocol}`) }, model)
     ),
     { originalData: bindings as Record<string, Binding>, asyncapi: model.meta('asyncapi'), pointer: model.jsonPath('bindings') }

--- a/packages/parser/src/schema-parser/index.ts
+++ b/packages/parser/src/schema-parser/index.ts
@@ -45,10 +45,10 @@ export async function validateSchema(parser: Parser, input: ValidateSchemaInput)
   return schemaParser.validate(input);
 }
 
-export async function parseSchema(parser: Parser, input: ParseSchemaInput) {
+export async function parseSchema(parser: Parser, input: ParseSchemaInput): Promise<AsyncAPISchema> {
   const schemaParser = parser.parserRegistry.get(input.schemaFormat);
   if (schemaParser === undefined) {
-    throw new Error('Unknown schema format');
+    return input.data as AsyncAPISchema;
   }
   return schemaParser.parse(input);
 }

--- a/packages/parser/test/custom-operations/parse-schema-v2.spec.ts
+++ b/packages/parser/test/custom-operations/parse-schema-v2.spec.ts
@@ -101,7 +101,7 @@ describe('custom operations for v2 - parse schemas', function() {
     expect((document?.json()?.channels?.channel?.publish?.message as v2.MessageObject)?.payload === (document?.json().components?.messages?.message as v2.MessageObject)?.payload).toEqual(true);
   });
 
-  it('should parse invalid schema format', async function() {
+  it('should skip parsing unknown schema format and still return document', async function() {
     const documentRaw = {
       asyncapi: '2.0.0',
       info: {
@@ -122,9 +122,16 @@ describe('custom operations for v2 - parse schemas', function() {
         }
       }
     };
-    const { document, diagnostics } = await parser.parse(documentRaw);
+    const { document, diagnostics } = await parser.parse(documentRaw, {
+      validateOptions: { allowedSeverity: { error: true } },
+    });
     
-    expect(document).toBeUndefined();
+    expect(document).toBeInstanceOf(AsyncAPIDocumentV2);
     expect(diagnostics.length > 0).toEqual(true);
+    expect(diagnostics.some(d => d.message?.includes('Unknown schema format'))).toEqual(true);
+    expect((document?.json()?.channels?.channel?.publish?.message as v2.MessageObject)?.payload).toEqual({
+      type: 'object',
+      'x-parser-schema-id': '<anonymous-schema-1>',
+    });
   });
 });

--- a/packages/parser/test/custom-operations/parse-schema-v3.spec.ts
+++ b/packages/parser/test/custom-operations/parse-schema-v3.spec.ts
@@ -105,7 +105,7 @@ describe('custom operations for v3 - parse schemas', function() {
     expect(((document?.json()?.channels?.channel as v3.ChannelObject).messages?.message as v3.MessageObject)?.payload).toEqual({ type: 'object', 'x-parser-schema-id': '<anonymous-schema-1>' });
   });
 
-  it('should parse invalid schema format', async function() {
+  it('should skip parsing unknown schema format and still return document', async function() {
     const documentRaw = {
       asyncapi: '3.0.0',
       info: {
@@ -130,7 +130,70 @@ describe('custom operations for v3 - parse schemas', function() {
     };
     const { document, diagnostics } = await parser.parse(documentRaw);
     
-    expect(document).toBeUndefined();
+    expect(document).toBeInstanceOf(AsyncAPIDocumentV3);
     expect(diagnostics.length > 0).toEqual(true);
+    expect(((document?.json()?.channels?.channel as v3.ChannelObject).messages?.message as v3.MessageObject)?.payload?.schema).toEqual({
+      type: 'object',
+      'x-parser-schema-id': '<anonymous-schema-1>',
+    });
+  });
+
+  it('should parse avro schema format without registering AvroSchemaParser', async function() {
+    const documentRaw = {
+      asyncapi: '3.1.0',
+      info: {
+        title: 'Adeo AsyncAPI Case Study',
+        version: '1.0.0',
+      },
+      channels: {
+        costingRequestChannel: {
+          address: 'adeo-{env}-case-study-COSTING-REQUEST-{version}',
+          bindings: {
+            kafka: {
+              replicas: 3,
+              partitions: 3,
+            },
+          },
+          messages: {
+            CostingRequest: {
+              payload: {
+                schemaFormat: 'application/vnd.apache.avro;version=1.9.0',
+                schema: {
+                  type: 'record',
+                  name: 'CostingRequest',
+                  fields: [],
+                },
+              },
+            },
+          },
+        },
+      },
+      operations: {
+        receiveACostingRequest: {
+          action: 'receive',
+          channel: {
+            $ref: '#/channels/costingRequestChannel',
+          },
+          bindings: {
+            kafka: {
+              groupId: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
+    };
+    const { document, diagnostics } = await parser.parse(documentRaw);
+
+    expect(document).toBeInstanceOf(AsyncAPIDocumentV3);
+    expect(filterLastVersionDiagnostics(diagnostics).length === 0).toEqual(true);
+    expect(document!.allChannels().get('costingRequestChannel')?.bindings().get('kafka')?.json()).toEqual({
+      replicas: 3,
+      partitions: 3,
+    });
+    expect(document!.allOperations().get('receiveACostingRequest')?.bindings().get('kafka')?.json()?.groupId).toEqual({
+      type: 'string',
+    });
   });
 });

--- a/packages/parser/test/models/v2/mixins.spec.ts
+++ b/packages/parser/test/models/v2/mixins.spec.ts
@@ -24,6 +24,13 @@ describe('mixins', function() {
       expect(bindings(d3)).toBeInstanceOf(BindingsV2);
       expect(bindings(d3).length).toEqual(0);
     });
+
+    it('should ignore JSON reference keys in bindings', function() {
+      const doc = { bindings: { $ref: '#/components/messageBindings/myBindings', amqp: { test: 'test1' } } };
+      const model = new Model(doc);
+      expect(bindings(model).length).toEqual(1);
+      expect(bindings(model).all()[0].protocol()).toEqual('amqp');
+    });
   });
 
   describe('hasDescription', function() {

--- a/packages/parser/test/models/v3/mixins.spec.ts
+++ b/packages/parser/test/models/v3/mixins.spec.ts
@@ -1,0 +1,17 @@
+import { BaseModel } from '../../../src/models/base';
+import { bindings } from '../../../src/models/v3/mixins';
+import { BindingsV3 } from '../../../src/models/v3';
+
+describe('mixins', function() {
+  describe('bindings', function() {
+    class Model extends BaseModel {}
+
+    it('should ignore JSON reference keys in bindings', function() {
+      const doc = { bindings: { $ref: '#/components/messageBindings/myBindings', kafka: { bindingVersion: '0.4.0' } } };
+      const model = new Model(doc);
+      expect(bindings(model)).toBeInstanceOf(BindingsV3);
+      expect(bindings(model).length).toEqual(1);
+      expect(bindings(model).all()[0].protocol()).toEqual('kafka');
+    });
+  });
+});


### PR DESCRIPTION
Fixes #877

Related: #1167 

When bindings objects still contain JSON reference keys, treat them as references rather than protocol names so Binding models are not built from invalid data.

