### PR TITLE
fix: ship LICENSE, NOTICE and README in the published packages

### DIFF
--- a/.changeset/ship-legal-files.md
+++ b/.changeset/ship-legal-files.md
@@ -1,0 +1,9 @@
+---
+"@asyncapi/parser": patch
+"@asyncapi/multi-parser": patch
+"@asyncapi/openapi-schema-parser": patch
+---
+
+Ship LICENSE, NOTICE and README.md inside the published tarballs. All three were already listed in each
+package's `files` array, but those entries resolve inside `packages/<pkg>/` where the files do not exist,
+so npm packed none of them.

--- a/.changeset/ship-legal-files.md
+++ b/.changeset/ship-legal-files.md
@@ -4,6 +4,6 @@
 "@asyncapi/openapi-schema-parser": patch
 ---
 
-Ship LICENSE, NOTICE and README.md inside the published tarballs. All three were already listed in each
-package's `files` array, but those entries resolve inside `packages/<pkg>/` where the files do not exist,
-so npm packed none of them.
+Ship the Apache-2.0 `LICENSE` and the `NOTICE` file inside the published tarballs, and add the repository
+README to the two packages that had none. `LICENSE` and `README.md` were already listed in each package's
+`files` array, but those entries resolve inside `packages/<pkg>/`, where neither file exists.

--- a/packages/multi-parser/.gitignore
+++ b/packages/multi-parser/.gitignore
@@ -8,3 +8,8 @@ node_modules
 /cjs
 /browser
 *.tgz
+
+# copied from the repo root by prepublishOnly (scripts/copy-legal.js)
+LICENSE
+NOTICE
+README.md

--- a/packages/multi-parser/package.json
+++ b/packages/multi-parser/package.json
@@ -23,6 +23,7 @@
     "/esm",
     "/cjs",
     "LICENSE",
+    "NOTICE",
     "README.md"
   ],
   "scripts": {
@@ -36,7 +37,8 @@
     "generate:readme:toc": "markdown-toc -i \"../../README.md\"",
     "generate:assets": "npm run generate:readme:toc",
     "bump:version": "npm --no-git-tag-version --allow-same-version version $VERSION",
-    "prepublishOnly": "npm run generate:assets"
+    "copy:legal": "node ../../scripts/copy-legal.js",
+    "prepublishOnly": "npm run copy:legal && npm run generate:assets"
   },
   "dependencies": {
     "@asyncapi/avro-schema-parser": "^3.0.3",

--- a/packages/openapi-schema-parser/.gitignore
+++ b/packages/openapi-schema-parser/.gitignore
@@ -10,4 +10,3 @@ node_modules
 # copied from the repo root by prepublishOnly (scripts/copy-legal.js)
 LICENSE
 NOTICE
-README.md

--- a/packages/openapi-schema-parser/.gitignore
+++ b/packages/openapi-schema-parser/.gitignore
@@ -6,3 +6,8 @@ node_modules
 /lib
 /esm
 /cjs
+
+# copied from the repo root by prepublishOnly (scripts/copy-legal.js)
+LICENSE
+NOTICE
+README.md

--- a/packages/openapi-schema-parser/package.json
+++ b/packages/openapi-schema-parser/package.json
@@ -34,6 +34,7 @@
     "/esm",
     "/cjs",
     "LICENSE",
+    "NOTICE",
     "README.md"
   ],
   "scripts": {
@@ -47,7 +48,8 @@
     "generate:readme:toc": "markdown-toc -i \"README.md\"",
     "generate:assets": "npm run build && npm run generate:readme:toc",
     "bump:version": "npm --no-git-tag-version --allow-same-version version $VERSION",
-    "prepublishOnly": "npm run generate:assets"
+    "copy:legal": "node ../../scripts/copy-legal.js",
+    "prepublishOnly": "npm run copy:legal && npm run generate:assets"
   },
   "dependencies": {
     "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",

--- a/packages/parser/.gitignore
+++ b/packages/parser/.gitignore
@@ -9,3 +9,8 @@ node_modules
 /browser
 *.tgz
 .turbo
+
+# copied from the repo root by prepublishOnly (scripts/copy-legal.js)
+LICENSE
+NOTICE
+README.md

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -24,6 +24,7 @@
     "/cjs",
     "/browser",
     "LICENSE",
+    "NOTICE",
     "README.md"
   ],
   "scripts": {
@@ -40,7 +41,8 @@
     "generate:readme:toc": "markdown-toc -i \"../../README.md\"",
     "generate:assets": "npm run generate:readme:toc",
     "bump:version": "npm --no-git-tag-version --allow-same-version version $VERSION",
-    "prepublishOnly": "npm run generate:assets"
+    "copy:legal": "node ../../scripts/copy-legal.js",
+    "prepublishOnly": "npm run copy:legal && npm run generate:assets"
   },
   "dependencies": {
     "@asyncapi/specs": "^6.11.1",

--- a/scripts/copy-legal.js
+++ b/scripts/copy-legal.js
@@ -1,0 +1,10 @@
+// Copy the monorepo-root legal and readme files into the package being published.
+// npm only packs files that exist inside the package directory, so without this the published tarballs
+// contain no LICENSE, no NOTICE and no README - see the "files" array in each packages/*/package.json.
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '..');
+for (const name of ['LICENSE', 'NOTICE', 'README.md']) {
+  fs.copyFileSync(path.join(root, name), path.join(process.cwd(), name));
+}

