### PR TITLE
fix(multi-parser)!: drop unmaintained Parser API v1/v2 to fix jsonpath-plus vulnerability

### DIFF
--- a/.changeset/drop-vulnerable-legacy-parsers.md
+++ b/.changeset/drop-vulnerable-legacy-parsers.md
@@ -1,0 +1,9 @@
+---
+"@asyncapi/multi-parser": major
+---
+
+Drop support for Parser API v1 and v2.
+
+Both were implemented via aliased dependencies on unmaintained, frozen releases (`@asyncapi/parser@2.1.0` for v1, `@asyncapi/parser@3.0.0-next-major-spec.8` for v2), both of which depend on the vulnerable `jsonpath-plus@^7.2.0` and will never receive a security patch (see #1065). `NewParser()` and `ConvertDocumentParserAPIVersion()` now throw a clear error when v1 or v2 is requested, directing callers to migrate to Parser API v3, which already depends on the patched `jsonpath-plus@^10.0.7`.
+
+This supersedes #1086, which attempted to fix the same vulnerability by forcing `jsonpath-plus` to a newer version inside the old v1/v2 dependency trees via npm `overrides`. That approach left those unmaintained codebases running against a jsonpath-plus major version they were never tested against, which caused CI to hang.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3560,6 +3560,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
@@ -3637,6 +3638,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
       "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -5256,6 +5258,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -5623,7 +5626,8 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -7949,6 +7953,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/json-schema-migrate/-/json-schema-migrate-0.2.0.tgz",
       "integrity": "sha512-dq4/oHWmtw/+0ytnXsDqVn+VsVweTEmzm5jLgguPn9BjSzn6/q58ZiZx3BHiQyJs612f0T5Z+MrUEUUY5DHsRg==",
+      "dev": true,
       "dependencies": {
         "ajv": "^5.0.0"
       }
@@ -7957,6 +7962,7 @@
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha512-Ajr4IcMXq/2QmMkEmSvxqfLN5zGmJ92gHXAeOXq1OekoH2rfDNsgdDoL2f7QaRCy7G/E6TpxBVdRuNraMztGHw==",
+      "dev": true,
       "dependencies": {
         "co": "^4.6.0",
         "fast-deep-equal": "^1.0.0",
@@ -7967,12 +7973,14 @@
     "node_modules/json-schema-migrate/node_modules/fast-deep-equal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha512-fueX787WZKCV0Is4/T2cyAdM4+x1S3MXXOAhavE1ys/W42SHAPacLTQhucja22QBYrfGw50M2sRiXPtTGv9Ymw=="
+      "integrity": "sha512-fueX787WZKCV0Is4/T2cyAdM4+x1S3MXXOAhavE1ys/W42SHAPacLTQhucja22QBYrfGw50M2sRiXPtTGv9Ymw==",
+      "dev": true
     },
     "node_modules/json-schema-migrate/node_modules/json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha512-4JD/Ivzg7PoW8NzdrBSr3UFwC9mHgvI7Z6z3QGBsSHgKaRTUDmyZAAKJo2UbG1kUVfS9WS8bi36N49U1xw43DA=="
+      "integrity": "sha512-4JD/Ivzg7PoW8NzdrBSr3UFwC9mHgvI7Z6z3QGBsSHgKaRTUDmyZAAKJo2UbG1kUVfS9WS8bi36N49U1xw43DA==",
+      "dev": true
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -9061,82 +9069,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/parserapiv1": {
-      "name": "@asyncapi/parser",
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.1.2.tgz",
-      "integrity": "sha512-2pHKnr2P8EujcrvZo4x4zNwsEIAg5vb1ZEhl2+OH0YBg8EYH/Xx73XZ+bbwLaYIg1gvFjm29jNB9UL3CMeDU5w==",
-      "dependencies": {
-        "@asyncapi/specs": "^5.1.0",
-        "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
-        "@stoplight/json": "^3.20.2",
-        "@stoplight/json-ref-readers": "^1.2.2",
-        "@stoplight/json-ref-resolver": "^3.1.5",
-        "@stoplight/spectral-core": "^1.16.1",
-        "@stoplight/spectral-functions": "^1.7.2",
-        "@stoplight/spectral-parsers": "^1.0.2",
-        "@stoplight/spectral-ref-resolver": "^1.0.3",
-        "@stoplight/types": "^13.12.0",
-        "@types/json-schema": "^7.0.11",
-        "@types/urijs": "^1.19.19",
-        "ajv": "^8.11.0",
-        "ajv-errors": "^3.0.0",
-        "ajv-formats": "^2.1.1",
-        "avsc": "^5.7.5",
-        "js-yaml": "^4.1.0",
-        "jsonpath-plus": "^7.2.0",
-        "node-fetch": "2.6.7"
-      }
-    },
-    "node_modules/parserapiv1/node_modules/@asyncapi/specs": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-5.1.0.tgz",
-      "integrity": "sha512-yffhETqehkim43luMnPKOwzY0D0YtU4bKpORIXIaid6p5Y5kDLrMGJaEPkNieQp03HMjhjFrnUPtT8kvqe0+aQ==",
-      "dependencies": {
-        "@types/json-schema": "^7.0.11"
-      }
-    },
-    "node_modules/parserapiv1/node_modules/jsonpath-plus": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz",
-      "integrity": "sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==",
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/parserapiv2": {
-      "name": "@asyncapi/parser",
-      "version": "3.0.0-next-major-spec.8",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.0-next-major-spec.8.tgz",
-      "integrity": "sha512-d8ebYM08BCsx3Q4AeLke6naU/NrcAXFEVpS6b3EWcKRdUDce+v0X5k9aDH+YXWCaQApEF28UzcxhlSOJvhIFgQ==",
-      "dependencies": {
-        "@asyncapi/specs": "^6.0.0-next-major-spec.9",
-        "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
-        "@stoplight/json-ref-resolver": "^3.1.5",
-        "@stoplight/spectral-core": "^1.16.1",
-        "@stoplight/spectral-functions": "^1.7.2",
-        "@stoplight/spectral-parsers": "^1.0.2",
-        "@types/json-schema": "^7.0.11",
-        "@types/urijs": "^1.19.19",
-        "ajv": "^8.11.0",
-        "ajv-errors": "^3.0.0",
-        "ajv-formats": "^2.1.1",
-        "avsc": "^5.7.5",
-        "js-yaml": "^4.1.0",
-        "jsonpath-plus": "^7.2.0",
-        "node-fetch": "2.6.7",
-        "ramldt2jsonschema": "^1.2.3",
-        "webapi-parser": "^0.5.0"
-      }
-    },
-    "node_modules/parserapiv2/node_modules/jsonpath-plus": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz",
-      "integrity": "sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==",
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/patch-text": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/patch-text/-/patch-text-1.0.2.tgz",
@@ -9567,6 +9499,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/ramldt2jsonschema/-/ramldt2jsonschema-1.2.3.tgz",
       "integrity": "sha512-+wLDAV2NNv9NkfEUOYStaDu/6RYgYXeC1zLtXE+dMU/jDfjpN4iJnBGycDwFTFaIQGosOQhxph7fEX6Mpwxdug==",
