### PR TITLE
fix: support native array methods on collections

### DIFF
--- a/.changeset/fix-collection-native-array-methods.md
+++ b/.changeset/fix-collection-native-array-methods.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/parser": patch
+---
+
+Fix native array methods on parser collections.

--- a/packages/parser/src/models/collection.ts
+++ b/packages/parser/src/models/collection.ts
@@ -8,6 +8,10 @@ export interface CollectionMetadata<T = any> {
 }
 
 export abstract class Collection<T extends BaseModel = BaseModel, M extends Record<string, any> = {}> extends Array<T> {
+  static get [Symbol.species](): ArrayConstructor {
+    return Array;
+  }
+
   constructor(
     protected readonly collections: T[],
     protected readonly _meta: CollectionMetadata<T> & M = {} as CollectionMetadata<T> & M,

--- a/packages/parser/test/models/collection.spec.ts
+++ b/packages/parser/test/models/collection.spec.ts
@@ -96,4 +96,46 @@ describe('Collection model', function() {
       expect(d.filterBy(filter)).toEqual([]);
     });
   });
+
+  describe('native array methods', function() {
+    const createCollection = () => {
+      const item1 = new ItemModel({ name: 'name1' });
+      const item2 = new ItemModel({ name: 'name2' });
+      return { collection: new Model([item1, item2]), item1, item2 };
+    };
+
+    it('should map collection items into a plain array', function() {
+      const { collection } = createCollection();
+
+      const names = collection.map(item => item.name());
+
+      expect(names).toEqual(['name1', 'name2']);
+      expect(names).toBeInstanceOf(Array);
+      expect(names).not.toBeInstanceOf(Model);
+    });
+
+    it('should return plain arrays from filter and slice', function() {
+      const { collection, item1, item2 } = createCollection();
+
+      const filtered = collection.filter(item => item.name() === 'name2');
+      const sliced = collection.slice(0, 1);
+
+      expect(filtered).toEqual([item2]);
+      expect(sliced).toEqual([item1]);
+      expect(filtered).not.toBeInstanceOf(Model);
+      expect(sliced).not.toBeInstanceOf(Model);
+    });
+
+    it('should leave the source collection unchanged', function() {
+      const { collection, item1, item2 } = createCollection();
+
+      collection.map(item => item.name());
+      collection.filter(item => item.name() === 'name1');
+      collection.slice(1);
+
+      expect(collection).toBeInstanceOf(Model);
+      expect(collection.all()).toEqual([item1, item2]);
+      expect(collection.meta()).toEqual({});
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- make native `Collection` transforms return plain arrays through `Symbol.species`
- preserve the existing constructor and metadata invariants
- add regression tests for `map`, `filter`, and `slice`

## Root cause

Native Array transforms use the subclass species constructor. They pass an array length, but `Collection` expects an iterable of models and spreads it into `super()`, causing the reported error. Returning `Array` from `Symbol.species` keeps Collection construction strict while making transforms return normal arrays.

## Validation

- reproduced the old failure in a focused harness
- verified `map`, `filter`, and `slice` return plain arrays
- verified the source collection and metadata remain unchanged
- TypeScript transpilation checks
- `git diff --check`
- branch changes only the implementation, regression tests, and patch changeset


Fixes #874