### PR TITLE
fix: handle null message objects in spectral JSONPath filters

### DIFF
--- a/packages/parser/src/ruleset/v2/functions/messageExamples-spectral-rule-v2.ts
+++ b/packages/parser/src/ruleset/v2/functions/messageExamples-spectral-rule-v2.ts
@@ -17,9 +17,9 @@ export function asyncApi2MessageExamplesParserRule(parser: Parser): RuleDefiniti
     recommended: true,
     given: [
       // messages
-      '$.channels.*.[publish,subscribe][?(@property === \'message\' && @.schemaFormat !== void 0)]',
+      '$.channels.*.[publish,subscribe][?(@property === \'message\' && !@null && @.schemaFormat !== void 0)]',
       '$.channels.*.[publish,subscribe].message.oneOf[?(!@null && @.schemaFormat !== void 0)]',
-      '$.components.channels.*.[publish,subscribe].message[?(@property === \'message\' && @.schemaFormat !== void 0)]',
+      '$.components.channels.*.[publish,subscribe].message[?(@property === \'message\' && !@null && @.schemaFormat !== void 0)]',
       '$.components.channels.*.[publish,subscribe].message.oneOf[?(!@null && @.schemaFormat !== void 0)]',
       '$.components.messages[?(!@null && @.schemaFormat !== void 0)]',
       // message traits

--- a/packages/parser/src/ruleset/v2/ruleset.ts
+++ b/packages/parser/src/ruleset/v2/ruleset.ts
@@ -123,9 +123,9 @@ export const v2CoreRuleset = {
       recommended: true,
       given: [
         // messages
-        '$.channels.*.[publish,subscribe][?(@property === \'message\' && @.schemaFormat === void 0)]',
+        '$.channels.*.[publish,subscribe][?(@property === \'message\' && !@null && @.schemaFormat === void 0)]',
         '$.channels.*.[publish,subscribe].message.oneOf[?(!@null && @.schemaFormat === void 0)]',
-        '$.components.channels.*.[publish,subscribe][?(@property === \'message\' && @.schemaFormat === void 0)]',
+        '$.components.channels.*.[publish,subscribe][?(@property === \'message\' && !@null && @.schemaFormat === void 0)]',
         '$.components.channels.*.[publish,subscribe].message.oneOf[?(!@null && @.schemaFormat === void 0)]',
         '$.components.messages[?(!@null && @.schemaFormat === void 0)]',
         // message traits
@@ -201,9 +201,9 @@ export const v2SchemasRuleset = (parser: Parser) => {
         severity: 'error',
         recommended: true,
         given: [
-          '$.channels[*][publish,subscribe][?(@property === \'message\' && @.schemaFormat === void 0)].payload.default^',
+          '$.channels[*][publish,subscribe][?(@property === \'message\' && !@null && @.schemaFormat === void 0)].payload.default^',
           '$.channels.*.parameters.*.schema.default^',
-          '$.components.channels[*][publish,subscribe][?(@property === \'message\' && @.schemaFormat === void 0)].payload.default^',
+          '$.components.channels[*][publish,subscribe][?(@property === \'message\' && !@null && @.schemaFormat === void 0)].payload.default^',
           '$.components.channels.*.parameters.*.schema.default^',
           '$.components.schemas.*.default^',
           '$.components.parameters.*.schema.default^',
@@ -223,9 +223,9 @@ export const v2SchemasRuleset = (parser: Parser) => {
         severity: 'error',
         recommended: true,
         given: [
-          '$.channels[*][publish,subscribe][?(@property === \'message\' && @.schemaFormat === void 0)].payload.examples^',
+          '$.channels[*][publish,subscribe][?(@property === \'message\' && !@null && @.schemaFormat === void 0)].payload.examples^',
           '$.channels.*.parameters.*.schema.examples^',
-          '$.components.channels[*][publish,subscribe][?(@property === \'message\' && @.schemaFormat === void 0)].payload.examples^',
+          '$.components.channels[*][publish,subscribe][?(@property === \'message\' && !@null && @.schemaFormat === void 0)].payload.examples^',
           '$.components.channels.*.parameters.*.schema.examples^',
           '$.components.schemas.*.examples^',
           '$.components.parameters.*.schema.examples^',
@@ -338,9 +338,9 @@ export const v2RecommendedRuleset = {
       recommended: true,
       formats: AsyncAPIFormats.filterByMajorVersions(['2']).excludeByVersions(['2.0.0', '2.1.0', '2.2.0', '2.3.0']).formats(), // message.messageId is available starting from v2.4.      
       given: [
-        '$.channels.*.[publish,subscribe][?(@property === "message" && @.oneOf == void 0)]',
+        '$.channels.*.[publish,subscribe][?(@property === "message" && !@null && @.oneOf == void 0)]',
         '$.channels.*.[publish,subscribe].message.oneOf.*',
-        '$.components.channels.*.[publish,subscribe][?(@property === "message" && @.oneOf == void 0)]',
+        '$.components.channels.*.[publish,subscribe][?(@property === "message" && !@null && @.oneOf == void 0)]',
         '$.components.channels.*.[publish,subscribe].message.oneOf.*',
         '$.components.messages.*',
       ],

--- a/packages/parser/test/ruleset/rules/v2/asyncapi2-message-examples.spec.ts
+++ b/packages/parser/test/ruleset/rules/v2/asyncapi2-message-examples.spec.ts
@@ -477,4 +477,37 @@ testRule('asyncapi2-message-examples', [
       },
     ],
   },
+
+  {
+    name: 'valid case (payload property named "message" with null value in example)',
+    document: {
+      asyncapi: '2.6.0',
+      channels: {
+        someChannel: {
+          publish: {
+            message: {
+              payload: {
+                type: 'object',
+                required: ['message'],
+                properties: {
+                  message: {
+                    type: ['string', 'null'],
+                    maxLength: 50,
+                  },
+                },
+              },
+              examples: [
+                {
+                  payload: {
+                    message: null,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
 ]);


### PR DESCRIPTION
## Description

When a payload property is literally named  and has a  value (e.g. in a message example), the spectral JSONPath filter expressions that check  crash with:

```
TypeError: Cannot read properties of null (reading 'schemaFormat')
```

This happens because the filter expression walks into the payload's properties and encounters the property named  with value , then tries to read  on it.

Several paths already had  guards; this PR adds them to all expressions that were missing them.

## Before / after

Before:
```
Error thrown during AsyncAPI document validation. Name: TypeError, message: Cannot read properties of null (reading 'schemaFormat')
```

After:
- No crash, document parses cleanly
- Standard lint suggestions remain, no TypeError

Fixes #863