+      "dev": true,
       "dependencies": {
         "commander": "^5.0.0",
         "js-yaml": "^3.14.0",
@@ -9582,6 +9515,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
@@ -9590,6 +9524,7 @@
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -10403,7 +10338,8 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -11404,6 +11340,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -11412,6 +11349,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -11521,6 +11459,7 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/webapi-parser/-/webapi-parser-0.5.0.tgz",
       "integrity": "sha512-fPt6XuMqLSvBz8exwX4QE1UT+pROLHa00EMDCdO0ybICduwQ1V4f7AWX4pNOpCp+x+0FjczEsOxtQU0d8L3QKw==",
+      "dev": true,
       "dependencies": {
         "ajv": "6.5.2"
       }
@@ -11529,6 +11468,7 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
       "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
+      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -11539,12 +11479,14 @@
     "node_modules/webapi-parser/node_modules/fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w=="
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
+      "dev": true
     },
     "node_modules/webapi-parser/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -11996,9 +11938,7 @@
         "@asyncapi/avro-schema-parser": "^3.0.3",
         "@asyncapi/openapi-schema-parser": "*",
         "@asyncapi/parser": "*",
-        "@asyncapi/protobuf-schema-parser": "^3.8.3",
-        "parserapiv1": "npm:@asyncapi/parser@^2.1.0",
-        "parserapiv2": "npm:@asyncapi/parser@3.0.0-next-major-spec.8"
+        "@asyncapi/protobuf-schema-parser": "^3.8.3"
       },
       "devDependencies": {
         "@asyncapi/raml-dt-schema-parser": "^4.0.4",

--- a/packages/multi-parser/package.json
+++ b/packages/multi-parser/package.json
@@ -42,9 +42,7 @@
     "@asyncapi/avro-schema-parser": "^3.0.3",
     "@asyncapi/openapi-schema-parser": "*",
     "@asyncapi/parser": "*",
-    "@asyncapi/protobuf-schema-parser": "^3.8.3",
-    "parserapiv1": "npm:@asyncapi/parser@^2.1.0",
-    "parserapiv2": "npm:@asyncapi/parser@3.0.0-next-major-spec.8"
+    "@asyncapi/protobuf-schema-parser": "^3.8.3"
   },
   "peerDependencies": {
     "@asyncapi/raml-dt-schema-parser": "^4.0.4"

--- a/packages/multi-parser/src/convert.ts
+++ b/packages/multi-parser/src/convert.ts
@@ -1,16 +1,10 @@
-import { createAsyncAPIDocument as createAsyncAPIDocumentParserV1 } from 'parserapiv1';
-import { createAsyncAPIDocument as createAsyncAPIDocumentParserV2 } from 'parserapiv2';
 import { createAsyncAPIDocument as createAsyncAPIDocumentParserV3 } from '@asyncapi/parser';
 
-import type { AsyncAPIDocumentInterface as AsyncAPIDocumentInterfaceParserV1 } from 'parserapiv1';
-import type { AsyncAPIDocumentInterface as AsyncAPIDocumentInterfaceParserV2 } from 'parserapiv2';
 import type { AsyncAPIDocumentInterface as AsyncAPIDocumentInterfaceParserV3 } from '@asyncapi/parser';
 
-import type { DetailedAsyncAPI as DetailedAsyncAPIParserV1 } from 'parserapiv1/esm/types';
-import type { DetailedAsyncAPI as DetailedAsyncAPIParserV2 } from 'parserapiv2/esm/types';
 import type { DetailedAsyncAPI as DetailedAsyncAPIParserV3 } from '@asyncapi/parser/esm/types';
 
-export type AsyncAPIDocument = AsyncAPIDocumentInterfaceParserV1 | AsyncAPIDocumentInterfaceParserV2 | AsyncAPIDocumentInterfaceParserV3;
+export type AsyncAPIDocument = AsyncAPIDocumentInterfaceParserV3;
 
 export function ConvertDocumentParserAPIVersion(doc: AsyncAPIDocument, toParserAPIMajorVersion: number): AsyncAPIDocument {
   if (!doc || !doc.json) return doc;
@@ -25,12 +19,11 @@ export function ConvertDocumentParserAPIVersion(doc: AsyncAPIDocument, toParserA
   const detailedAsyncAPI = doc.meta().asyncapi;
   switch (toParserAPIMajorVersion) {
   case 1:
-    return createAsyncAPIDocumentParserV1(detailedAsyncAPI as DetailedAsyncAPIParserV1);
   case 2:
-    return createAsyncAPIDocumentParserV2(detailedAsyncAPI as DetailedAsyncAPIParserV2);
+    throw new Error(`Parser API v${toParserAPIMajorVersion} is no longer supported because its pinned dependency carries an unpatchable jsonpath-plus vulnerability (see https://github.com/asyncapi/parser-js/issues/1065). Use Parser API v3 instead.`);
   case 3:
     return createAsyncAPIDocumentParserV3(detailedAsyncAPI as DetailedAsyncAPIParserV3);
-  default: 
+  default:
     return doc;
   }
 }

--- a/packages/multi-parser/src/parse.ts
+++ b/packages/multi-parser/src/parse.ts
@@ -1,5 +1,3 @@
-import { Parser as ParserV1 } from 'parserapiv1';
-import { Parser as ParserV2 } from 'parserapiv2';
 import { Parser as ParserV3 } from '@asyncapi/parser';
 
 import { AvroSchemaParser } from '@asyncapi/avro-schema-parser';
@@ -8,17 +6,15 @@ import { ProtoBuffSchemaParser } from '@asyncapi/protobuf-schema-parser';
 
 import { loadRamlDTSchemaParser } from './raml-dt-schema-parser-loader';
 
-import type { ParserOptions as ParserOptionsParserV1 } from 'parserapiv1/esm/parser';
-import type { ParserOptions as ParserOptionsParserV2 } from 'parserapiv2/esm/parser';
 import type { ParserOptions as ParserOptionsParserV3 } from '@asyncapi/parser/esm/parser';
 
-export type ParserOptions = ParserOptionsParserV1 | ParserOptionsParserV2 | ParserOptionsParserV3;
+export type ParserOptions = ParserOptionsParserV3;
 export type Options = {
   includeSchemaParsers?: boolean;
   parserOptions?: ParserOptions;
 }
 
-type Parser = ParserV1 | ParserV2 | ParserV3;
+type Parser = ParserV3;
 
 export function NewParser(parserAPIMajorVersion?: number, options?: Options): Parser {
   const parserOptions: ParserOptions = options?.parserOptions || {};
@@ -46,11 +42,10 @@ export function NewParser(parserAPIMajorVersion?: number, options?: Options): Pa
  
   switch (parserAPIMajorVersion) {
   case 1:
-    return new ParserV1(parserOptions as ParserOptionsParserV1);
   case 2:
-    return new ParserV2(parserOptions as ParserOptionsParserV2);
+    throw new Error(`Parser API v${parserAPIMajorVersion} is no longer supported because its pinned dependency carries an unpatchable jsonpath-plus vulnerability (see https://github.com/asyncapi/parser-js/issues/1065). Use Parser API v3 instead.`);
   default: // default to latest version
   case 3:
     return new ParserV3(parserOptions as ParserOptionsParserV3);
-  }   
+  }
 }

--- a/packages/multi-parser/test/convert.spec.ts
+++ b/packages/multi-parser/test/convert.spec.ts
@@ -1,63 +1,28 @@
 
-import { Parser as ParserV1 } from 'parserapiv1';
-import { Parser as ParserV2 } from 'parserapiv2';
 import { Parser as ParserV3 } from '@asyncapi/parser';
 
 import { AsyncAPIDocument, ConvertDocumentParserAPIVersion } from '../src/convert';
 
 describe('ConvertDocumentParserAPIVersion()', function() {
-  it('Converts from Parser-API v1 to Parser-API v2', async function() {
-    const doc = { asyncapi: '2.6.0', info: { title: '', description: '', version: ''}, channels: {} };
-    const parsedDocParserV1 = (await new ParserV1().parse(doc)).document as AsyncAPIDocument;
-
-    // Even though the value here is 1 for Parser V1, we force to be 2 for this test to do the equality check later.
-    parsedDocParserV1['_json']['x-parser-api-version'] = 2;
-
-    const parsedDocParserV2 = await new ParserV2().parse(doc);
-    const convertedDoc = ConvertDocumentParserAPIVersion(parsedDocParserV1, 2);
-
-    expect(convertedDoc).toEqual(parsedDocParserV2.document);
-  });
-
-  it('Converts from Parser-API v2 to Parser-API v1', async function() {
-    const doc = { asyncapi: '2.6.0', info: { title: '', description: '', version: ''}, channels: {} };
-    const parsedDocParserV2 = (await new ParserV2().parse(doc)).document as AsyncAPIDocument;
-
-    // Even though the value here is 2 for Parser V2, we force to be 1 for this test to do the equality check later.
-    parsedDocParserV2['_json']['x-parser-api-version'] = 1;
-
-    const parsedDocParserV1 = (await new ParserV1().parse(doc)).document;
-    const convertedDoc = ConvertDocumentParserAPIVersion(parsedDocParserV2, 1);
-    expect(convertedDoc).toEqual(parsedDocParserV1);
-  });
-
-  it('Converts from Parser-API v3 to Parser-API v2', async function() {
+  it('Throws when converting to Parser-API v1, which is no longer supported', async function() {
     const doc = { asyncapi: '2.6.0', info: { title: '', description: '', version: ''}, channels: {} };
     const parsedDocParserV3 = (await new ParserV3().parse(doc)).document as AsyncAPIDocument;
-
-    // Even though the value here is 3 for Parser V3, we force to be 2 for this test to do the equality check later.
     parsedDocParserV3['_json']['x-parser-api-version'] = 2;
 
-    const parsedDocParserV2 = (await new ParserV2().parse(doc)).document;
-    const convertedDoc = ConvertDocumentParserAPIVersion(parsedDocParserV3, 2);
-    expect(convertedDoc).toEqual(parsedDocParserV2);
+    expect(() => ConvertDocumentParserAPIVersion(parsedDocParserV3, 1)).toThrow(/Parser API v1 is no longer supported/);
   });
 
-  it('Converts from Parser-API v3 to Parser-API v1', async function() {
+  it('Throws when converting to Parser-API v2, which is no longer supported', async function() {
     const doc = { asyncapi: '2.6.0', info: { title: '', description: '', version: ''}, channels: {} };
     const parsedDocParserV3 = (await new ParserV3().parse(doc)).document as AsyncAPIDocument;
-
-    // Even though the value here is 3 for Parser V3, we force to be 1 for this test to do the equality check later.
     parsedDocParserV3['_json']['x-parser-api-version'] = 1;
 
-    const parsedDocParserV1 = (await new ParserV1().parse(doc)).document;
-    const convertedDoc = ConvertDocumentParserAPIVersion(parsedDocParserV3, 1);
-    expect(convertedDoc).toEqual(parsedDocParserV1);
+    expect(() => ConvertDocumentParserAPIVersion(parsedDocParserV3, 2)).toThrow(/Parser API v2 is no longer supported/);
   });
-  
+
   it('Skips converting if no document is passed', async function() {
     const doc = { } as AsyncAPIDocument;
-    const convertedDoc = ConvertDocumentParserAPIVersion(doc, 1);
+    const convertedDoc = ConvertDocumentParserAPIVersion(doc, 3);
     expect(convertedDoc).toEqual(doc);
   });
 });

--- a/packages/multi-parser/test/parse.spec.ts
+++ b/packages/multi-parser/test/parse.spec.ts
@@ -1,6 +1,4 @@
 
-import { Parser as ParserV1 } from 'parserapiv1';
-import { Parser as ParserV2 } from 'parserapiv2';
 import { Parser as ParserV3 } from '@asyncapi/parser';
 
 import { AvroSchemaParser } from '@asyncapi/avro-schema-parser';
@@ -18,41 +16,12 @@ const fakeSchemaParser = {
 };
 
 describe('NewParser()', function() {
-  it('Creates a Parser without options compatible with Parser-API v1 and caches it', async function() {
-    const parser = NewParser(1);
-    expect(parser).toBeInstanceOf(ParserV1);
+  it('Throws when asked for Parser-API v1, which is no longer supported', function() {
+    expect(() => NewParser(1)).toThrow(/Parser API v1 is no longer supported/);
   });
 
-  it('Creates a Parser with options compatible with Parser-API v1', async function() {
-    const options: Options = { parserOptions: { schemaParsers: [fakeSchemaParser]} };
-    const parser = NewParser(1, options);
-    
-    expect(parser).toBeInstanceOf(ParserV1);
-    expect(parser.parserRegistry.get('fake-format')).not.toBeUndefined();
-  });
-
-  it('Creates a Parser with options including known Schema Parsers and do not overwrite those with Parser-API v1', async function() {
-    const knownSchemaParser = AvroSchemaParser();
-    const options: Options = { parserOptions: { schemaParsers: [knownSchemaParser]}, includeSchemaParsers: true };
-    const parser = NewParser(1, options);
-    
-    expect(parser).toBeInstanceOf(ParserV1);
-    expect(parser.parserRegistry.get(knownSchemaParser.getMimeTypes()[0])).toStrictEqual(knownSchemaParser);
-    expect(parser.parserRegistry.get(OpenAPISchemaParser().getMimeTypes()[0])).toEqual(OpenAPISchemaParser());
-    expect(parser.parserRegistry.get(RamlDTSchemaParser().getMimeTypes()[0])).toEqual(RamlDTSchemaParser());
-    expect(parser.parserRegistry.get(ProtoBuffSchemaParser().getMimeTypes()[0])).toEqual(ProtoBuffSchemaParser());
-  });
-
-  it('Creates a Parser without options compatible with Parser-API v2', async function() {
-    const parser = NewParser(2);
-    expect(parser).toBeInstanceOf(ParserV2);
-  });
-
-  it('Creates a Parser with options compatible with Parser-API v2', async function() {
-    const options: Options = { parserOptions: { schemaParsers: [fakeSchemaParser]} };
-    const parser = NewParser(2, options);
-    expect(parser).toBeInstanceOf(ParserV2);
-    expect(parser.parserRegistry.get('fake-format')).not.toBeUndefined();
+  it('Throws when asked for Parser-API v2, which is no longer supported', function() {
+    expect(() => NewParser(2)).toThrow(/Parser API v2 is no longer supported/);
   });
 
   it('Creates a Parser with options compatible with Parser-API v3', async function() {
@@ -60,18 +29,6 @@ describe('NewParser()', function() {
     const parser = NewParser(3, options);
     expect(parser).toBeInstanceOf(ParserV3);
     expect(parser.parserRegistry.get('fake-format')).not.toBeUndefined();
-  });
-
-  it('Creates a Parser 2 with options including known Schema Parsers and do not overwrite those with Parser-API v2', async function() {
-    const knownSchemaParser = AvroSchemaParser();
-    const options: Options = { parserOptions: { schemaParsers: [knownSchemaParser]}, includeSchemaParsers: true };
-    const parser = NewParser(2, options);
-    
-    expect(parser).toBeInstanceOf(ParserV2);
-    expect(parser.parserRegistry.get(knownSchemaParser.getMimeTypes()[0])).toStrictEqual(knownSchemaParser);
-    expect(parser.parserRegistry.get(OpenAPISchemaParser().getMimeTypes()[0])).toEqual(OpenAPISchemaParser());
-    expect(parser.parserRegistry.get(RamlDTSchemaParser().getMimeTypes()[0])).toEqual(RamlDTSchemaParser());
-    expect(parser.parserRegistry.get(ProtoBuffSchemaParser().getMimeTypes()[0])).toEqual(ProtoBuffSchemaParser());
   });
 
   it('Creates a Parser without options compatible with old Parser API (AKA v0)', async function() {


### PR DESCRIPTION
## What

`@asyncapi/multi-parser` aliases two legacy dependencies:

- `parserapiv1` → `@asyncapi/parser@2.1.0`
- `parserapiv2` → `@asyncapi/parser@3.0.0-next-major-spec.8`

Both are frozen, unmaintained releases (no `2.1.x` patch has ever shipped past `2.1.2`, and the `3.0.0-next-major-spec.*` prerelease line was superseded long ago by the stable `3.x` release) and both pin the vulnerable `jsonpath-plus@^7.2.0`. Since they're unmaintained, they can never receive a security patch through a normal release — the vulnerability is structurally permanent as long as multi-parser depends on them.

This PR removes the `parserapiv1`/`parserapiv2` aliases entirely. `NewParser()` and `ConvertDocumentParserAPIVersion()` now throw a clear, actionable error when Parser API v1 or v2 is requested, pointing callers to Parser API v3 — which already depends on the patched `jsonpath-plus@^10.0.7` (via #1058 and #1062).

## Why this approach, and not #1086

Fixes #1065.

Supersedes #1086, which is still open and unresolved. That PR forced `jsonpath-plus` to `^10.0.7` via npm `overrides` injected into the old `parserapiv1`/`parserapiv2` dependency trees, without changing which parser version backs v1/v2. The problem: those old parser codebases (`2.1.0` and `3.0.0-next-major-spec.8`) were only ever tested against jsonpath-plus 7.x's query behavior, and jsonpath-plus 10.x changed that behavior — CI hung indefinitely as a result ([comment](https://github.com/asyncapi/parser-js/pull/1086#issuecomment-2668530721)). `@shivansh-source` [flagged this as a workaround rather than a root-cause fix](https://github.com/asyncapi/parser-js/pull/1086#issuecomment-3904386279), and `@kraenhansen` [asked for a better alternative approach](https://github.com/asyncapi/parser-js/pull/1086#issuecomment-4751095726).

This PR is that alternative: rather than forcing an untested dependency version into dead code, it retires the dead code path. Parser API v1 and v2 consumers get a clear migration error instead of a silently-still-vulnerable dependency.

## Breaking change

This is a **major** release for `@asyncapi/multi-parser` (changeset included). `NewParser(1)`, `NewParser(2)`, and `ConvertDocumentParserAPIVersion(doc, 1)` / `(doc, 2)` now throw instead of returning a v1/v2 parser or document. Callers must migrate to Parser API v3.

## Verification

- `npx turbo run build --filter=@asyncapi/multi-parser...` — builds clean, no leftover references to `parserapiv1`/`parserapiv2`.
- `npm run test:unit` in `packages/multi-parser` — full suite passes (10/10), and does **not** hang, unlike #1086.
- `npm ls jsonpath-plus` at the repo root shows only `jsonpath-plus@10.4.0` in the tree — the vulnerable `7.2.0` line is fully gone.

## Related

- Fixes #1065
- Supersedes #1086

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126g1scxgfBLx1rJTLXqeUR