### PR TITLE
fix: allow payload property named message with null value

### DIFF
--- a/.changeset/fix-payload-message-null.md
+++ b/.changeset/fix-payload-message-null.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/parser": patch
+---
+
+fix: allow payload property named message with null value (#863)

--- a/packages/parser/src/ruleset/v2/functions/messageExamples-spectral-rule-v2.ts
+++ b/packages/parser/src/ruleset/v2/functions/messageExamples-spectral-rule-v2.ts
@@ -17,9 +17,9 @@ export function asyncApi2MessageExamplesParserRule(parser: Parser): RuleDefiniti
     recommended: true,
     given: [
       // messages
-      '$.channels.*.[publish,subscribe][?(@property === \'message\' && @.schemaFormat !== void 0)]',
+      '$.channels.*.[publish,subscribe][?(@property === \'message\' && !@null && @.schemaFormat !== void 0)]',
       '$.channels.*.[publish,subscribe].message.oneOf[?(!@null && @.schemaFormat !== void 0)]',
-      '$.components.channels.*.[publish,subscribe].message[?(@property === \'message\' && @.schemaFormat !== void 0)]',
+      '$.components.channels.*.[publish,subscribe].message[?(@property === \'message\' && !@null && @.schemaFormat !== void 0)]',
       '$.components.channels.*.[publish,subscribe].message.oneOf[?(!@null && @.schemaFormat !== void 0)]',
       '$.components.messages[?(!@null && @.schemaFormat !== void 0)]',
       // message traits

--- a/packages/parser/src/ruleset/v2/ruleset.ts
+++ b/packages/parser/src/ruleset/v2/ruleset.ts
@@ -123,9 +123,9 @@ export const v2CoreRuleset = {
       recommended: true,
       given: [
         // messages
-        '$.channels.*.[publish,subscribe][?(@property === \'message\' && @.schemaFormat === void 0)]',
+        '$.channels.*.[publish,subscribe][?(@property === \'message\' && !@null && @.schemaFormat === void 0)]',
         '$.channels.*.[publish,subscribe].message.oneOf[?(!@null && @.schemaFormat === void 0)]',
-        '$.components.channels.*.[publish,subscribe][?(@property === \'message\' && @.schemaFormat === void 0)]',
+        '$.components.channels.*.[publish,subscribe][?(@property === \'message\' && !@null && @.schemaFormat === void 0)]',
         '$.components.channels.*.[publish,subscribe].message.oneOf[?(!@null && @.schemaFormat === void 0)]',
         '$.components.messages[?(!@null && @.schemaFormat === void 0)]',
         // message traits
@@ -201,9 +201,9 @@ export const v2SchemasRuleset = (parser: Parser) => {
         severity: 'error',
         recommended: true,
         given: [
-          '$.channels[*][publish,subscribe][?(@property === \'message\' && @.schemaFormat === void 0)].payload.default^',
+          '$.channels[*][publish,subscribe][?(@property === \'message\' && !@null && @.schemaFormat === void 0)].payload.default^',
           '$.channels.*.parameters.*.schema.default^',
-          '$.components.channels[*][publish,subscribe][?(@property === \'message\' && @.schemaFormat === void 0)].payload.default^',
+          '$.components.channels[*][publish,subscribe][?(@property === \'message\' && !@null && @.schemaFormat === void 0)].payload.default^',
           '$.components.channels.*.parameters.*.schema.default^',
           '$.components.schemas.*.default^',
           '$.components.parameters.*.schema.default^',
@@ -223,9 +223,9 @@ export const v2SchemasRuleset = (parser: Parser) => {
         severity: 'error',
         recommended: true,
         given: [
-          '$.channels[*][publish,subscribe][?(@property === \'message\' && @.schemaFormat === void 0)].payload.examples^',
+          '$.channels[*][publish,subscribe][?(@property === \'message\' && !@null && @.schemaFormat === void 0)].payload.examples^',
           '$.channels.*.parameters.*.schema.examples^',
-          '$.components.channels[*][publish,subscribe][?(@property === \'message\' && @.schemaFormat === void 0)].payload.examples^',
+          '$.components.channels[*][publish,subscribe][?(@property === \'message\' && !@null && @.schemaFormat === void 0)].payload.examples^',
           '$.components.channels.*.parameters.*.schema.examples^',
           '$.components.schemas.*.examples^',
           '$.components.parameters.*.schema.examples^',
@@ -338,9 +338,9 @@ export const v2RecommendedRuleset = {
       recommended: true,
       formats: AsyncAPIFormats.filterByMajorVersions(['2']).excludeByVersions(['2.0.0', '2.1.0', '2.2.0', '2.3.0']).formats(), // message.messageId is available starting from v2.4.      
       given: [
-        '$.channels.*.[publish,subscribe][?(@property === "message" && @.oneOf == void 0)]',
+        '$.channels.*.[publish,subscribe][?(@property === "message" && !@null && @.oneOf == void 0)]',
         '$.channels.*.[publish,subscribe].message.oneOf.*',
-        '$.components.channels.*.[publish,subscribe][?(@property === "message" && @.oneOf == void 0)]',
+        '$.components.channels.*.[publish,subscribe][?(@property === "message" && !@null && @.oneOf == void 0)]',
         '$.components.channels.*.[publish,subscribe].message.oneOf.*',
         '$.components.messages.*',
       ],

--- a/packages/parser/test/ruleset/rules/v2/asyncapi2-message-examples.spec.ts
+++ b/packages/parser/test/ruleset/rules/v2/asyncapi2-message-examples.spec.ts
@@ -477,4 +477,52 @@ testRule('asyncapi2-message-examples', [
       },
     ],
   },
+
+  // See https://github.com/asyncapi/parser-js/issues/863
+  {
+    name: 'valid case with payload property named message and null example value',
+    document: {
+      asyncapi: '2.4.0',
+      info: {
+        title: 'Messages',
+        version: '1.1.0',
+      },
+      defaultContentType: 'application/json',
+      channels: {
+        'test/message': {
+          subscribe: {
+            message: {
+              $ref: '#/components/messages/transferReturned',
+            },
+          },
+        },
+      },
+      components: {
+        messages: {
+          transferReturned: {
+            title: 'Transfer Returned',
+            payload: {
+              type: 'object',
+              properties: {
+                message: {
+                  type: ['string', 'null'],
+                  maxLength: 50,
+                },
+              },
+              required: ['message'],
+            },
+            examples: [
+              {
+                name: 'return',
+                payload: {
+                  message: null,
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+    errors: [],
+  },
 ]);

--- a/packages/parser/test/ruleset/rules/v2/asyncapi2-schema-examples.spec.ts
+++ b/packages/parser/test/ruleset/rules/v2/asyncapi2-schema-examples.spec.ts
@@ -396,4 +396,52 @@ testRule('asyncapi2-schema-examples', [
       },
     ],
   },
+
+  // See https://github.com/asyncapi/parser-js/issues/863
+  {
+    name: 'valid case with payload property named message and null example value',
+    document: {
+      asyncapi: '2.4.0',
+      info: {
+        title: 'Messages',
+        version: '1.1.0',
+      },
+      defaultContentType: 'application/json',
+      channels: {
+        'test/message': {
+          subscribe: {
+            message: {
+              $ref: '#/components/messages/transferReturned',
+            },
+          },
+        },
+      },
+      components: {
+        messages: {
+          transferReturned: {
+            title: 'Transfer Returned',
+            payload: {
+              type: 'object',
+              properties: {
+                message: {
+                  type: ['string', 'null'],
+                  maxLength: 50,
+                },
+              },
+              required: ['message'],
+            },
+            examples: [
+              {
+                name: 'return',
+                payload: {
+                  message: null,
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+    errors: [],
+  },
 ]);

--- a/packages/parser/test/validate.spec.ts
+++ b/packages/parser/test/validate.spec.ts
@@ -1,3 +1,4 @@
+import { AsyncAPIDocumentV2 } from '../src/models';
 import { AsyncAPIDocument } from '../src/models/v3/asyncapi';
 import { Parser } from '../src/parser';
 import { hasErrorDiagnostic, hasWarningDiagnostic } from '../src/utils';
@@ -96,5 +97,57 @@ describe('validate()', function() {
 
     expect(document).toBeInstanceOf(AsyncAPIDocument);
     expect(filterLastVersionDiagnostics(diagnostics)).toHaveLength(0);
+  });
+
+  // See https://github.com/asyncapi/parser-js/issues/863
+  it('should parse document with payload property named message and null example value', async function() {
+    const documentRaw = {
+      asyncapi: '2.4.0',
+      info: {
+        title: 'Messages',
+        version: '1.1.0',
+      },
+      defaultContentType: 'application/json',
+      channels: {
+        'test/message': {
+          subscribe: {
+            message: {
+              $ref: '#/components/messages/transferReturned',
+            },
+          },
+        },
+      },
+      components: {
+        messages: {
+          transferReturned: {
+            title: 'Transfer Returned',
+            payload: {
+              type: 'object',
+              properties: {
+                message: {
+                  type: ['string', 'null'],
+                  maxLength: 50,
+                },
+              },
+              required: ['message'],
+            },
+            examples: [
+              {
+                name: 'return',
+                payload: {
+                  message: null,
+                },
+              },
+            ],
+          },
+        },
+      },
+    };
+    const { document, diagnostics } = await parser.parse(documentRaw);
+
+    expect(document).toBeInstanceOf(AsyncAPIDocumentV2);
+    expect(diagnostics.some(d => d.message?.includes('Cannot read properties of null'))).toEqual(false);
+    expect(diagnostics.some(d => d.code === 'uncaught-error')).toEqual(false);
+    expect(hasErrorDiagnostic(diagnostics)).toEqual(false);
   });
 });


### PR DESCRIPTION
closes[#863](https://github.com/asyncapi/parser-js/issues/863):
Related: #1203 
 parsing/validating an AsyncAPI 2.x document no longer crashes when a payload schema defines a property named `message` with a `null` example value.

The issue occurred because several v2 Spectral rule JSONPath filters used expressions like:

```ts
[?(@property === 'message' && @.schemaFormat === void 0)]
```

`jsonpath-plus` evaluates these filters while traversing the document tree. Any property named `message` matched the filter — including payload schema fields, not just AsyncAPI Message Objects. When that value was `null`, accessing `@.schemaFormat` threw:

```
Cannot read properties of null (reading 'schemaFormat')
```

This fix adds `!@null` guards before property access on `@`, consistent with other filters already in the ruleset.

## Changes

- Add `!@null &&` guards to 8 JSONPath filters in `packages/parser/src/ruleset/v2/ruleset.ts`
  - `asyncapi2-message-examples`
  - `asyncapi2-schema-default`
  - `asyncapi2-schema-examples`
  - `asyncapi2-message-messageId`
- Add `!@null &&` guards to 2 JSONPath filters in `messageExamples-spectral-rule-v2.ts`
- Add regression tests based on the gist from the issue
- Add integration test in `validate.spec.ts` using `parser.parse()`

## Test plan

- [x] Parse a document with `payload.properties.message` allowing `null` and `examples[0].payload.message: null`
- [x] Confirm no `Cannot read properties of null` diagnostic
- [x] Confirm no `uncaught-error` diagnostic
- [x] Confirm existing rule tests still pass for `asyncapi2-message-examples`, `asyncapi2-schema-examples`, `asyncapi2-schema-default`, and `asyncapi2-message-messageId`

Closes #863