--- a/scripts/copy-legal.js
+++ b/scripts/copy-legal.js
@@ -1,10 +1,18 @@
 // Copy the monorepo-root legal and readme files into the package being published.
 // npm only packs files that exist inside the package directory, so without this the published tarballs
-// contain no LICENSE, no NOTICE and no README - see the "files" array in each packages/*/package.json.
+// contain no LICENSE and no NOTICE - see the "files" array in each packages/*/package.json.
 const fs = require('fs');
 const path = require('path');
 
 const root = path.join(__dirname, '..');
-for (const name of ['LICENSE', 'NOTICE', 'README.md']) {
-  fs.copyFileSync(path.join(root, name), path.join(process.cwd(), name));
+const pkg = process.cwd();
+
+for (const name of ['LICENSE', 'NOTICE']) {
+  fs.copyFileSync(path.join(root, name), path.join(pkg, name));
+}
+
+// Only fall back to the monorepo README for packages that do not ship one of their own;
+// @asyncapi/openapi-schema-parser has its own and it must not be overwritten.
+if (!fs.existsSync(path.join(pkg, 'README.md'))) {
+  fs.copyFileSync(path.join(root, 'README.md'), path.join(pkg, 'README.md'));
 }


### PR DESCRIPTION
## Description

The published packages of this monorepo are missing their legal files, and two of the three are missing
their README as well.

Each manifest asks for them:

```json
"files": ["/esm", "/cjs", "/browser", "LICENSE", "README.md"]
```

but those paths resolve relative to `packages/<pkg>/`, and `LICENSE`, `NOTICE` and (for two of the three
packages) `README.md` exist only at the repository root, so npm has nothing to match and packs neither.

### Evidence from the published artifacts

Listing the current tarballs, everything outside `esm/`, `cjs/` and `browser/`:

| package | version | files at the tarball root |
| --- | --- | --- |
| `@asyncapi/parser` | 3.6.3 | `package.json` |
| `@asyncapi/multi-parser` | 2.4.0 | `package.json` |
| `@asyncapi/openapi-schema-parser` | 3.1.0 | `package.json`, `README.md` |

```
$ curl -sLO https://registry.npmjs.org/@asyncapi/parser/-/parser-3.6.3.tgz
$ tar tzf parser-3.6.3.tgz | grep -vE "^package/(esm|cjs|browser)/"
package/package.json
```

So no package ships a `LICENSE` or a `NOTICE`, and only `openapi-schema-parser` ships a `README`.

### Why it matters

Apache-2.0 section 4(a) requires a copy of the licence to accompany each distribution of the work, and 4(d)
requires the `NOTICE` attributions to travel with it. The npm tarball is how essentially every consumer
receives these packages, and it currently carries neither. Separately, `@asyncapi/parser` and
`@asyncapi/multi-parser` render with no README on npmjs.com.

## Changes

- new `scripts/copy-legal.js`, copying the root `LICENSE` and `NOTICE` into the package being published, plus
  the root `README.md` **only when the package does not ship one of its own** (so
  `openapi-schema-parser`’s README is left alone);
- each package runs it from `prepublishOnly`, so the files exist by the time npm packs;
- `NOTICE` added to each `files` array next to the `LICENSE` entry that was already there;
- the copied files are gitignored per package.

No new dependency - `prepublishOnly` already existed in all three manifests, this only prepends one step.

### Verifying

```
npm -w @asyncapi/parser run copy:legal && npm pack -w @asyncapi/parser --dry-run
```

`LICENSE`, `NOTICE` and `README.md` now appear in the pack listing.