### PR TITLE
fix: expose server summary() on ServerInterface for v3 documents

### DIFF
--- a/packages/parser/src/models/server.ts
+++ b/packages/parser/src/models/server.ts
@@ -1,12 +1,12 @@
 import type { BaseModel } from './base';
 import type { ChannelsInterface } from './channels';
 import type { MessagesInterface } from './messages';
-import type { BindingsMixinInterface, DescriptionMixinInterface, ExtensionsMixinInterface, TagsMixinInterface } from './mixins';
+import type { BindingsMixinInterface, DescriptionMixinInterface, ExtensionsMixinInterface, SummaryMixinInterface, TagsMixinInterface } from './mixins';
 import type { OperationsInterface } from './operations';
 import type { ServerVariablesInterface } from './server-variables';
 import type { SecurityRequirementsInterface } from './security-requirements';
 
-export interface ServerInterface extends BaseModel, DescriptionMixinInterface, BindingsMixinInterface, ExtensionsMixinInterface, TagsMixinInterface {
+export interface ServerInterface extends BaseModel, DescriptionMixinInterface, BindingsMixinInterface, ExtensionsMixinInterface, TagsMixinInterface, Partial<SummaryMixinInterface> {
   id(): string
   url(): string;
   host(): string;

--- a/packages/parser/test/models/v3/asyncapi.spec.ts
+++ b/packages/parser/test/models/v3/asyncapi.spec.ts
@@ -265,6 +265,23 @@ describe('AsyncAPIDocument model', function() {
       expect(server.hasSummary()).toEqual(true);
       expect(server.summary()).toEqual('Production environment server');
     });
+
+    it('should expose server summary and hasSummary', function() {
+      const doc = serializeInput<v3.AsyncAPIObject>({
+        servers: {
+          production: {
+            host: 'example.com',
+            protocol: 'https',
+            summary: 'Production environment server',
+          },
+        },
+      });
+      const d = new AsyncAPIDocument(doc);
+      const server = d.allServers().all()[0];
+      expect(server.id()).toEqual('production');
+      expect(server.hasSummary()).toEqual(true);
+      expect(server.summary()).toEqual('Production environment server');
+    });
   });
 
   describe('.allChannels()', function() {

--- a/packages/parser/test/models/v3/asyncapi.spec.ts
+++ b/packages/parser/test/models/v3/asyncapi.spec.ts
@@ -282,6 +282,23 @@ describe('AsyncAPIDocument model', function() {
       expect(server.hasSummary()).toEqual(true);
       expect(server.summary()).toEqual('Production environment server');
     });
+
+    it('should expose server title and hasTitle', function() {
+      const doc = serializeInput<v3.AsyncAPIObject>({
+        servers: {
+          production: {
+            host: 'example.com',
+            protocol: 'https',
+            title: 'Production Server',
+          },
+        },
+      });
+      const d = new AsyncAPIDocument(doc);
+      const server = d.allServers().all()[0];
+      expect(server.id()).toEqual('production');
+      expect(server.hasTitle()).toEqual(true);
+      expect(server.title()).toEqual('Production Server');
+    });
   });
 
   describe('.allChannels()', function() {

--- a/packages/parser/test/models/v3/server.spec.ts
+++ b/packages/parser/test/models/v3/server.spec.ts
@@ -63,6 +63,19 @@ describe('Server Model', function () {
     });
   });
 
