### PR TITLE
fix: expose server title() on the server object v3

### DIFF
--- a/packages/parser/src/models/server.ts
+++ b/packages/parser/src/models/server.ts
@@ -1,12 +1,12 @@
 import type { BaseModel } from './base';
 import type { ChannelsInterface } from './channels';
 import type { MessagesInterface } from './messages';
-import type { BindingsMixinInterface, DescriptionMixinInterface, ExtensionsMixinInterface, SummaryMixinInterface, TagsMixinInterface, TitleMixinInterface } from './mixins';
+import type { BindingsMixinInterface, DescriptionMixinInterface, ExtensionsMixinInterface, TagsMixinInterface, TitleMixinInterface } from './mixins';
 import type { OperationsInterface } from './operations';
 import type { ServerVariablesInterface } from './server-variables';
 import type { SecurityRequirementsInterface } from './security-requirements';
 
-export interface ServerInterface extends BaseModel, DescriptionMixinInterface, BindingsMixinInterface, ExtensionsMixinInterface, TagsMixinInterface, Partial<TitleMixinInterface>, Partial<SummaryMixinInterface> {
+export interface ServerInterface extends BaseModel, DescriptionMixinInterface, BindingsMixinInterface, ExtensionsMixinInterface, TagsMixinInterface, Partial<TitleMixinInterface> {
   id(): string
   url(): string;
   host(): string;

--- a/packages/parser/src/models/server.ts
+++ b/packages/parser/src/models/server.ts
@@ -1,12 +1,12 @@
 import type { BaseModel } from './base';
 import type { ChannelsInterface } from './channels';
 import type { MessagesInterface } from './messages';
-import type { BindingsMixinInterface, DescriptionMixinInterface, ExtensionsMixinInterface, TagsMixinInterface } from './mixins';
+import type { BindingsMixinInterface, DescriptionMixinInterface, ExtensionsMixinInterface, SummaryMixinInterface, TagsMixinInterface, TitleMixinInterface } from './mixins';
 import type { OperationsInterface } from './operations';
 import type { ServerVariablesInterface } from './server-variables';
 import type { SecurityRequirementsInterface } from './security-requirements';
 
-export interface ServerInterface extends BaseModel, DescriptionMixinInterface, BindingsMixinInterface, ExtensionsMixinInterface, TagsMixinInterface {
+export interface ServerInterface extends BaseModel, DescriptionMixinInterface, BindingsMixinInterface, ExtensionsMixinInterface, TagsMixinInterface, Partial<TitleMixinInterface>, Partial<SummaryMixinInterface> {
   id(): string
   url(): string;
   host(): string;

--- a/packages/parser/test/models/v3/asyncapi.spec.ts
+++ b/packages/parser/test/models/v3/asyncapi.spec.ts
@@ -265,6 +265,23 @@ describe('AsyncAPIDocument model', function() {
       expect(server.hasSummary()).toEqual(true);
       expect(server.summary()).toEqual('Production environment server');
     });
+
+    it('should expose server title and hasTitle (#1075)', function() {
+      const doc = serializeInput<v3.AsyncAPIObject>({
+        servers: {
+          production: {
+            host: 'example.com',
+            protocol: 'https',
+            title: 'Production Server',
+          },
+        },
+      });
+      const d = new AsyncAPIDocument(doc);
+      const server = d.allServers().all()[0];
+      expect(server.id()).toEqual('production');
+      expect(server.hasTitle()).toEqual(true);
+      expect(server.title()).toEqual('Production Server');
+    });
   });
 
   describe('.allChannels()', function() {

--- a/packages/parser/test/models/v3/asyncapi.spec.ts
+++ b/packages/parser/test/models/v3/asyncapi.spec.ts
@@ -266,7 +266,7 @@ describe('AsyncAPIDocument model', function() {
       expect(server.summary()).toEqual('Production environment server');
     });
 
-    it('should expose server title and hasTitle (#1075)', function() {
+    it('should expose server title and hasTitle', function() {
       const doc = serializeInput<v3.AsyncAPIObject>({
         servers: {
           production: {

--- a/packages/parser/test/models/v3/server.spec.ts
+++ b/packages/parser/test/models/v3/server.spec.ts
@@ -63,6 +63,19 @@ describe('Server Model', function () {
     });
   });
 
+  describe('.title()', function () {
+    it('should return server title from spec (#1075)', function () {
+      const doc = serializeInput<v3.ServerObject>({
+        host: 'example.com',
+        protocol: 'https',
+        title: 'Production Server',
+      });
+      const d = new Server(doc, { asyncapi: {} as any, pointer: '/servers/production', id: 'production' });
+      expect(d.hasTitle()).toEqual(true);
+      expect(d.title()).toEqual('Production Server');
+    });
+  });
+
   describe('.id()', function () {
     it('should return name if present', function () {
       expect(docItem.id()).toEqual('production');

--- a/packages/parser/test/models/v3/server.spec.ts
+++ b/packages/parser/test/models/v3/server.spec.ts
@@ -64,7 +64,7 @@ describe('Server Model', function () {
   });
 
   describe('.title()', function () {
-    it('should return server title from spec (#1075)', function () {
+    it('should return server title from spec', function () {
       const doc = serializeInput<v3.ServerObject>({
         host: 'example.com',
         protocol: 'https',

--- a/packages/parser/test/parse.spec.ts
+++ b/packages/parser/test/parse.spec.ts
@@ -462,6 +462,28 @@ channels: {}
     expect(server.summary()).toEqual('Production environment server');
   });
 
+  it('should return server title from allServers() (#1075)', async function () {
+    const { document, diagnostics } = await parser.parse(`
+asyncapi: 3.0.0
+info:
+  title: API
+  version: 1.0.0
+servers:
+  production:
+    host: example.com
+    protocol: https
+    title: Production Server
+channels: {}
+`);
+
+    expect(document).toBeDefined();
+    expect(filterLastVersionDiagnostics(diagnostics).length === 0).toEqual(true);
+    const server = document!.allServers().all()[0];
+    expect(server.id()).toEqual('production');
+    expect(server.hasTitle()).toEqual(true);
+    expect(server.title()).toEqual('Production Server');
+  });
+
   it('should not parse invalid v3 YAML document and give error in line 153 (#936)', async function () {
     const documentRaw = `asyncapi: 3.0.0
 info:

--- a/packages/parser/test/parse.spec.ts
+++ b/packages/parser/test/parse.spec.ts
@@ -462,7 +462,7 @@ channels: {}
     expect(server.summary()).toEqual('Production environment server');
   });
 
-  it('should return server title from allServers() (#1075)', async function () {
+  it('should return server title from allServers()', async function () {
     const { document, diagnostics } = await parser.parse(`
 asyncapi: 3.0.0
 info:


### PR DESCRIPTION
## Summary

Fixes #1075 by exposing `server.title()` and `server.hasTitle()` on the shared `ServerInterface` for v3 documents.

## Problem

The [AsyncAPI 3.0 Server Object](https://www.asyncapi.com/docs/reference/specification/v3.0.0#serverObject) defines an optional `title` field — a human-friendly name for the server. Users could not access it through the parser's typed API when retrieving servers via `document.allServers()`.

At runtime, v3 `Server` already inherits `title()` from `CoreModel`. The issue was that `ServerInterface` did not declare these methods, so TypeScript consumers had no proper type support for `server.title()`.

## Why only `ServerInterface` needed a production change

| Layer | Status |
| --- | --- |
| AsyncAPI v3 spec | Defines optional `title` on Server Object |
| v3 `Server` class | Already implements `title()` via `CoreModel` |
| Parsing / runtime | Already worked |
| `ServerInterface` | Did not declare `title()` / `hasTitle()` |

No changes to the v3 `Server` implementation were required. Only the shared TypeScript contract needed updating.

## Why v2 was not changed

- AsyncAPI v2 does **not** define `title` on the Server Object
- Adding required `title()` to `ServerInterface` would force stub methods on v2 `Server`
- `Partial<TitleMixinInterface>` is used instead so:
  - v3 servers expose `title()` as expected
  - v2 servers remain unchanged and spec-accurate

## Changes

- `packages/parser/src/models/server.ts` — extend `ServerInterface` with `Partial<TitleMixinInterface>`
- `packages/parser/test/models/v3/server.spec.ts` — unit tests for `.title()` and absent title
- `packages/parser/test/models/v3/asyncapi.spec.ts` — test `allServers()` exposes `title` and `hasTitle`
- `packages/parser/test/parse.spec.ts` — v3 integration test for `title` via `parse()`

## Test plan

- [x] v3 Server model unit tests for `title()` pass
- [x] v3 `AsyncAPIDocument.allServers()` test passes
- [x] v3 `parse()` integration test passes
- [x] TypeScript build passes with no v2 changes