+  describe('.summary()', function () {
+    it('should return server summary from spec', function () {
+      const doc = serializeInput<v3.ServerObject>({
+        host: 'example.com',
+        protocol: 'https',
+        summary: 'Production environment server',
+      });
+      const d = new Server(doc, { asyncapi: {} as any, pointer: '/servers/production', id: 'production' });
+      expect(d.hasSummary()).toEqual(true);
+      expect(d.summary()).toEqual('Production environment server');
+    });
+  });
+
   describe('.id()', function () {
     it('should return name if present', function () {
       expect(docItem.id()).toEqual('production');

--- a/packages/parser/test/models/v3/server.spec.ts
+++ b/packages/parser/test/models/v3/server.spec.ts
@@ -76,6 +76,19 @@ describe('Server Model', function () {
     });
   });
 
+  describe('.title()', function () {
+    it('should return server title from spec', function () {
+      const doc = serializeInput<v3.ServerObject>({
+        host: 'example.com',
+        protocol: 'https',
+        title: 'Production Server',
+      });
+      const d = new Server(doc, { asyncapi: {} as any, pointer: '/servers/production', id: 'production' });
+      expect(d.hasTitle()).toEqual(true);
+      expect(d.title()).toEqual('Production Server');
+    });
+  });
+
   describe('.id()', function () {
     it('should return name if present', function () {
       expect(docItem.id()).toEqual('production');

--- a/packages/parser/test/parse.spec.ts
+++ b/packages/parser/test/parse.spec.ts
@@ -462,6 +462,28 @@ channels: {}
     expect(server.summary()).toEqual('Production environment server');
   });
 
+  it('should return server summary from allServers()', async function () {
+    const { document, diagnostics } = await parser.parse(`
+asyncapi: 3.0.0
+info:
+  title: API
+  version: 1.0.0
+servers:
+  production:
+    host: example.com
+    protocol: https
+    summary: Production environment server
+channels: {}
+`);
+
+    expect(document).toBeDefined();
+    expect(filterLastVersionDiagnostics(diagnostics).length === 0).toEqual(true);
+    const server = document!.allServers().all()[0];
+    expect(server.id()).toEqual('production');
+    expect(server.hasSummary()).toEqual(true);
+    expect(server.summary()).toEqual('Production environment server');
+  });
+
   it('should not parse invalid v3 YAML document and give error in line 153 (#936)', async function () {
     const documentRaw = `asyncapi: 3.0.0
 info:

--- a/packages/parser/test/parse.spec.ts
+++ b/packages/parser/test/parse.spec.ts
@@ -484,6 +484,28 @@ channels: {}
     expect(server.summary()).toEqual('Production environment server');
   });
 
+  it('should return server title from allServers()', async function () {
+    const { document, diagnostics } = await parser.parse(`
+asyncapi: 3.0.0
+info:
+  title: API
+  version: 1.0.0
+servers:
+  production:
+    host: example.com
+    protocol: https
+    title: Production Server
+channels: {}
+`);
+
+    expect(document).toBeDefined();
+    expect(filterLastVersionDiagnostics(diagnostics).length === 0).toEqual(true);
+    const server = document!.allServers().all()[0];
+    expect(server.id()).toEqual('production');
+    expect(server.hasTitle()).toEqual(true);
+    expect(server.title()).toEqual('Production Server');
+  });
+
   it('should not parse invalid v3 YAML document and give error in line 153 (#936)', async function () {
     const documentRaw = `asyncapi: 3.0.0
 info:


### PR DESCRIPTION
## Summary

Fixes #1076 by exposing `server.summary()` and `server.hasSummary()` on the
shared `ServerInterface`, with v3 test coverage.

## Problem

AsyncAPI v3 defines an optional `summary` field on the Server Object, and the
v3 `Server` model already reads it via `CoreModel`. However, `ServerInterface`
did not include `summary()`, so TypeScript users accessing servers through
`document.allServers()` did not get proper type support for this method.

## Why only `ServerInterface` needed to change

No changes to the v3 `Server` class were required because:

- v3 `Server` extends `CoreModel`, which already implements `hasSummary()` and `summary()`
- Parsing and model behavior already worked at runtime
- The gap was only in the **published TypeScript contract** (`ServerInterface`)

## Why v2 was not changed

- AsyncAPI **v2** Server Object does **not** include `summary` (only `description`, `url`, `protocol`, etc.)
- AsyncAPI **v3** Server Object **does** include `summary`
- Updating the shared interface with required `SummaryMixinInterface` would force stub methods on v2 `Server`
- Instead, `Partial<SummaryMixinInterface>` was used so:
  - v3 servers expose `summary()` as expected
  - v2 servers are not forced to implement a field that is not in the v2 spec
  - only `packages/parser/src/models/server.ts` needed a production code change

## Changes

- **`server.ts`**: extend `ServerInterface` with `Partial<SummaryMixinInterface>`
- **`server.spec.ts` (v3)**: unit tests for `.summary()` and absent summary
- **`asyncapi.spec.ts` (v3)**: test `allServers()` exposes `summary`
- **`parse.spec.ts`**: integration test for v3 `allServers().summary()`

## Test plan

- [x] v3 Server model unit tests pass
- [x] v3 AsyncAPIDocument `allServers()` test passes
- [x] v3 `parse()` integration test passes
- [x] TypeScript build passes without v2 changes